### PR TITLE
CDS-521 - Fixing error summary links

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_bank_account_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_bank_account_details.scala.html
@@ -55,7 +55,7 @@
 
     @layout(pageTitle = Some(s"$title"), backLink = Some(link), signedInUserDetails = request.signedInUserDetails) {
 
-        @errorSummary(form.errors, Some(key))
+        @errorSummary(form.errors)
 
         @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_claim.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_claim.scala.html
@@ -50,7 +50,7 @@
 
     @layout(pageTitle = Some(s"$title"), signedInUserDetails = request.signedInUserDetails) {
 
-    @errorSummary(form.errors, Some(key))
+    @errorSummary(form.errors)
 
     @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_claimant_details_as_importer_company.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_claimant_details_as_importer_company.scala.html
@@ -56,7 +56,7 @@
 
     @layout(pageTitle = Some(s"$title"), backLink = Some(link), signedInUserDetails = request.signedInUserDetails) {
 
-        @errorSummary(form.errors, Some(key))
+        @errorSummary(form.errors)
 
         @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_claimant_details_as_individual.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_claimant_details_as_individual.scala.html
@@ -59,7 +59,7 @@
 
     @layout(pageTitle = Some(s"$title"), backLink = Some(link), signedInUserDetails = request.signedInUserDetails) {
 
-        @errorSummary(form.errors, Some(key))
+        @errorSummary(form.errors)
 
         @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_commodities_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_commodities_details.scala.html
@@ -42,7 +42,7 @@
 
     @layout(pageTitle = Some(s"$title"), backLink = Some(bLink), signedInUserDetails = request.signedInUserDetails) {
 
-        @errorSummary(form.errors, Some(key))
+        @errorSummary(form.errors)
 
         @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_declarant_eori_number.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_declarant_eori_number.scala.html
@@ -39,7 +39,7 @@
 
 @layout(pageTitle = Some(s"$title"), signedInUserDetails = request.signedInUserDetails) {
 
-    @errorSummary(form.errors, Some(key))
+    @errorSummary(form.errors)
 
     @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_declaration_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_declaration_details.scala.html
@@ -49,7 +49,7 @@
 
         @formWithCSRF(postAction, 'novalidate -> "novalidate") {
 
-            @errorSummary(form.errors, Some(key))
+            @errorSummary(form.errors)
 
             @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_importer_eori_number.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_importer_eori_number.scala.html
@@ -39,7 +39,7 @@
 
     @layout(pageTitle = Some(s"$title"), signedInUserDetails = request.signedInUserDetails) {
 
-        @errorSummary(form.errors, Some(key))
+        @errorSummary(form.errors)
 
         @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_movement_reference_number.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_movement_reference_number.scala.html
@@ -46,7 +46,7 @@
 
         @formWithCSRF(postAction, 'novalidate -> "novalidate") {
 
-            @errorSummary(form.errors, Some(key))
+            @errorSummary(form.errors)
 
             @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_basis_for_claim.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_basis_for_claim.scala.html
@@ -45,7 +45,7 @@ formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF,
 
     @layout(pageTitle = Some(s"$title"), backLink = Some(link), signedInUserDetails = request.signedInUserDetails) {
 
-        @errorSummary(form.errors, Some(key))
+        @errorSummary(form.errors)
 
         @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_duties.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_duties.scala.html
@@ -55,7 +55,7 @@
 
     @layout(pageTitle = Some(s"$title"), backLink = Some(link), signedInUserDetails = request.signedInUserDetails) {
 
-        @errorSummary(form.errors, Some(key))
+        @errorSummary(form.errors)
 
         @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_reason_and_basis_for_claim.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_reason_and_basis_for_claim.scala.html
@@ -28,6 +28,7 @@
     layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
     submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
     formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF,
+    errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary,
     pageHeading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.page_heading,
     paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block,
     inputSelect : uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.input_select,
@@ -43,6 +44,10 @@
  @link = @{if(isAmend) routes.CheckYourAnswersAndSubmitController.checkAllAnswers else backLink}
 
     @layout(pageTitle = Some(s"$title"), backLink = Some(link), signedInUserDetails = request.signedInUserDetails) {
+
+        @formWithCSRF(postAction, 'novalidate -> "novalidate") {
+
+        @errorSummary(form.errors)
 
         @pageHeading(title)
 
@@ -65,8 +70,6 @@
                 |</ul>
                 |""".stripMargin
             ))
-
-  @formWithCSRF(postAction, 'novalidate -> "novalidate") {
 
     @inputSelect(
         label = messages(s"$key.basis.select-label"),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_who_is_making_the_claim.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_who_is_making_the_claim.scala.html
@@ -55,7 +55,7 @@ formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF,
 
     @layout(pageTitle = Some(s"$title"), backLink = Some(link), signedInUserDetails = request.signedInUserDetails) {
 
-        @errorSummary(form.errors, Some(key))
+        @errorSummary(form.errors)
 
         @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/error_summary.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/error_summary.scala.html
@@ -24,12 +24,12 @@
 
 @this(govukErrorSummary: govukErrorSummary)
 
-@(errors: Seq[FormError], errorFieldName: Option[String] = None)(implicit messages: Messages)
+@(errors: Seq[FormError])(implicit messages: Messages)
 
 @if(errors.nonEmpty) {
     @defining(errors.map { error =>
         ErrorLink(
-            href = Some(s"#${errorFieldName.getOrElse(error.key)}"),
+            href = Some(s"#${error.key}"),
             content = Text(messages(s"${error.key}.${error.message}", error.args:_*))
         )
     }) { errorLinks =>
@@ -38,4 +38,6 @@
             title = Text(messages("error.summary.title"))
         ))
     }
+
+
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/supportingevidence/choose_document_type.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/supportingevidence/choose_document_type.scala.html
@@ -28,6 +28,7 @@
     layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
     submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
     formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF,
+    errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary,
     pageHeading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.page_heading,
     inputSelect : uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.input_select,
     paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block
@@ -40,12 +41,13 @@
 
     @layout(pageTitle = Some(s"$title"), signedInUserDetails = request.signedInUserDetails) {
 
-
-        @pageHeading(title)
-
-        @paragraph(Html(messages(s"$key.help-text")), Some("govuk-inset-text govuk-!-margin-bottom-8"))
-
         @formWithCSRF(routes.SupportingEvidenceController.chooseSupportingEvidenceDocumentTypeSubmit(uploadReference), 'novalidate -> "novalidate") {
+
+            @errorSummary(form.errors)
+
+            @pageHeading(title)
+    
+            @paragraph(Html(messages(s"$key.help-text")), Some("govuk-inset-text govuk-!-margin-bottom-8"))
 
             @inputSelect(
                 label = "Choose document type",


### PR DESCRIPTION
That turned into a rabbit hole quickly - I've tested the Entry number journey end-to-end and get most summary error links working. Only page I couldn't do was the `enter claim` page.