### PR TITLE
CDSR-517 - Added heading & help text for duplicate MRN page

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_duplicate_movement_reference_number.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_duplicate_movement_reference_number.scala.html
@@ -16,26 +16,36 @@
 
 @import play.api.data.Form
 @import play.api.i18n.Messages
+@import play.twirl.api.Html
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterMovementReferenceNumberController.MovementReferenceNumber
 
 @this(
- layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
- submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
-formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF,
-inputText : uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.input_text
+    layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
+    pageHeading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.page_heading,
+    paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block,
+    submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
+    errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary,
+    formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF,
+    inputText: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.input_text
 )
 
 @(form: Form[MovementReferenceNumber])(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
 
- @key = @{"enter-movement-reference-number"}
- @title = @{messages(s"$key.title")}
+    @key = @{"enter-movement-reference-number"}
+    @title = @{messages("enter-duplicate-movement-reference-number.title")}
 
- @layout(pageTitle = Some(s"$title"), signedInUserDetails = request.signedInUserDetails) {
+    @layout(pageTitle = Some(s"$title"), signedInUserDetails = request.signedInUserDetails) {
 
-          @formWithCSRF(routes.EnterMovementReferenceNumberController.enterDuplicateMrnSubmit(), 'novalidate -> "novalidate") {
+        @formWithCSRF(routes.EnterMovementReferenceNumberController.enterDuplicateMrnSubmit(), 'novalidate -> "novalidate") {
+
+            @errorSummary(form.errors)
+
+            @pageHeading(title)
+
+            @paragraph(Html(messages(s"${key}.help-text", viewConfig.mrnGuideUrl)), Some("govuk-inset-text govuk-!-margin-bottom-8"))
 
             @inputText(
                 form = form,
@@ -50,7 +60,6 @@ inputText : uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.inpu
 
             @submitButton(messages("button.continue"))
 
-          }
+        }
 
-
-}
+    }

--- a/conf/messages
+++ b/conf/messages
@@ -141,8 +141,6 @@ enter-movement-reference-number.error.required=Enter a valid MRN or entry number
 #  ENTER DUPLICATE MRN PAGE
 #===================================================
 enter-duplicate-movement-reference-number.title=What is your duplicated Movement Reference Number (MRN)?
-enter-duplicate-movement-reference-number.help-text=The Movement Reference Number (MRN) will be issued when an import is declared. <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{0}">Find out more about this number (opens in new tab)</a>. You can also add an entry (legacy) number found in your CHIEF documentation.
-
 
 #===================================================
 #  MRN DOES NOT MATCH EORI PAGE

--- a/conf/messages
+++ b/conf/messages
@@ -138,6 +138,13 @@ enter-movement-reference-number.invalid=Enter a valid MRN or entry number
 enter-movement-reference-number.error.required=Enter a valid MRN or entry number
 
 #===================================================
+#  ENTER DUPLICATE MRN PAGE
+#===================================================
+enter-duplicate-movement-reference-number.title=What is your duplicated Movement Reference Number (MRN)?
+enter-duplicate-movement-reference-number.help-text=The Movement Reference Number (MRN) will be issued when an import is declared. <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{0}">Find out more about this number (opens in new tab)</a>. You can also add an entry (legacy) number found in your CHIEF documentation.
+
+
+#===================================================
 #  MRN DOES NOT MATCH EORI PAGE
 #===================================================
 mrn-not-linked-to-eori.title=The MRN number you entered is not linked to your EORI number


### PR DESCRIPTION
Because this page largely uses the same content as `Enter MRN` I've hard-coded the title key specific to this page rather than duplicating content in the messages file.