### PR TITLE
[CDSR-1247][AO] fix single claim input and summary page

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_single_claim_summary.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_single_claim_summary.scala.html
@@ -21,6 +21,7 @@
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ClaimedReimbursement
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 @import cats.data.NonEmptyList
@@ -39,7 +40,7 @@
         errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary
 )
 
-@(claims: NonEmptyList[ClaimedReimbursement], form: Form[YesNo])(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(mrn: MRN, claims: NonEmptyList[ClaimedReimbursement], form: Form[YesNo])(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
 
 
 @key = @{"check-claim-summary"}
@@ -47,35 +48,15 @@
 
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@layout(pageTitle = Some(s"$title"), suppressBackLink = true, hasErrors = hasErrors) {
+@layout(pageTitle = Some(s"$title"), suppressBackLink = false, hasErrors = hasErrors) {
 
     @errorSummary(form.errors)
     @pageHeading(title)
 
-    @paragraph(Html(messages(s"$key.help-text")), Some("govuk-body govuk-!-margin-bottom-8"))
+    @paragraph(Html(messages(s"$key.help-text")), Some("govuk-body"))
 
-    @if(claims.containsUkClaim(claims)) {
-        @pageHeading(messages(s"$key.uk-duty.label"), "govuk-heading-m govuk-!-margin-top-9", "h2")
-        @summary(SummaryList(claimSummaryHelper.makeUkClaimSummary(claims)))
-    } else {
-        @paragraph(Html(""))
-    }
-
-    @if(claims.containsEuClaim(claims)) {
-        @pageHeading(messages(s"$key.eu-duty.label"), "govuk-heading-m govuk-!-margin-top-9", "h2")
-        @summary(SummaryList(claimSummaryHelper.makeEuClaimSummary(claims)))
-    } else {
-        @paragraph(Html(""))
-    }
-    @if(claims.containsExciseClaim(claims)) {
-        @pageHeading(messages(s"$key.excise-duty.label"), "govuk-heading-m govuk-!-margin-top-9", "h2")
-        @summary(SummaryList(claimSummaryHelper.makeExciseClaimSummary(claims)))
-    } else {
-        @paragraph(Html(""))
-    }
-
-    @pageHeading(messages(s"$key.overall-total.label"), "govuk-heading-m govuk-!-margin-top-9", "h2")
-    @summary(SummaryList(List(claimSummaryHelper.makeClaimTotalRow(claims))))
+    @pageHeading(messages(s"$key.duty.label",mrn.value), "govuk-heading-m", "h2")
+    @summary(SummaryList(claimSummaryHelper.makeClaimSummary(claims)))
 
     @formWithCSRF(routes.EnterSingleClaimController.checkClaimSummarySubmit, 'novalidate -> "novalidate") {
         @radios(
@@ -84,7 +65,7 @@
             legend = messages(s"$key.are-duties-correct"),
             legendAsHeading = false,
             hintKey = None,
-            classes = "govuk-fieldset__legend--m govuk-!-margin-top-6",
+            classes = "govuk-fieldset__legend--s",
             inline = true,
             items = Seq(
                 RadioItem(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/utils/ClaimSummaryHelper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/utils/ClaimSummaryHelper.scala
@@ -16,14 +16,19 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.utils
 
-import play.api.i18n.{Lang, Langs, MessagesApi}
+import cats.data.NonEmptyList
+import play.api.i18n.Lang
+import play.api.i18n.Langs
+import play.api.i18n.MessagesApi
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{BigDecimalOps, ClaimedReimbursement}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ClaimedReimbursementsAnswer
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ClaimedReimbursement
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Actions, _}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Actions
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Inject
+import javax.inject.Singleton
 
 @Singleton
 class ClaimSummaryHelper @Inject() (implicit langs: Langs, messages: MessagesApi) {
@@ -32,19 +37,13 @@ class ClaimSummaryHelper @Inject() (implicit langs: Langs, messages: MessagesApi
 
   private val key = "check-claim-summary"
 
-  def makeUkClaimSummary(answer: ClaimedReimbursementsAnswer): List[SummaryListRow] =
-    makeClaimSummaryRows(answer.ukClaims(answer)) ++ makeTotalRow(answer.ukClaims(answer))
+  def makeClaimSummary(claims: NonEmptyList[ClaimedReimbursement]): List[SummaryListRow] =
+    makeClaimSummaryRows(claims) ++ makeTotalRow(claims)
 
-  def makeEuClaimSummary(answer: ClaimedReimbursementsAnswer): List[SummaryListRow] =
-    makeClaimSummaryRows(answer.euClaims(answer)) ++ makeTotalRow(answer.euClaims(answer))
-
-  def makeExciseClaimSummary(answer: ClaimedReimbursementsAnswer): List[SummaryListRow] =
-    makeClaimSummaryRows(answer.exciseClaims(answer)) ++ makeTotalRow(answer.exciseClaims(answer))
-
-  def makeClaimSummaryRows(claims: List[ClaimedReimbursement]): List[SummaryListRow] =
-    claims.map { claim =>
+  def makeClaimSummaryRows(claims: NonEmptyList[ClaimedReimbursement]): List[SummaryListRow] =
+    claims.toList.map { claim =>
       SummaryListRow(
-        key = Key(Text(messages(s"select-duties.duty.${claim.taxCode}")(lang))),
+        key = Key(Text(s"${claim.taxCode} - ${messages(s"select-duties.duty.${claim.taxCode}")(lang)}")),
         value = Value(Text(claim.claimAmount.toPoundSterlingString)),
         actions = Some(
           Actions(
@@ -60,16 +59,11 @@ class ClaimSummaryHelper @Inject() (implicit langs: Langs, messages: MessagesApi
       )
     }
 
-  def makeTotalRow(claims: List[ClaimedReimbursement]): List[SummaryListRow] =
+  def makeTotalRow(claims: NonEmptyList[ClaimedReimbursement]): List[SummaryListRow] =
     SummaryListRow(
       key = Key(Text(messages(s"$key.total")(lang))),
-      value = Value(Text(claims.map(_.claimAmount).sum.toPoundSterlingString))
+      value = Value(Text(claims.toList.map(_.claimAmount).sum.toPoundSterlingString)),
+      classes = "govuk-!-margin-bottom-9"
     ) :: Nil
-
-  def makeClaimTotalRow(claims: ClaimedReimbursementsAnswer): SummaryListRow =
-    SummaryListRow(
-      key = Key(Text(messages(s"$key.total")(lang))),
-      value = Value(Text(claims.total.toPoundSterlingString))
-    )
 
 }

--- a/conf/messages
+++ b/conf/messages
@@ -774,15 +774,16 @@ multiple-enter-claim.invalid.claim=Amount that should have been paid must be low
 #===================================================
 #  CHECK REIMBURSEMENT CLAIM TOTAL PAGE
 #===================================================
-check-claim-summary.title=Check the reimbursement claim totals for your MRN
+check-claim-summary.title=Check the reimbursement claim total for your MRN
 check-claim-summary.help-text=Your reimbursement calculations are shown below based upon what you have paid and the information you provided on what you should have paid.
 check-claim-summary.scheduled.help-text=These are the calculations based on the information you gave us.
+check-claim-summary.duty.label=MRN: {0}
 check-claim-summary.uk-duty.label=UK Duty
 check-claim-summary.eu-duty.label=EU Duty
 check-claim-summary.excise-duty.label=Excise Duty
 check-claim-summary.overall-total.label=Overall total
 check-claim-summary.change-amount=Change amount
-check-claim-summary.total=Total reimbursement
+check-claim-summary.total=Reimbursement for this MRN
 check-claim-summary.are-duties-correct=Are these duties correct?
 check-claim-summary.yes=Yes
 check-claim-summary.no=No, select different duties

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterSingleClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterSingleClaimControllerSpec.scala
@@ -270,7 +270,7 @@ class EnterSingleClaimControllerSpec
     "render the previous answer when the user has answered this question before" in {
       val taxCode              = TaxCode.B05
       val claimedReimbursement = sample[ClaimedReimbursement]
-        .copy(claimAmount = BigDecimal(10), paidAmount = BigDecimal(5), isFilled = true, taxCode = taxCode)
+        .copy(claimAmount = BigDecimal(6), paidAmount = BigDecimal(10), isFilled = true, taxCode = taxCode)
       val answers              = ClaimedReimbursementsAnswer(claimedReimbursement)
 
       val session = createSessionWithPreviousAnswers(Some(answers))._1
@@ -283,7 +283,7 @@ class EnterSingleClaimControllerSpec
       checkPageIsDisplayed(
         performAction(claimedReimbursement.id),
         messageFromMessageKey("enter-claim.title", taxCode.value, "Value Added Tax"),
-        doc => doc.getElementById("enter-claim").`val`() shouldBe "10.00"
+        doc => doc.getElementById("enter-claim").`val`() shouldBe "4.00"
       )
     }
 
@@ -310,8 +310,8 @@ class EnterSingleClaimControllerSpec
     "user enters a valid paid and claim amount on the MRN journey" in {
       val claimedReimbursement = sample[ClaimedReimbursement]
         .copy(
-          claimAmount = BigDecimal(1.00).setScale(2),
-          paidAmount = BigDecimal(10.00).setScale(2),
+          claimAmount = BigDecimal("1.00"),
+          paidAmount = BigDecimal("10.00"),
           isFilled = false,
           taxCode = TaxCode.A00
         )
@@ -320,7 +320,7 @@ class EnterSingleClaimControllerSpec
 
       val session        =
         createSessionWithPreviousAnswers(Some(answers), None, None, sample[MRN])._1
-      val updatedAnswer  = claimedReimbursement.copy(claimAmount = BigDecimal(5.00).setScale(2), isFilled = true)
+      val updatedAnswer  = claimedReimbursement.copy(claimAmount = BigDecimal("5.00"), isFilled = true)
       val updatedSession = updateSession(session, ClaimedReimbursementsAnswer(updatedAnswer))
 
       inSequence {


### PR DESCRIPTION
This PR is a quick-fix for three issues:
- when changing the existing answer wrong amount was pre-populated, should be the corrected amount, not the reimbursed
- the look of a summary page was different to the prototype, new UI needs MRN
- after changing the amount and getting back to the summary the order of duties was different