### PR TITLE
CDSR-689-1: remove label and help text; change error message

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_commodities_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_commodities_details.scala.html
@@ -16,7 +16,6 @@
 
 @import play.api.data.Form
 @import play.api.i18n.Messages
-@import play.twirl.api.Html
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
@@ -28,8 +27,7 @@
  submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
  textArea: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.input_textarea,
  pageHeading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.page_heading,
- errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary,
- paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block
+ errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary
 )
 
 @(form : Form[CommodityDetails], isAmend: Boolean = false)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
@@ -45,8 +43,6 @@
         @errorSummary(form.errors)
 
         @pageHeading(title)
-
-        @paragraph(Html(messages(s"$key.help-text")), Some("govuk-body govuk-!-margin-bottom-8"))
 
         @formWithCSRF(postAction, 'novalidate -> "novalidate") {
 

--- a/conf/messages
+++ b/conf/messages
@@ -567,9 +567,8 @@ select-reason-and-basis-for-claim.reason.d2=Special circumstances
 #  ENTER COMMODITIES PAGE
 #===================================================
 enter-commodities-details.title=Tell us the reason for this claim
-enter-commodities-details.label=Enter claim reason
-enter-commodities-details.help-text=This will help reduce delays in your claim being processed.
-enter-commodities-details.error.required=Enter details about the commodities you would like to be reimbursed for
+enter-commodities-details.label=
+enter-commodities-details.error.required=Enter claim reason
 enter-commodities-details.error.maxLength=Claim reason must be 500 characters or fewer
 enter-commodities-details.hint=Explain why you would like to be reimbursed and why you are entitled to this claim.
 


### PR DESCRIPTION
In the messages file enter-commodities-details.label= is left blank, this is because this label is intrinsic to checkPageIsDisplayed() in the tests.  The tests fail if this message key is removed.