### PR TITLE
CDSR-1056: Ensure that the user can continue to the CYA page

### DIFF
--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/fileupload/SupportingEvidenceControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/fileupload/SupportingEvidenceControllerSpec.scala
@@ -745,6 +745,23 @@ class SupportingEvidenceControllerSpec extends FileUploadControllerSpec {
             claimRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(journey)
           )
         }
+
+        "user has already added the maximum number of documents" in {
+          val journey = sample[JourneyBindable]
+          val answer  = sample(arbitrarySupportingEvidencesAnswerOfN(60))
+
+          val (session, _, _) = sessionWithClaimState(answer)
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(session)
+          }
+
+          checkIsRedirect(
+            performAction(journey, whetherAddNewDocument = None),
+            claimRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(journey)
+          )
+        }
       }
 
       "redirect to upload new document page" when {


### PR DESCRIPTION
Ensure that the user can continue to the CYA page if they have entered the maximum number of document.