### PR TITLE
some suggestions

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Router.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Router.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers
 
 import play.api.mvc.Call
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{JourneyBindable, routes => claimRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnJourney.MrnImporter
 
@@ -62,11 +63,11 @@ case object EntryBulkRoutes extends EntryNumberRoutes with BulkRoutes
 case object MRNScheduledRoutes extends MRNRoutes with ScheduledRoutes
 case object EntryScheduledRoutes extends EntryNumberRoutes with ScheduledRoutes
 
-case object ErrorRoutes extends JourneyTypeRoutes with ReferenceNumberTypeRoutes {
+case object JourneyNotDetectedRoutes extends JourneyTypeRoutes with ReferenceNumberTypeRoutes {
   override val subKey: Option[String] = None
   override val journeyBindable        = JourneyBindable.Single
 
   val selectNumberOfClaimsPage: Call                  = claimRoutes.SelectNumberOfClaimsController.show()
-  def nextPageForEnterMRN(importer: MrnJourney): Call = selectNumberOfClaimsPage
+  def nextPageForEnterMRN(importer: MrnJourney): Call = controllers.routes.IneligibleController.ineligible()
 
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMovementReferenceNumberController.scala
@@ -113,7 +113,7 @@ class EnterMovementReferenceNumberController @Inject() (
                       )
                     ),
                   isAmend,
-                  getRoutes(journey, Some(MovementReferenceNumber(Right(MRN("")))))
+                  getRoutes(getNumberOfClaims(fillingOutClaim.draftClaim), None, journey)
                 )
               ),
             mrnOrEntryNumber => {
@@ -133,7 +133,14 @@ class EnterMovementReferenceNumberController @Inject() (
                         .leftMap(_ => Error("Could not save Entry Number"))
                         .fold(
                           errorRedirect,
-                          _ => Redirect(getRoutes(journey, Option(mrnOrEntryNumber)).nextPageForEnterMRN(ErnImporter))
+                          _ =>
+                            Redirect(
+                              getRoutes(
+                                getNumberOfClaims(fillingOutClaim.draftClaim),
+                                Option(mrnOrEntryNumber),
+                                journey
+                              ).nextPageForEnterMRN(ErnImporter)
+                            )
                         )
                     case mrnAnswer @ MovementReferenceNumber(Right(mrn))      =>
                       val result = for {
@@ -156,7 +163,10 @@ class EnterMovementReferenceNumberController @Inject() (
                       result.fold(
                         errorRedirect,
                         mrnJourney =>
-                          Redirect(getRoutes(journey, Option(mrnOrEntryNumber)).nextPageForEnterMRN(mrnJourney))
+                          Redirect(
+                            getRoutes(getNumberOfClaims(fillingOutClaim.draftClaim), Option(mrnOrEntryNumber), journey)
+                              .nextPageForEnterMRN(mrnJourney)
+                          )
                       )
                   }
               }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/SessionDataExtractorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/SessionDataExtractorSpec.scala
@@ -139,7 +139,8 @@ class SessionDataExtractorSpec extends AnyWordSpec with Matchers {
         val sessionData          = sample[SessionData].copy(journeyStatus = Some(foc))
         val request              = RequestWithSessionData(Some(sessionData), authenticatedRequest)
 
-        val result = sessionTester.method(expectedData, ErrorRoutes)(dataExtractor, request, JourneyBindable.Single)
+        val result =
+          sessionTester.method(expectedData, JourneyNotDetectedRoutes)(dataExtractor, request, JourneyBindable.Single)
         status(result) shouldBe 200
       }
 
@@ -182,7 +183,8 @@ class SessionDataExtractorSpec extends AnyWordSpec with Matchers {
         val sessionData          = sample[SessionData].copy(journeyStatus = Some(foc))
         val request              = RequestWithSessionData(Some(sessionData), authenticatedRequest)
 
-        val result = sessionTester.method(expectedData, MRNSingleRoutes)(dataExtractor, request, JourneyBindable.Bulk)
+        val result =
+          sessionTester.method(expectedData, JourneyNotDetectedRoutes)(dataExtractor, request, JourneyBindable.Bulk)
         status(result) shouldBe 200
       }
 


### PR DESCRIPTION
Changes,
1) Instead of having two getRoutes methods, consolidate on one. Forces MRN controller to get number of claims out of session, but that's a good thing IMO.
2) Collapse nested if/else and multiple pattern matchs into single pattern match. 

End result
Makes it impossible to get onto later pages if you don't have the right thing in your session.