### PR TITLE
Replace session data copy ops with copyWith

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartController.scala
@@ -72,7 +72,7 @@ class StartController @Inject() (
       val result = for {
         _ <- EitherT(
                updateSession(sessionStore, request)(
-                 _.copy(
+                 _.copyWith(
                    journeyStatus = Some(
                      FillingOutClaim(
                        justSubmittedClaim.ggCredId,
@@ -186,7 +186,7 @@ class StartController @Inject() (
     )
 
     updateSession(sessionStore, request)(
-      _.copy(
+      _.copyWith(
         journeyStatus = Some(NonGovernmentGatewayJourney)
       )
     ).map {
@@ -210,7 +210,7 @@ class StartController @Inject() (
     val result = for {
       _ <- EitherT(
              updateSession(sessionStore, request)(
-               _.copy(
+               _.copyWith(
                  journeyStatus = Some(
                    FillingOutClaim(
                      ggCredId,

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountController.scala
@@ -116,7 +116,11 @@ class BankAccountController @Inject() (
 
                   (for {
                     _                  <- EitherT
-                                            .liftF(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+                                            .liftF(
+                                              updateSession(sessionStore, request)(
+                                                _.copy(journeyStatus = Some(updatedJourney))
+                                              )
+                                            )
                                             .leftMap((_: Unit) => Error("could not update session"))
                     reputationResponse <- {
                       val barsAccount =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountController.scala
@@ -118,7 +118,7 @@ class BankAccountController @Inject() (
                     _                  <- EitherT
                                             .liftF(
                                               updateSession(sessionStore, request)(
-                                                _.copy(journeyStatus = Some(updatedJourney))
+                                                _.copyWith(journeyStatus = Some(updatedJourney))
                                               )
                                             )
                                             .leftMap((_: Unit) => Error("could not update session"))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckContactDetailsMrnController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckContactDetailsMrnController.scala
@@ -116,7 +116,7 @@ class CheckContactDetailsMrnController @Inject() (
                   _.copy(mrnContactDetailsAnswer = None, mrnContactAddressAnswer = None)
                 )
 
-                EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedClaim))))
+                EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedClaim))))
                   .leftMap(err => Error(s"Could not remove contact details: ${err.message}"))
                   .fold(
                     e => logAndDisplayError("Submit Declarant Type error: ").apply(e),
@@ -161,7 +161,7 @@ class CheckContactDetailsMrnController @Inject() (
           for {
             newAddress <- addressLookupService.retrieveUserAddress(id)
             copyClaim   = FillingOutClaim.from(claim)(_.copy(mrnContactAddressAnswer = newAddress.some))
-            result     <- EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = copyClaim.some)))
+            result     <- EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = copyClaim.some)))
           } yield result
 
         maybeAddressLookupId

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsController.scala
@@ -107,7 +107,7 @@ class CheckEoriDetailsController @Inject() (
                   val returnErrorPage: Unit => Result = _ => errorHandler.errorResult()
 
                   def saveSession(verifiedEmail: VerifiedEmail): SessionData => SessionData =
-                    _.copy(journeyStatus = Some(emailLens.set(fillingOutClaim)(verifiedEmail.toEmail)))
+                    _.copyWith(journeyStatus = Some(emailLens.set(fillingOutClaim)(verifiedEmail.toEmail)))
 
                   val eitherErrorOrNextPage = for {
                     maybeVerifiedEmail <-

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckMovementReferenceNumbersController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckMovementReferenceNumbersController.scala
@@ -73,7 +73,7 @@ class CheckMovementReferenceNumbersController @Inject() (
             )
           )
 
-        EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = updatedClaim.some)))
+        EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = updatedClaim.some)))
           .fold(
             logAndDisplayError(s"Error updating MRNs removing ${mrnIndex.ordinalNumeral} MRN: "),
             _ => redirectToShowMrnsPage()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckScheduledClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckScheduledClaimController.scala
@@ -94,7 +94,7 @@ class CheckScheduledClaimController @Inject() (
                     _.copy(claimedReimbursementsAnswer = ClaimedReimbursementsAnswer(reimbursements))
                   )
 
-                EitherT(updateSession(sessionCache, request)(_.copy(journeyStatus = updatedClaim.some)))
+                EitherT(updateSession(sessionCache, request)(_.copyWith(journeyStatus = updatedClaim.some)))
                   .leftMap(_ => Error("Could not update session"))
                   .fold(
                     logAndDisplayError("Could not update reimbursement claims: "),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourAnswersAndSubmitController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourAnswersAndSubmitController.scala
@@ -101,7 +101,7 @@ class CheckYourAnswersAndSubmitController @Inject() (
                                               }
             _                              <- EitherT(
                                                 updateSession(sessionStore, request)(
-                                                  _.copy(journeyStatus = Some(newJourneyStatus))
+                                                  _.copyWith(journeyStatus = Some(newJourneyStatus))
                                                 )
                                               )
           } yield response

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ClaimNorthernIrelandController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ClaimNorthernIrelandController.scala
@@ -93,7 +93,7 @@ class ClaimNorthernIrelandController @Inject() (
                   )
                 )
 
-                EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+                EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
                   .leftMap(_ => Error("could not update session"))
                   .fold(
                     logAndDisplayError("could not capture select number of claims"),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAssociatedMrnController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAssociatedMrnController.scala
@@ -161,7 +161,7 @@ class EnterAssociatedMrnController @Inject() (
                   .map(e => logAndDisplayError("Error updating claim answers: ").apply(Error(e)))
               )
 
-            _ <- EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = updatedDraftClaim.some)))
+            _ <- EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = updatedDraftClaim.some)))
                    .leftMap(logAndDisplayError(s"Error storing ${index.ordinalNumeral} MRN: "))
 
           } yield ()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterCommoditiesDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterCommoditiesDetailsController.scala
@@ -75,7 +75,7 @@ class EnterCommoditiesDetailsController @Inject() (
               val newDraftClaim  = fillingOutClaim.draftClaim.copy(commoditiesDetailsAnswer = Some(commodityDetails))
               val updatedJourney = fillingOutClaim.copy(draftClaim = newDraftClaim)
 
-              EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+              EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
                 .leftMap(_ => Error("could not update session"))
                 .fold(
                   logAndDisplayError("could not get commodity details"),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterContactDetailsMrnController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterContactDetailsMrnController.scala
@@ -90,7 +90,7 @@ class EnterContactDetailsMrnController @Inject() (
                 FillingOutClaim.from(fillingOutClaim)(_.copy(mrnContactDetailsAnswer = Some(formOk)))
 
               val result = EitherT
-                .liftF(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedClaim))))
+                .liftF(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedClaim))))
                 .leftMap((_: Unit) => Error("could not update session"))
 
               result.fold(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDeclarantEoriNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDeclarantEoriNumberController.scala
@@ -85,7 +85,7 @@ class EnterDeclarantEoriNumberController @Inject() (
                 FillingOutClaim.from(fillingOutClaim)(_.copy(declarantEoriNumberAnswer = Some(declarantEoriNumber)))
 
               val result = EitherT
-                .liftF(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+                .liftF(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
                 .leftMap((_: Unit) => Error("could not update session"))
 
               result.fold(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDuplicateMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDuplicateMovementReferenceNumberController.scala
@@ -136,7 +136,7 @@ class EnterDuplicateMovementReferenceNumberController @Inject() (
 
   def updateDraftClaim(fillingOutClaim: FillingOutClaim, newDraftClaim: DraftClaim): SessionDataTransform = {
     val updatedJourney               = fillingOutClaim.copy(draftClaim = newDraftClaim)
-    val update: SessionDataTransform = _.copy(journeyStatus = Some(updatedJourney))
+    val update: SessionDataTransform = _.copyWith(journeyStatus = Some(updatedJourney))
     update
   }
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterImporterEoriNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterImporterEoriNumberController.scala
@@ -85,7 +85,7 @@ class EnterImporterEoriNumberController @Inject() (
               def updateJourney() = EitherT {
                 val updatedJourney =
                   FillingOutClaim.from(fillingOutClaim)(_.copy(importerEoriNumberAnswer = Some(importerEoriNumber)))
-                updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney)))
+                updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney)))
               }
 
               def checkWhetherConsigneeEORIsMatch = for {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMovementReferenceNumberController.scala
@@ -200,7 +200,8 @@ class EnterMovementReferenceNumberController @Inject() (
   }
 
   def updateDraftClaim(fillingOutClaim: FillingOutClaim, newDraftClaim: DraftClaim): SessionDataTransform = {
-    val update: SessionDataTransform = _.copy(journeyStatus = Some(fillingOutClaim.copy(draftClaim = newDraftClaim)))
+    val update: SessionDataTransform =
+      _.copyWith(journeyStatus = Some(fillingOutClaim.copy(draftClaim = newDraftClaim)))
     update
   }
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMultipleClaimsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMultipleClaimsController.scala
@@ -110,7 +110,7 @@ class EnterMultipleClaimsController @Inject() (
                 .fold(
                   e => logAndDisplayError("could not update draft claim").apply(Error(e)),
                   updatedJourney =>
-                    EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+                    EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
                       .leftMap(_ => Error("could not update session"))
                       .fold(
                         logAndDisplayError("could not save claims"),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterScheduledClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterScheduledClaimController.scala
@@ -97,7 +97,7 @@ class EnterScheduledClaimController @Inject() (
       withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (fillingOutClaim, maybeAnswer) =>
         def updateClaim(answer: SelectedDutyTaxCodesReimbursementAnswer) =
           updateSession(sessionCache, request)(
-            _.copy(journeyStatus =
+            _.copyWith(journeyStatus =
               from(fillingOutClaim)(_.copy(selectedDutyTaxCodesReimbursementAnswer = answer.some)).some
             )
           )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterSingleClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterSingleClaimController.scala
@@ -193,7 +193,7 @@ class EnterSingleClaimController @Inject() (
   ): Future[Result] = {
     val newDraftClaim  = fillingOutClaim.draftClaim.copy(claimedReimbursementsAnswer = Some(reimbursements))
     val updatedJourney = fillingOutClaim.copy(draftClaim = newDraftClaim)
-    EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+    EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
       .leftMap(_ => Error("could not update session"))
       .fold(logAndDisplayError("could not save claims"), _ => nextPage)
   }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ReimbursementMethodController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ReimbursementMethodController.scala
@@ -71,7 +71,7 @@ class ReimbursementMethodController @Inject() (
           formWithErrors => Future.successful(BadRequest(selectReimbursementMethod(formWithErrors))),
           answer => {
             val updatedJourney = FillingOutClaim.from(fillingOutClaim)(_.copy(reimbursementMethodAnswer = Some(answer)))
-            EitherT(updateSession(sessionCache, request)(_.copy(journeyStatus = Some(updatedJourney))))
+            EitherT(updateSession(sessionCache, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
               .leftMap(_ => Error("could not update session"))
               .fold(
                 logAndDisplayError("could not get reimbursement method selected "),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBankAccountTypeController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBankAccountTypeController.scala
@@ -79,7 +79,7 @@ class SelectBankAccountTypeController @Inject() (
 
               val updatedJourney = FillingOutClaim.from(fillingOutClaim)(_.copy(bankAccountTypeAnswer = Some(formOk)))
 
-              EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+              EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
                 .leftMap(_ => Error("could not update session"))
                 .fold(
                   logAndDisplayError("could not capture bank account type answer"),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBasisForClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBasisForClaimController.scala
@@ -91,7 +91,7 @@ class SelectBasisForClaimController @Inject() (
             answer => {
               val updatedJourney = FillingOutClaim.from(fillingOutClaim)(_.copy(basisOfClaimAnswer = answer.some))
 
-              EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = updatedJourney.some)))
+              EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = updatedJourney.some)))
                 .leftMap(_ => Error("could not update session"))
                 .fold(
                   logAndDisplayError("could not store reason for claim answer"),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutiesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutiesController.scala
@@ -98,7 +98,7 @@ class SelectDutiesController @Inject() (
                     fillingOutClaim.draftClaim.copy(dutiesSelectedAnswer = Some(dutiesSelected))
                   val updatedJourney = fillingOutClaim.copy(draftClaim = newDraftClaim)
 
-                  EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+                  EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
                     .leftMap(_ => Error("could not update session"))
                     .fold(
                       logAndDisplayError("could not get duties selected "),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyCodesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyCodesController.scala
@@ -84,7 +84,7 @@ class SelectDutyCodesController @Inject() (
       withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (fillingOutClaim, maybeAnswer) =>
         def updateClaim(answer: SelectedDutyTaxCodesReimbursementAnswer) = {
           val claim = from(fillingOutClaim)(_.copy(selectedDutyTaxCodesReimbursementAnswer = answer.some))
-          updateSession(sessionCache, request)(_.copy(journeyStatus = claim.some))
+          updateSession(sessionCache, request)(_.copyWith(journeyStatus = claim.some))
         }
 
         selectDutyCodesForm

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyTypesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyTypesController.scala
@@ -83,7 +83,7 @@ class SelectDutyTypesController @Inject() (
                 FillingOutClaim
                   .from(fillingOutClaim)(_.copy(selectedDutyTaxCodesReimbursementAnswer = Some(updatedAnswer)))
 
-              EitherT(updateSession(sessionCache, request)(_.copy(journeyStatus = Some(updatedJourney))))
+              EitherT(updateSession(sessionCache, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
                 .leftMap(_ => Error("could not update session"))
                 .fold(
                   logAndDisplayError("could not get duty types selected"),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectMultipleDutiesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectMultipleDutiesController.scala
@@ -167,7 +167,7 @@ class SelectMultipleDutiesController @Inject() (
                       val updatedJourney: FillingOutClaim = journey.copy(draftClaim = newDraftClaim)
 
                       EitherT
-                        .liftF(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+                        .liftF(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
                         .leftMap((_: Unit) => Error("could not update session"))
                         .fold(
                           logAndDisplayError("could not get duties selected "),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectTypeOfClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectTypeOfClaimController.scala
@@ -79,7 +79,7 @@ class SelectTypeOfClaimController @Inject() (
               val updatedJourney =
                 FillingOutClaim.from(fillingOutClaim)(_.copy(typeOfClaim = Some(typeOfClaimAnswer)))
 
-              EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+              EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
                 .leftMap(_ => Error("could not update session"))
                 .fold(
                   logAndDisplayError("Could not capture select number of claims"),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectWhoIsMakingTheClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectWhoIsMakingTheClaimController.scala
@@ -74,7 +74,7 @@ class SelectWhoIsMakingTheClaimController @Inject() (
             answer => {
               val updatedJourney = FillingOutClaim.from(fillingOutClaim)(_.copy(declarantTypeAnswer = Some(answer)))
 
-              EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+              EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(updatedJourney))))
                 .leftMap(_ => Error("Could not save Declarant Type"))
                 .fold(
                   logAndDisplayError("Submit Declarant Type error: "),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/fileupload/ScheduleOfMrnDocumentController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/fileupload/ScheduleOfMrnDocumentController.scala
@@ -127,7 +127,7 @@ class ScheduleOfMrnDocumentController @Inject() (
                             case Some(upscanSuccess: UpscanSuccess) =>
                               EitherT(
                                 updateSession(sessionStore, request)(
-                                  _.copy(journeyStatus = addDocument(upscanUpload, upscanSuccess, fillingOut).some)
+                                  _.copyWith(journeyStatus = addDocument(upscanUpload, upscanSuccess, fillingOut).some)
                                 )
                               )
                             case _                                  =>
@@ -165,7 +165,7 @@ class ScheduleOfMrnDocumentController @Inject() (
         val newJourney = FillingOutClaim.from(fillingOutClaim)(_.copy(scheduledDocumentAnswer = None))
 
         val result = for {
-          _ <- EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(newJourney))))
+          _ <- EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(newJourney))))
         } yield ()
 
         result.fold(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/fileupload/SupportingEvidenceController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/fileupload/SupportingEvidenceController.scala
@@ -134,7 +134,7 @@ class SupportingEvidenceController @Inject() (
                                 if maybeAnswers.forall(_.forall(_.uploadReference =!= uploadReference)) =>
                               EitherT(
                                 updateSession(sessionStore, request)(
-                                  _.copy(journeyStatus =
+                                  _.copyWith(journeyStatus =
                                     attachDocument(upscanUpload, upscanSuccess, maybeAnswers, fillingOutReturn).some
                                   )
                                 )
@@ -223,7 +223,7 @@ class SupportingEvidenceController @Inject() (
                 _         <-
                   EitherT(
                     updateSession(sessionStore, request)(
-                      _.copy(
+                      _.copyWith(
                         journeyStatus =
                           FillingOutClaim.from(fillingOutClaim)(_.copy(supportingEvidencesAnswer = evidences.some)).some
                       )
@@ -256,7 +256,7 @@ class SupportingEvidenceController @Inject() (
           )
 
         val result = for {
-          _ <- EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(newJourney))))
+          _ <- EitherT(updateSession(sessionStore, request)(_.copyWith(journeyStatus = Some(newJourney))))
         } yield ()
 
         result.fold(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/Journey.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/Journey.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
+
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.TraitFormat
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus
+
+/** An interface of a journey objects */
+trait Journey
+
+object Journey extends TraitFormat[Journey] {
+
+  override val members =
+    Seq(
+      Member[JourneyStatus](),
+      Member[RejectedGoodsSingleJourney]()
+    )
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
@@ -51,7 +51,8 @@ import java.time.LocalDate
   *  - [[RejectedGoodsSingleJourney.Outcome]] - final outcome of the journey to be sent to backend processing
   */
 final class RejectedGoodsSingleJourney private (val answers: RejectedGoodsSingleJourney.Answers)
-    extends FluentSyntax[RejectedGoodsSingleJourney] {
+    extends Journey
+    with FluentSyntax[RejectedGoodsSingleJourney] {
 
   /** Check if the journey is ready to finalize, i.e. to get the output. */
   def isComplete: Boolean =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/JourneyStatus.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/JourneyStatus.scala
@@ -22,8 +22,9 @@ import play.api.libs.json.OFormat
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResponse
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.Journey
 
-sealed trait JourneyStatus extends Product with Serializable
+sealed trait JourneyStatus extends Journey
 
 object JourneyStatus {
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/SessionData.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/SessionData.scala
@@ -21,8 +21,15 @@ import cats.implicits.catsSyntaxOptionId
 import play.api.libs.json.{Format, Json}
 
 final case class SessionData(
-  journeyStatus: Option[JourneyStatus]
-)
+  journey: Option[JourneyStatus]
+) {
+
+  def copyWith(journeyStatus: Option[JourneyStatus]): SessionData =
+    copy(journey = journeyStatus)
+
+  def journeyStatus: Option[JourneyStatus] = journey
+
+}
 
 object SessionData {
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/utils/TraitFormat.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/utils/TraitFormat.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.utils
+
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import play.api.libs.json._
+import scala.reflect.ClassTag
+
+/** Helper trait providing JSON formatter based on the set of subtype formatters.
+  * Designed to be mixed in the companion object of the trait and as a typeclass.
+  * @tparam A sealed trait type
+  */
+@SuppressWarnings(
+  Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.Throw", "org.wartremover.warts.Equals")
+)
+trait TraitFormat[A] {
+
+  /** Formatters of the member classes. */
+  val members: Seq[Member[_ <: A]]
+
+  final def keyOf[T : ClassTag]: String =
+    implicitly[ClassTag[T]].runtimeClass.getSimpleName
+
+  final def keyOf(value: Any): String =
+    value.getClass.getSimpleName
+
+  final def get[T <: A](mapInstance: Map[String, A])(implicit cta: ClassTag[A], ctt: ClassTag[T]): Option[T] = {
+    val key = keyOf[T]
+    formatMap.get(key).flatMap { member =>
+      mapInstance.get(key).flatMap(value => member.checkType(value).map(_.asInstanceOf[T]))
+    }
+  }
+
+  final def set[T <: A : ClassTag](value: T, mapInstance: Map[String, A]): Map[String, A] = {
+    val key = keyOf[T]
+    mapInstance + ((key, value))
+  }
+
+  final def remove[T <: A : ClassTag](mapInstance: Map[String, A]): Map[String, A] = {
+    val key = keyOf[T]
+    mapInstance - key
+  }
+
+  private final lazy val formatMap: Map[String, Member[_ <: A]] =
+    members.map(m => (m.key, m)).toMap
+
+  protected case class Member[T <: A : ClassTag]()(implicit format: Format[T]) {
+    val key = keyOf[T]
+
+    def writes(value: A): JsValue =
+      format.writes(value.asInstanceOf[T])
+
+    def reads(json: JsValue): JsResult[A] =
+      format.reads(json).map(_.asInstanceOf[A])
+
+    def checkType[T1 : ClassTag](value: T1): Option[T1] =
+      if (implicitly[ClassTag[T1]].runtimeClass eq implicitly[ClassTag[T]].runtimeClass)
+        Some(value)
+      else
+        None
+  }
+
+  object CanSerialize {
+    def unapply(entry: (String, A)): Option[(String, JsValue)] = {
+      val (key, value) = entry
+      formatMap
+        .get(key)
+        .map(_.writes(value))
+        .map(jsvalue => (key, jsvalue))
+    }
+  }
+
+  object CanDeserialize {
+    def unapply(field: (String, JsValue)): Option[(String, A)] = {
+      val (key, jsvalue) = field
+      formatMap
+        .get(key)
+        .map(
+          _.reads(jsvalue)
+            .map(value => (key, value))
+            .getOrElse(throw new Exception(s"Failure de-serializing ${Json.stringify(jsvalue)}"))
+        )
+    }
+  }
+
+  implicit final val mapFormat: Format[Map[String, A]] = Format(
+    Reads {
+      case o: JsObject =>
+        JsSuccess(
+          o.fields.collect { case CanDeserialize(key, value) => (key, value) }.toMap
+        )
+
+      case json => JsError(s"Expected json object but got ${json.getClass.getSimpleName}")
+    },
+    Writes.apply { mapInstance =>
+      JsObject(
+        mapInstance.toSeq
+          .collect { case CanSerialize(key, jsvalue) =>
+            key -> jsvalue
+          }
+      )
+    }
+  )
+
+  implicit final val format: Format[A] = Format(
+    Reads {
+      case o: JsObject =>
+        o.fields
+          .collect { case CanDeserialize(_, value) => value }
+          .headOption
+          .map[JsResult[A]](JsSuccess.apply(_))
+          .getOrElse(JsError(s"Could not deserialize $o"))
+
+      case json => JsError(s"Expected json object but got ${json.getClass.getSimpleName}")
+    },
+    Writes.apply { value =>
+      (keyOf(value), value) match {
+        case CanSerialize(key, jsvalue) => Json.obj(key -> jsvalue)
+        case _                          => JsNull
+      }
+    }
+  )
+
+  /** Instance of a typeclass declaration */
+  implicit final val traitFormat: TraitFormat[A] = this
+
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/C285SessionFixtures.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/C285SessionFixtures.scala
@@ -47,7 +47,7 @@ trait C285JourneySessionFixtures {
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = JourneyStatus.FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey
@@ -67,7 +67,7 @@ trait C285JourneySessionFixtures {
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = JourneyStatus.FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyExtractorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyExtractorSpec.scala
@@ -42,7 +42,7 @@ class JourneyExtractorSpec extends AnyWordSpec with Matchers {
       val authenticatedRequest = AuthenticatedRequest[AnyContent](msgReq)
       val draftC285Claim       = sample[DraftClaim].copy(typeOfClaim = None)
       val foc                  = sample[FillingOutClaim].copy(draftClaim = draftC285Claim)
-      val sessionData          = sample[SessionData].copy(journeyStatus = Some(foc))
+      val sessionData          = sample[SessionData].copyWith(journeyStatus = Some(foc))
       val request              = RequestWithSessionData(Some(sessionData), authenticatedRequest)
 
       JourneyExtractor.extractJourney(request) shouldBe JourneyBindable.Single
@@ -62,7 +62,7 @@ class JourneyExtractorSpec extends AnyWordSpec with Matchers {
         val authenticatedRequest = AuthenticatedRequest[AnyContent](msgReq)
         val draftC285Claim       = sample[DraftClaim].copy(typeOfClaim = Some(numberOfClaims))
         val foc                  = sample[FillingOutClaim].copy(draftClaim = draftC285Claim)
-        val sessionData          = sample[SessionData].copy(journeyStatus = Some(foc))
+        val sessionData          = sample[SessionData].copyWith(journeyStatus = Some(foc))
         val request              = RequestWithSessionData(Some(sessionData), authenticatedRequest)
 
         JourneyExtractor.extractJourney(request) shouldBe journeyBindable

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/RedirectToStartBehaviour.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/RedirectToStartBehaviour.scala
@@ -50,7 +50,7 @@ trait RedirectToStartBehaviour {
           whenever(!isValidJourneyStatus(j)) {
             inSequence {
               mockAuthWithNoRetrievals()
-              mockGetSession(SessionData.empty.copy(journeyStatus = Some(j)))
+              mockGetSession(SessionData.empty.copyWith(journeyStatus = Some(j)))
             }
 
             checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/SessionDataExtractorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/SessionDataExtractorSpec.scala
@@ -75,7 +75,7 @@ class SessionDataExtractorSpec extends AnyWordSpec with Matchers {
       val draftC285Claim       =
         sample[DraftClaim].copy(whetherNorthernIrelandAnswer = Some(Yes))
       val foc                  = sample[FillingOutClaim].copy(draftClaim = draftC285Claim)
-      val sessionData          = sample[SessionData].copy(journeyStatus = Some(foc))
+      val sessionData          = sample[SessionData].copyWith(journeyStatus = Some(foc))
       val request              = RequestWithSessionData(Some(sessionData), authenticatedRequest)
 
       val result = sessionTester.method(dataExtractor, request)
@@ -114,7 +114,7 @@ class SessionDataExtractorSpec extends AnyWordSpec with Matchers {
             whetherNorthernIrelandAnswer = expectedData
           )
         val foc                  = sample[FillingOutClaim].copy(draftClaim = draftC285Claim)
-        val sessionData          = sample[SessionData].copy(journeyStatus = Some(foc))
+        val sessionData          = sample[SessionData].copyWith(journeyStatus = Some(foc))
         val request              = RequestWithSessionData(Some(sessionData), authenticatedRequest)
 
         val result =
@@ -136,7 +136,7 @@ class SessionDataExtractorSpec extends AnyWordSpec with Matchers {
             whetherNorthernIrelandAnswer = expectedData
           )
         val foc                  = sample[FillingOutClaim].copy(draftClaim = draftC285Claim)
-        val sessionData          = sample[SessionData].copy(journeyStatus = Some(foc))
+        val sessionData          = sample[SessionData].copyWith(journeyStatus = Some(foc))
         val request              = RequestWithSessionData(Some(sessionData), authenticatedRequest)
 
         val result =
@@ -158,7 +158,7 @@ class SessionDataExtractorSpec extends AnyWordSpec with Matchers {
             whetherNorthernIrelandAnswer = expectedData
           )
         val foc                  = sample[FillingOutClaim].copy(draftClaim = draftC285Claim)
-        val sessionData          = sample[SessionData].copy(journeyStatus = Some(foc))
+        val sessionData          = sample[SessionData].copyWith(journeyStatus = Some(foc))
         val request              = RequestWithSessionData(Some(sessionData), authenticatedRequest)
 
         val result =
@@ -180,7 +180,7 @@ class SessionDataExtractorSpec extends AnyWordSpec with Matchers {
             whetherNorthernIrelandAnswer = expectedData
           )
         val foc                  = sample[FillingOutClaim].copy(draftClaim = draftC285Claim)
-        val sessionData          = sample[SessionData].copy(journeyStatus = Some(foc))
+        val sessionData          = sample[SessionData].copyWith(journeyStatus = Some(foc))
         val request              = RequestWithSessionData(Some(sessionData), authenticatedRequest)
 
         val result =

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartControllerSpec.scala
@@ -67,13 +67,13 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           lazy val messagesRequest = new MessagesRequest(FakeRequest(), messagesApi)
 
           val sessionData =
-            sample[SessionData].copy(journeyStatus = None)
+            sample[SessionData].copyWith(journeyStatus = None)
 
           inSequence {
             mockAuthWithNonGGUserRetrievals()
             mockGetSession(sessionData)
             mockStoreSession(
-              sessionData.copy(
+              sessionData.copyWith(
                 journeyStatus = Some(NonGovernmentGatewayJourney)
               )
             )(Right(()))
@@ -95,13 +95,13 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           lazy val messagesRequest = new MessagesRequest(FakeRequest(), messagesApi)
 
           val sessionData =
-            sample[SessionData].copy(journeyStatus = None)
+            sample[SessionData].copyWith(journeyStatus = None)
 
           inSequence {
             mockAuthWithNonGGUserRetrievals()
             mockGetSession(sessionData)
             mockStoreSession(
-              sessionData.copy(
+              sessionData.copyWith(
                 journeyStatus = Some(NonGovernmentGatewayJourney)
               )
             )(Left(Error("Boom!")))
@@ -133,13 +133,13 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           lazy val messagesRequest = new MessagesRequest(FakeRequest(), messagesApi)
 
           val sessionData =
-            sample[SessionData].copy(journeyStatus = None)
+            sample[SessionData].copyWith(journeyStatus = None)
 
           inSequence {
             mockAuthWithEoriEnrolmentRetrievals()
             mockGetSession(sessionData)
             mockStoreSession(
-              sessionData.copy(
+              sessionData.copyWith(
                 journeyStatus = Some(
                   FillingOutClaim(
                     GGCredId("gg-cred-id"),
@@ -178,13 +178,13 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           lazy val messagesRequest = new MessagesRequest(FakeRequest(), messagesApi)
 
           val sessionData =
-            sample[SessionData].copy(journeyStatus = None)
+            sample[SessionData].copyWith(journeyStatus = None)
 
           inSequence {
             mockAuthWithEoriEnrolmentRetrievals()
             mockGetSession(sessionData)
             mockStoreSession(
-              sessionData.copy(
+              sessionData.copyWith(
                 journeyStatus = Some(
                   FillingOutClaim(
                     GGCredId("gg-cred-id"),
@@ -226,13 +226,13 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           lazy val messagesRequest = new MessagesRequest(FakeRequest(), messagesApi)
 
           val sessionData =
-            sample[SessionData].copy(journeyStatus = None)
+            sample[SessionData].copyWith(journeyStatus = None)
 
           inSequence {
             mockAuthWithOrgWithEoriEnrolmentRetrievals()
             mockGetSession(sessionData)
             mockStoreSession(
-              sessionData.copy(
+              sessionData.copyWith(
                 journeyStatus = Some(
                   FillingOutClaim(
                     GGCredId("gg-cred-id"),
@@ -261,7 +261,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
         "redirect the user to the submission error page" in {
 
           val submitClaimFailed = sample[SubmitClaimFailed]
-          val sessionData       = sample[SessionData].copy(journeyStatus = Some(submitClaimFailed))
+          val sessionData       = sample[SessionData].copyWith(journeyStatus = Some(submitClaimFailed))
 
           inSequence {
             mockAuthWithEoriEnrolmentRetrievals()
@@ -283,7 +283,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
         "redirect the user to the main CYA page" in {
 
           val justSubmittedClaim = sample[JustSubmittedClaim]
-          val sessionData        = sample[SessionData].copy(journeyStatus = Some(justSubmittedClaim))
+          val sessionData        = sample[SessionData].copyWith(journeyStatus = Some(justSubmittedClaim))
 
           inSequence {
             mockAuthWithEoriEnrolmentRetrievals()
@@ -303,7 +303,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
 
         "redirect the user to the main CYA page" in {
           val fillingOutClaim = sample[FillingOutClaim]
-          val sessionData     = sample[SessionData].copy(journeyStatus = Some(fillingOutClaim))
+          val sessionData     = sample[SessionData].copyWith(journeyStatus = Some(fillingOutClaim))
 
           inSequence {
             mockAuthWithEoriEnrolmentRetrievals()
@@ -320,7 +320,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
 
         "redirect the user to the `we only support gg page`" in {
 
-          val sessionData = sample[SessionData].copy(journeyStatus = Some(NonGovernmentGatewayJourney))
+          val sessionData = sample[SessionData].copyWith(journeyStatus = Some(NonGovernmentGatewayJourney))
 
           inSequence {
             mockAuthWithEoriEnrolmentRetrievals()
@@ -345,13 +345,13 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
         "redirect the user to the first page of the journey" in {
 
           val justSubmittedClaim = sample[JustSubmittedClaim]
-          val sessionData        = sample[SessionData].copy(journeyStatus = Some(justSubmittedClaim))
+          val sessionData        = sample[SessionData].copyWith(journeyStatus = Some(justSubmittedClaim))
 
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(sessionData)
             mockStoreSession(
-              sessionData.copy(
+              sessionData.copyWith(
                 journeyStatus = Some(
                   FillingOutClaim(
                     justSubmittedClaim.ggCredId,
@@ -372,13 +372,13 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
 
         "return an error if session update fails" in {
           val justSubmittedClaim = sample[JustSubmittedClaim]
-          val sessionData        = sample[SessionData].copy(journeyStatus = Some(justSubmittedClaim))
+          val sessionData        = sample[SessionData].copyWith(journeyStatus = Some(justSubmittedClaim))
 
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(sessionData)
             mockStoreSession(
-              sessionData.copy(
+              sessionData.copyWith(
                 journeyStatus = Some(
                   FillingOutClaim(
                     justSubmittedClaim.ggCredId,
@@ -401,7 +401,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
         "redirect the user to the error page" in {
 
           val fillingOutClaim = sample[FillingOutClaim]
-          val sessionData     = sample[SessionData].copy(journeyStatus = Some(fillingOutClaim))
+          val sessionData     = sample[SessionData].copyWith(journeyStatus = Some(fillingOutClaim))
 
           inSequence {
             mockAuthWithNoRetrievals()
@@ -438,7 +438,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(
-              SessionData.empty.copy(journeyStatus = Some(journey))
+              SessionData.empty.copyWith(journeyStatus = Some(journey))
             )
           }
 
@@ -469,7 +469,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           mockAuthWithNoRetrievals()
           mockGetSession(
             SessionData.empty
-              .copy(journeyStatus = Some(NonGovernmentGatewayJourney))
+              .copyWith(journeyStatus = Some(NonGovernmentGatewayJourney))
           )
         }
 
@@ -501,7 +501,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           mockAuthWithNoRetrievals()
           mockGetSession(
             SessionData.empty
-              .copy(
+              .copyWith(
                 journeyStatus = Some(NonGovernmentGatewayJourney)
               )
           )

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountControllerSpec.scala
@@ -109,7 +109,7 @@ class BankAccountControllerSpec
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
 
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey,
@@ -132,7 +132,7 @@ class BankAccountControllerSpec
     val signedInUserDetails   = sample[SignedInUserDetails]
     val journey               = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey,
@@ -146,7 +146,7 @@ class BankAccountControllerSpec
         val newClaim      =
           draftClaim.copy(bankAccountDetailsAnswer = Some(bankAccountDetails))
         val journeyStatus = FillingOutClaim(g, s, newClaim)
-        sessionData.copy(journeyStatus = Some(journeyStatus))
+        sessionData.copyWith(journeyStatus = Some(journeyStatus))
       case _                                                   => fail()
     }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckContactDetailsMrnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckContactDetailsMrnControllerSpec.scala
@@ -100,7 +100,7 @@ class CheckContactDetailsMrnControllerSpec
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey
     )
   }
@@ -119,7 +119,7 @@ class CheckContactDetailsMrnControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -252,7 +252,7 @@ class CheckContactDetailsMrnControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(fillingOutClaim)))
+          mockGetSession(session.copyWith(journeyStatus = Some(fillingOutClaim)))
         }
 
         checkIsRedirect(
@@ -273,7 +273,7 @@ class CheckContactDetailsMrnControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(fillingOutClaim)))
+          mockGetSession(session.copyWith(journeyStatus = Some(fillingOutClaim)))
         }
 
         checkIsRedirect(
@@ -293,7 +293,7 @@ class CheckContactDetailsMrnControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(fillingOutClaim)))
+          mockGetSession(session.copyWith(journeyStatus = Some(fillingOutClaim)))
         }
 
         checkPageIsDisplayed(
@@ -320,7 +320,7 @@ class CheckContactDetailsMrnControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(fillingOutClaim)))
+          mockGetSession(session.copyWith(journeyStatus = Some(fillingOutClaim)))
         }
 
         checkPageIsDisplayed(
@@ -614,7 +614,7 @@ class CheckContactDetailsMrnControllerSpec
 
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = None))
+        mockGetSession(session.copyWith(journeyStatus = None))
         mockAddressLookupInitiation(Right(lookupUrl))
       }
 
@@ -629,7 +629,7 @@ class CheckContactDetailsMrnControllerSpec
 
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = None))
+        mockGetSession(session.copyWith(journeyStatus = None))
         mockAddressLookupInitiation(Left(Error("Request was not accepted")))
       }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDeclarationDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDeclarationDetailsControllerSpec.scala
@@ -84,7 +84,7 @@ class CheckDeclarationDetailsControllerSpec
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey,
@@ -103,7 +103,7 @@ class CheckDeclarationDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -136,7 +136,7 @@ class CheckDeclarationDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         val action = performAction()
@@ -181,7 +181,7 @@ class CheckDeclarationDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDuplicateDeclarationDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDuplicateDeclarationDetailsControllerSpec.scala
@@ -78,7 +78,7 @@ class CheckDuplicateDeclarationDetailsControllerSpec
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey,
@@ -97,7 +97,7 @@ class CheckDuplicateDeclarationDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -161,7 +161,7 @@ class CheckDuplicateDeclarationDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -181,7 +181,7 @@ class CheckDuplicateDeclarationDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsControllerSpec.scala
@@ -74,7 +74,7 @@ class CheckEoriDetailsControllerSpec
       SignedInUserDetails(Some(email), eori, Email("amina@email.com"), ContactName("Fred Bread"))
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey,
       draftC285Claim
     )
@@ -101,7 +101,7 @@ class CheckEoriDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -119,7 +119,7 @@ class CheckEoriDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(fillingOutClaim)))
+          mockGetSession(session.copyWith(journeyStatus = Some(fillingOutClaim)))
         }
 
         checkPageIsDisplayed(
@@ -180,7 +180,7 @@ class CheckEoriDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(fillingOutClaim)))
+          mockGetSession(session.copyWith(journeyStatus = Some(fillingOutClaim)))
           mockGetEmail(Right(Some(VerifiedEmail(verifiedEmail, ""))))
           mockStoreSession(Right(()))
         }
@@ -195,7 +195,7 @@ class CheckEoriDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(fillingOutClaim)))
+          mockGetSession(session.copyWith(journeyStatus = Some(fillingOutClaim)))
           mockGetEmail(Right(Some(VerifiedEmail(verifiedEmail, ""))))
           mockStoreSession(Right(()))
         }
@@ -209,7 +209,7 @@ class CheckEoriDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(fillingOutClaim)))
+          mockGetSession(session.copyWith(journeyStatus = Some(fillingOutClaim)))
         }
 
         val result = performAction(Seq(checkEoriDetailsKey -> "false"))
@@ -221,7 +221,7 @@ class CheckEoriDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(fillingOutClaim)))
+          mockGetSession(session.copyWith(journeyStatus = Some(fillingOutClaim)))
         }
 
         val result = performAction(Seq())
@@ -241,7 +241,7 @@ class CheckEoriDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(fillingOutClaim)))
+          mockGetSession(session.copyWith(journeyStatus = Some(fillingOutClaim)))
         }
 
         val result = performAction(Seq.empty)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckMovementReferenceNumbersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckMovementReferenceNumbersControllerSpec.scala
@@ -93,7 +93,7 @@ class CheckMovementReferenceNumbersControllerSpec
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey,
@@ -132,7 +132,7 @@ class CheckMovementReferenceNumbersControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -221,7 +221,7 @@ class CheckMovementReferenceNumbersControllerSpec
           )
 
           val expectedSessionWithDeletedMrn =
-            session.copy(journeyStatus = Some(fillingOutClaim.copy(draftClaim = updatedDraftClaim)))
+            session.copyWith(journeyStatus = Some(fillingOutClaim.copy(draftClaim = updatedDraftClaim)))
 
           inSequence {
             mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckScheduledClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckScheduledClaimControllerSpec.scala
@@ -199,6 +199,6 @@ class CheckScheduledClaimControllerSpec extends ControllerSpec with AuthSupport 
   def sessionWithClaim(c285Claim: DraftClaim): SessionData = {
     val ggCredId            = sample[GGCredId]
     val signedInUserDetails = sample[SignedInUserDetails]
-    SessionData.empty.copy(journeyStatus = FillingOutClaim(ggCredId, signedInUserDetails, c285Claim).some)
+    SessionData.empty.copyWith(journeyStatus = FillingOutClaim(ggCredId, signedInUserDetails, c285Claim).some)
   }
 }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourAnswersAndSubmitControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourAnswersAndSubmitControllerSpec.scala
@@ -128,7 +128,7 @@ class CheckYourAnswersAndSubmitControllerSpec
 
           val session = SessionData(fillingOutClaim)
 
-          val justSubmittedJourney = session.copy(journeyStatus =
+          val justSubmittedJourney = session.copyWith(journeyStatus =
             Some(
               JustSubmittedClaim(
                 fillingOutClaim.ggCredId,
@@ -175,7 +175,7 @@ class CheckYourAnswersAndSubmitControllerSpec
 
           val session = SessionData(fillingOutClaim)
 
-          val submissionFailed = session.copy(journeyStatus =
+          val submissionFailed = session.copyWith(journeyStatus =
             Some(
               SubmitClaimFailed(
                 fillingOutClaim.ggCredId,
@@ -236,7 +236,7 @@ class CheckYourAnswersAndSubmitControllerSpec
 
           val submitClaimResponse = sample[SubmitClaimResponse]
 
-          val justSubmittedJourney = session.copy(journeyStatus =
+          val justSubmittedJourney = session.copyWith(journeyStatus =
             Some(
               JustSubmittedClaim(
                 fillingOutClaim.ggCredId,
@@ -295,7 +295,7 @@ class CheckYourAnswersAndSubmitControllerSpec
 
         val submitClaimResponse = sample[SubmitClaimResponse]
 
-        val justSubmittedJourney = session.copy(journeyStatus =
+        val justSubmittedJourney = session.copyWith(journeyStatus =
           Some(
             JustSubmittedClaim(
               fillingOutClaim.ggCredId,

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourAnswersSummarySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourAnswersSummarySpec.scala
@@ -61,7 +61,7 @@ abstract class CheckYourAnswersSummarySpec
     val signedInUserDetails = sample[SignedInUserDetails]
     val claim               = sample(genValidDraftClaim(maybeTypeOfClaim))
     val fillingOutClaim     = FillingOutClaim(ggCredId, signedInUserDetails, claim)
-    val session             = SessionData.empty.copy(journeyStatus = Some(fillingOutClaim))
+    val session             = SessionData.empty.copyWith(journeyStatus = Some(fillingOutClaim))
     (session, claim)
   }
 }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ClaimNorthernIrelandControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ClaimNorthernIrelandControllerSpec.scala
@@ -82,7 +82,7 @@ class ClaimNorthernIrelandControllerSpec
     val eori                = sample[Eori]
     val signedInUserDetails = SignedInUserDetails(Some(email), eori, email, ContactName("Anima Amina"))
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
-    SessionData.empty.copy(journeyStatus = Some(journey))
+    SessionData.empty.copyWith(journeyStatus = Some(journey))
   }
 
   private def updateSession(sessionData: SessionData, whetherNorthernIrelandClaim: YesNo): SessionData =
@@ -91,7 +91,7 @@ class ClaimNorthernIrelandControllerSpec
         val newClaim      =
           draftClaim.copy(whetherNorthernIrelandAnswer = Some(whetherNorthernIrelandClaim))
         val journeyStatus = FillingOutClaim(g, s, newClaim)
-        sessionData.copy(journeyStatus = Some(journeyStatus))
+        sessionData.copyWith(journeyStatus = Some(journeyStatus))
       case _                                                   => fail()
     }
 
@@ -133,7 +133,7 @@ class ClaimNorthernIrelandControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAssociatedMrnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAssociatedMrnControllerSpec.scala
@@ -106,7 +106,7 @@ class EnterAssociatedMrnControllerSpec
         .getOrElse(sample[SignedInUserDetails])
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey,

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterCommoditiesDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterCommoditiesDetailsControllerSpec.scala
@@ -88,7 +88,7 @@ class EnterCommoditiesDetailsControllerSpec
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
 
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey,
       draftC285Claim
     )
@@ -105,7 +105,7 @@ class EnterCommoditiesDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -133,7 +133,7 @@ class EnterCommoditiesDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -159,7 +159,7 @@ class EnterCommoditiesDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -186,7 +186,7 @@ class EnterCommoditiesDetailsControllerSpec
 
           inSequence {
             mockAuthWithNoRetrievals()
-            mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+            mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
           }
 
           checkPageIsDisplayed(
@@ -218,7 +218,7 @@ class EnterCommoditiesDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkIsRedirect(
@@ -246,7 +246,7 @@ class EnterCommoditiesDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkIsRedirect(
@@ -283,7 +283,7 @@ class EnterCommoditiesDetailsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterContactDetailsMrnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterContactDetailsMrnControllerSpec.scala
@@ -95,7 +95,7 @@ class EnterContactDetailsMrnControllerSpec
     val ggCredId            = sample[GGCredId]
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
-    (SessionData.empty.copy(journeyStatus = Some(journey)), journey)
+    (SessionData.empty.copyWith(journeyStatus = Some(journey)), journey)
   }
 
   private def updateSession(sessionData: SessionData, mrnContactDetailsAnswer: MrnContactDetails): SessionData =
@@ -104,7 +104,7 @@ class EnterContactDetailsMrnControllerSpec
         val newClaim      =
           draftClaim.copy(mrnContactDetailsAnswer = Some(mrnContactDetailsAnswer))
         val journeyStatus = FillingOutClaim(g, s, newClaim)
-        sessionData.copy(journeyStatus = Some(journeyStatus))
+        sessionData.copyWith(journeyStatus = Some(journeyStatus))
       case _                                                   => fail()
     }
 
@@ -119,7 +119,7 @@ class EnterContactDetailsMrnControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDeclarantEoriNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDeclarantEoriNumberControllerSpec.scala
@@ -77,7 +77,7 @@ class EnterDeclarantEoriNumberControllerSpec
       SignedInUserDetails(Some(email), eori, Email("email@email.com"), ContactName("Fred Bread"))
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey,
@@ -96,7 +96,7 @@ class EnterDeclarantEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -121,7 +121,7 @@ class EnterDeclarantEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -143,7 +143,7 @@ class EnterDeclarantEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -174,7 +174,7 @@ class EnterDeclarantEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkIsRedirect(
@@ -205,7 +205,7 @@ class EnterDeclarantEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -241,7 +241,7 @@ class EnterDeclarantEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDuplicateMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDuplicateMovementReferenceNumberControllerSpec.scala
@@ -105,7 +105,7 @@ class EnterDuplicateMovementReferenceNumberControllerSpec
           duplicateMovementReferenceNumberAnswer = Some(updatedMrn),
           duplicateDisplayDeclaration = Some(displayDeclaration)
         )
-      val updatedSession     = session.copy(journeyStatus = Some(claim.copy(draftClaim = updatedClaim)))
+      val updatedSession     = session.copyWith(journeyStatus = Some(claim.copy(draftClaim = updatedClaim)))
 
       inSequence {
         mockAuthWithNoRetrievals()
@@ -131,6 +131,6 @@ class EnterDuplicateMovementReferenceNumberControllerSpec
     val ggCredId            = sample[GGCredId]
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
-    (SessionData.empty.copy(journeyStatus = Some(journey)), journey)
+    (SessionData.empty.copyWith(journeyStatus = Some(journey)), journey)
   }
 }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterImporterEoriNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterImporterEoriNumberControllerSpec.scala
@@ -87,7 +87,7 @@ class EnterImporterEoriNumberControllerSpec
       SignedInUserDetails(Some(email), eori, Email("email@email.com"), ContactName("Fred Bread"))
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey,
@@ -106,7 +106,7 @@ class EnterImporterEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -131,7 +131,7 @@ class EnterImporterEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -153,7 +153,7 @@ class EnterImporterEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -194,7 +194,7 @@ class EnterImporterEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
           (mockClaimService
             .getDisplayDeclaration(_: MRN)(_: HeaderCarrier))
             .expects(*, *)
@@ -210,7 +210,7 @@ class EnterImporterEoriNumberControllerSpec
       "user chooses an un-matching importer EORI" in forAll(testCases) { journeyBindable =>
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
           (mockClaimService
             .getDisplayDeclaration(_: MRN)(_: HeaderCarrier))
             .expects(*, *)
@@ -244,7 +244,7 @@ class EnterImporterEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -280,7 +280,7 @@ class EnterImporterEoriNumberControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMultipleClaimsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMultipleClaimsControllerSpec.scala
@@ -142,7 +142,7 @@ class EnterMultipleClaimsControllerSpec
     val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
 
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey.draftClaim,
       leadMrn :: associatedMrns,
       ndrscDetails(selectedMrnIndex)
@@ -191,7 +191,7 @@ class EnterMultipleClaimsControllerSpec
 
           inSequence {
             mockAuthWithNoRetrievals()
-            mockGetSession(session.copy(journeyStatus = None))
+            mockGetSession(session.copyWith(journeyStatus = None))
           }
 
           checkIsRedirect(
@@ -336,7 +336,7 @@ class EnterMultipleClaimsControllerSpec
     val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
 
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey.draftClaim,
       leadMrn :: associatedMrns,
       claimedReimbursementLists
@@ -375,7 +375,7 @@ class EnterMultipleClaimsControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterScheduledClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterScheduledClaimControllerSpec.scala
@@ -142,7 +142,7 @@ class EnterScheduledClaimControllerSpec
           )
 
           val updatedSession: SessionData =
-            session.copy(journeyStatus = session.journeyStatus.collect { case fillingOutClaim: FillingOutClaim =>
+            session.copyWith(journeyStatus = session.journeyStatus.collect { case fillingOutClaim: FillingOutClaim =>
               fillingOutClaim.copy(
                 draftClaim = draftClaim.copy(
                   selectedDutyTaxCodesReimbursementAnswer = SelectedDutyTaxCodesReimbursementAnswer(
@@ -184,7 +184,7 @@ class EnterScheduledClaimControllerSpec
         )
 
         val updatedSession: SessionData =
-          session.copy(journeyStatus = session.journeyStatus.collect { case fillingOutClaim: FillingOutClaim =>
+          session.copyWith(journeyStatus = session.journeyStatus.collect { case fillingOutClaim: FillingOutClaim =>
             fillingOutClaim.copy(
               draftClaim = draftClaim.copy(
                 selectedDutyTaxCodesReimbursementAnswer = SelectedDutyTaxCodesReimbursementAnswer(
@@ -294,7 +294,7 @@ class EnterScheduledClaimControllerSpec
       selectedDutyTaxCodesReimbursementAnswer = selectedDutyTaxCodesReimbursementAnswer
     )
     (
-      SessionData.empty.copy(journeyStatus = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim).some),
+      SessionData.empty.copyWith(journeyStatus = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim).some),
       draftC285Claim
     )
   }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterSingleClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterSingleClaimControllerSpec.scala
@@ -82,7 +82,7 @@ class EnterSingleClaimControllerSpec
       )
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey
     )
   }
@@ -110,7 +110,7 @@ class EnterSingleClaimControllerSpec
       case Some(FillingOutClaim(g, s, (draftClaim: DraftClaim))) =>
         val newClaim      = draftClaim.copy(claimedReimbursementsAnswer = Some(answer))
         val journeyStatus = FillingOutClaim(g, s, newClaim)
-        sessionData.copy(journeyStatus = Some(journeyStatus))
+        sessionData.copyWith(journeyStatus = Some(journeyStatus))
       case _                                                     => fail()
     }
 
@@ -127,7 +127,7 @@ class EnterSingleClaimControllerSpec
       val session = createSessionWithPreviousAnswers(None)._1
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = None))
+        mockGetSession(session.copyWith(journeyStatus = None))
       }
 
       checkIsRedirect(
@@ -224,7 +224,7 @@ class EnterSingleClaimControllerSpec
       val session = createSessionWithPreviousAnswers(None)._1
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = None))
+        mockGetSession(session.copyWith(journeyStatus = None))
       }
 
       checkIsRedirect(
@@ -298,7 +298,7 @@ class EnterSingleClaimControllerSpec
       val session = createSessionWithPreviousAnswers(None)._1
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = None))
+        mockGetSession(session.copyWith(journeyStatus = None))
       }
 
       checkIsRedirect(
@@ -384,7 +384,7 @@ class EnterSingleClaimControllerSpec
       val session = createSessionWithPreviousAnswers(None)._1
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = None))
+        mockGetSession(session.copyWith(journeyStatus = None))
       }
 
       checkIsRedirect(
@@ -402,7 +402,7 @@ class EnterSingleClaimControllerSpec
       val session = createSessionWithPreviousAnswers(None)._1
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = None))
+        mockGetSession(session.copyWith(journeyStatus = None))
       }
 
       checkIsRedirect(
@@ -500,7 +500,7 @@ class EnterSingleClaimControllerSpec
     }
 
     "Redirect to Check Your Answers page" in {
-      val session = SessionData.empty.copy(
+      val session = SessionData.empty.copyWith(
         journeyStatus = Some(
           FillingOutClaim(
             sample[GGCredId],

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ReimbursementMethodControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ReimbursementMethodControllerSpec.scala
@@ -68,7 +68,7 @@ class ReimbursementMethodControllerSpec
       "there is no journey status in the session" in {
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(SessionData.empty.copy(journeyStatus = None))
+          mockGetSession(SessionData.empty.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -233,7 +233,7 @@ class ReimbursementMethodControllerSpec
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, DraftClaim.blank)
 
-    SessionData.empty.copy(
+    SessionData.empty.copyWith(
       journeyStatus = Some(journey)
     )
   }
@@ -243,7 +243,7 @@ class ReimbursementMethodControllerSpec
     val ggCredId            = sample[GGCredId]
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
-    SessionData.empty.copy(journeyStatus = Some(journey))
+    SessionData.empty.copyWith(journeyStatus = Some(journey))
   }
 
   private def isCurrentMonthAjustmentChecked(document: Document): Boolean = isChecked(document, "cma")
@@ -261,7 +261,7 @@ class ReimbursementMethodControllerSpec
         val newClaim      =
           draftClaim.copy(reimbursementMethodAnswer = Some(reimbusementMethod))
         val journeyStatus = FillingOutClaim(g, s, newClaim)
-        sessionData.copy(journeyStatus = Some(journeyStatus))
+        sessionData.copyWith(journeyStatus = Some(journeyStatus))
       case _                                                   => fail()
     }
 
@@ -271,7 +271,7 @@ class ReimbursementMethodControllerSpec
         val newClaim      =
           draftClaim.copy(supportingEvidencesAnswer = Some(sample[SupportingEvidencesAnswer]))
         val journeyStatus = FillingOutClaim(g, s, newClaim)
-        sessionData.copy(journeyStatus = Some(journeyStatus))
+        sessionData.copyWith(journeyStatus = Some(journeyStatus))
       case _                                                   => fail()
     }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBankAccountTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBankAccountTypeControllerSpec.scala
@@ -90,7 +90,7 @@ class SelectBankAccountTypeControllerSpec
     val eori                = sample[Eori]
     val signedInUserDetails = SignedInUserDetails(Some(email), eori, email, ContactName("Anima Amina"))
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
-    SessionData.empty.copy(journeyStatus = Some(journey))
+    SessionData.empty.copyWith(journeyStatus = Some(journey))
   }
 
   private def updateSession(sessionData: SessionData, bankAccountType: BankAccountType): SessionData =
@@ -98,7 +98,7 @@ class SelectBankAccountTypeControllerSpec
       case Some(FillingOutClaim(g, s, draftClaim: DraftClaim)) =>
         val newClaim      = draftClaim.copy(bankAccountTypeAnswer = Some(bankAccountType))
         val journeyStatus = FillingOutClaim(g, s, newClaim)
-        sessionData.copy(journeyStatus = Some(journeyStatus))
+        sessionData.copyWith(journeyStatus = Some(journeyStatus))
       case _                                                   => fail()
     }
 
@@ -130,7 +130,7 @@ class SelectBankAccountTypeControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBasisForClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBasisForClaimControllerSpec.scala
@@ -70,7 +70,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey,
@@ -89,7 +89,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -113,7 +113,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -134,7 +134,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -156,7 +156,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -179,7 +179,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -202,7 +202,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -232,7 +232,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkIsRedirect(
@@ -250,7 +250,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
         val claim = sample(genValidDraftClaim(TypeOfClaimAnswer.Individual))
         val idx   = BasisOfClaims.indexOf(claim.basisOfClaimAnswer.value)
 
-        val session = SessionData.empty.copy(
+        val session = SessionData.empty.copyWith(
           journeyStatus = FillingOutClaim(
             sample[GGCredId],
             sample[SignedInUserDetails],
@@ -289,7 +289,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -320,7 +320,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutiesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutiesControllerSpec.scala
@@ -77,7 +77,7 @@ class SelectDutiesControllerSpec
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey
     )
   }
@@ -120,7 +120,7 @@ class SelectDutiesControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyCodesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyCodesControllerSpec.scala
@@ -138,7 +138,7 @@ class SelectDutyCodesControllerSpec
         )
 
         val updatedSession: SessionData =
-          session.copy(journeyStatus = session.journeyStatus.collect { case fillingOutClaim: FillingOutClaim =>
+          session.copyWith(journeyStatus = session.journeyStatus.collect { case fillingOutClaim: FillingOutClaim =>
             fillingOutClaim.copy(
               draftClaim = draftClaim.copy(
                 selectedDutyTaxCodesReimbursementAnswer = SelectedDutyTaxCodesReimbursementAnswer(
@@ -173,7 +173,7 @@ class SelectDutyCodesControllerSpec
         )
 
         val updatedSession: SessionData =
-          session.copy(journeyStatus = session.journeyStatus.collect { case fillingOutClaim: FillingOutClaim =>
+          session.copyWith(journeyStatus = session.journeyStatus.collect { case fillingOutClaim: FillingOutClaim =>
             fillingOutClaim.copy(
               draftClaim = draftClaim.copy(
                 selectedDutyTaxCodesReimbursementAnswer = SelectedDutyTaxCodesReimbursementAnswer(
@@ -234,7 +234,7 @@ class SelectDutyCodesControllerSpec
       selectedDutyTaxCodesReimbursementAnswer = selectedDutyTaxCodesReimbursementAnswer
     )
     (
-      SessionData.empty.copy(journeyStatus = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim).some),
+      SessionData.empty.copyWith(journeyStatus = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim).some),
       draftC285Claim
     )
   }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyTypesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyTypesControllerSpec.scala
@@ -110,7 +110,7 @@ class SelectDutyTypesControllerSpec
 
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+        mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         mockStoreSession(Right(()))
       }
 
@@ -127,7 +127,7 @@ class SelectDutyTypesControllerSpec
 
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+        mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         mockStoreSession(Right(()))
       }
 
@@ -150,7 +150,7 @@ class SelectDutyTypesControllerSpec
 
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+        mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
       }
 
       checkIsRedirect(
@@ -170,7 +170,7 @@ class SelectDutyTypesControllerSpec
 
       inSequence {
         mockAuthWithNoRetrievals()
-        mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+        mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
       }
 
       checkPageIsDisplayed(
@@ -196,7 +196,7 @@ class SelectDutyTypesControllerSpec
     val signedInUserDetails = sample[SignedInUserDetails]
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey,
       draftC285Claim
     )

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectMultipleDutiesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectMultipleDutiesControllerSpec.scala
@@ -133,7 +133,7 @@ class SelectMultipleDutiesControllerSpec
     val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
 
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey.draftClaim,
       leadMrn :: associatedMrns
     )
@@ -187,7 +187,7 @@ class SelectMultipleDutiesControllerSpec
 
           inSequence {
             mockAuthWithNoRetrievals()
-            mockGetSession(session.copy(journeyStatus = None))
+            mockGetSession(session.copyWith(journeyStatus = None))
           }
 
           checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectTypeOfClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectTypeOfClaimControllerSpec.scala
@@ -74,7 +74,7 @@ class SelectTypeOfClaimControllerSpec
     val eori                = sample[Eori]
     val signedInUserDetails = SignedInUserDetails(Some(email), eori, email, ContactName("Anima Amina"))
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
-    SessionData.empty.copy(journeyStatus = Some(journey))
+    SessionData.empty.copyWith(journeyStatus = Some(journey))
   }
 
   private def updateSession(sessionData: SessionData, typeOfClaim: TypeOfClaimAnswer): SessionData =
@@ -83,7 +83,7 @@ class SelectTypeOfClaimControllerSpec
         val newClaim      =
           draftClaim.copy(typeOfClaim = Some(typeOfClaim))
         val journeyStatus = FillingOutClaim(g, s, newClaim)
-        sessionData.copy(journeyStatus = Some(journeyStatus))
+        sessionData.copyWith(journeyStatus = Some(journeyStatus))
       case _                                                   => fail()
     }
 
@@ -128,7 +128,7 @@ class SelectTypeOfClaimControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectWhoIsMakingTheClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectWhoIsMakingTheClaimControllerSpec.scala
@@ -85,7 +85,7 @@ class SelectWhoIsMakingTheClaimControllerSpec
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
 
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey,
       draftC285Claim
     )
@@ -101,7 +101,7 @@ class SelectWhoIsMakingTheClaimControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
+          mockGetSession(session.copyWith(journeyStatus = None))
         }
 
         checkIsRedirect(
@@ -126,7 +126,7 @@ class SelectWhoIsMakingTheClaimControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -146,7 +146,7 @@ class SelectWhoIsMakingTheClaimControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -176,7 +176,7 @@ class SelectWhoIsMakingTheClaimControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkIsRedirect(
@@ -198,7 +198,7 @@ class SelectWhoIsMakingTheClaimControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -227,7 +227,7 @@ class SelectWhoIsMakingTheClaimControllerSpec
 
         inSequence {
           mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = Some(updatedJourney)))
+          mockGetSession(session.copyWith(journeyStatus = Some(updatedJourney)))
         }
 
         checkPageIsDisplayed(
@@ -261,7 +261,7 @@ class SelectWhoIsMakingTheClaimControllerSpec
         inSequence {
           mockAuthWithNoRetrievals()
           mockGetSession(
-            session.copy(journeyStatus =
+            session.copyWith(journeyStatus =
               Some(
                 FillingOutClaim.from(fillingOutClaim)(_.copy(declarantTypeAnswer = Some(declarantType)))
               )
@@ -299,7 +299,7 @@ class SelectWhoIsMakingTheClaimControllerSpec
         inSequence {
           mockAuthWithNoRetrievals()
           mockGetSession(
-            session.copy(journeyStatus =
+            session.copyWith(journeyStatus =
               Some(
                 FillingOutClaim.from(fillingOutClaim)(_.copy(declarantTypeAnswer = Some(declarantType)))
               )
@@ -337,7 +337,7 @@ class SelectWhoIsMakingTheClaimControllerSpec
         inSequence {
           mockAuthWithNoRetrievals()
           mockGetSession(
-            session.copy(journeyStatus =
+            session.copyWith(journeyStatus =
               Some(
                 FillingOutClaim.from(fillingOutClaim)(_.copy(declarantTypeAnswer = Some(declarantType)))
               )

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/fileupload/ScheduleOfMrnDocumentControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/fileupload/ScheduleOfMrnDocumentControllerSpec.scala
@@ -49,7 +49,7 @@ class ScheduleOfMrnDocumentControllerSpec extends FileUploadControllerSpec {
     val signedInUserDetails = SignedInUserDetails(Some(email), eori, Email(""), ContactName(""))
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, claim)
     (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
+      SessionData.empty.copyWith(journeyStatus = Some(journey)),
       journey,
       claim
     )
@@ -174,7 +174,7 @@ class ScheduleOfMrnDocumentControllerSpec extends FileUploadControllerSpec {
             val updatedJourney     = journey.copy(draftClaim = updatedDraftReturn)
 
             val updatedSession: SessionData =
-              session.copy(journeyStatus = Some(updatedJourney))
+              session.copyWith(journeyStatus = Some(updatedJourney))
 
             inSequence {
               mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/fileupload/SupportingEvidenceControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/fileupload/SupportingEvidenceControllerSpec.scala
@@ -56,7 +56,7 @@ class SupportingEvidenceControllerSpec extends FileUploadControllerSpec {
     val signedInUserDetails = SignedInUserDetails(Some(email), eori, Email(""), ContactName(""))
     val journey             = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
     (
-      SessionData.empty.copy(
+      SessionData.empty.copyWith(
         journeyStatus = Some(journey)
       ),
       journey,
@@ -268,7 +268,7 @@ class SupportingEvidenceControllerSpec extends FileUploadControllerSpec {
           val updatedAnswer               = List(updatedSupportingEvidence).toNel
           val updatedDraftReturn          = draftClaim.copy(supportingEvidencesAnswer = updatedAnswer)
           val updatedJourney              = journey.copy(draftClaim = updatedDraftReturn)
-          val updatedSession: SessionData = session.copy(journeyStatus = Some(updatedJourney))
+          val updatedSession: SessionData = session.copyWith(journeyStatus = Some(updatedJourney))
 
           inSequence {
             mockAuthWithNoRetrievals()
@@ -299,7 +299,7 @@ class SupportingEvidenceControllerSpec extends FileUploadControllerSpec {
 
           val updatedDraftReturn          = draftClaim.copy(supportingEvidencesAnswer = updatedAnswer)
           val updatedJourney              = journey.copy(draftClaim = updatedDraftReturn)
-          val updatedSession: SessionData = session.copy(journeyStatus = Some(updatedJourney))
+          val updatedSession: SessionData = session.copyWith(journeyStatus = Some(updatedJourney))
 
           inSequence {
             mockAuthWithNoRetrievals()
@@ -336,7 +336,7 @@ class SupportingEvidenceControllerSpec extends FileUploadControllerSpec {
           val updatedJourney     = journey.copy(draftClaim = updatedDraftReturn)
 
           val updatedSession: SessionData =
-            session.copy(journeyStatus = Some(updatedJourney))
+            session.copyWith(journeyStatus = Some(updatedJourney))
 
           inSequence {
             mockAuthWithNoRetrievals()
@@ -364,7 +364,7 @@ class SupportingEvidenceControllerSpec extends FileUploadControllerSpec {
           val updatedDraftReturn          = draftClaim.copy(supportingEvidencesAnswer = updatedAnswer)
           val updatedJourney              = journey.copy(draftClaim = updatedDraftReturn)
           val updatedSession: SessionData =
-            session.copy(journeyStatus = Some(updatedJourney))
+            session.copyWith(journeyStatus = Some(updatedJourney))
 
           inSequence {
             mockAuthWithNoRetrievals()
@@ -390,7 +390,7 @@ class SupportingEvidenceControllerSpec extends FileUploadControllerSpec {
 
           val updatedDraftReturn          = draftClaim.copy(supportingEvidencesAnswer = None)
           val updatedJourney              = journey.copy(draftClaim = updatedDraftReturn)
-          val updatedSession: SessionData = session.copy(journeyStatus = Some(updatedJourney))
+          val updatedSession: SessionData = session.copyWith(journeyStatus = Some(updatedJourney))
 
           inSequence {
             mockAuthWithNoRetrievals()
@@ -440,7 +440,7 @@ class SupportingEvidenceControllerSpec extends FileUploadControllerSpec {
 
           val newJourney = journey.copy(draftClaim = newDraftClaim)
 
-          val updatedSession: SessionData = session.copy(journeyStatus = Some(newJourney))
+          val updatedSession: SessionData = session.copyWith(journeyStatus = Some(newJourney))
 
           inSequence {
             mockAuthWithNoRetrievals()
@@ -565,7 +565,7 @@ class SupportingEvidenceControllerSpec extends FileUploadControllerSpec {
           val updatedDraftReturn          = draftClaim.copy(supportingEvidencesAnswer = updatedAnswer)
           val updatedJourney              = journey.copy(draftClaim = updatedDraftReturn)
           val updatedSession: SessionData =
-            session.copy(journeyStatus = Some(updatedJourney))
+            session.copyWith(journeyStatus = Some(updatedJourney))
 
           inSequence {
             mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/SessionDataFormatSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/SessionDataFormatSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.support.JsonFormatTest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.SessionDataGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus
+import org.scalatest.Ignore
+
+@Ignore
+class SessionDataFormatSpec extends AnyWordSpec with JsonFormatTest with Matchers with ScalaCheckPropertyChecks {
+
+  "JourneyStatus" should {
+    "be serializable into a JSON format" in {
+      forAll { journeyStatus: JourneyStatus =>
+        validateCanReadAndWriteJson(journeyStatus)
+      }
+    }
+  }
+
+  "SessionData" should {
+    "be serializable into a JSON format" in {
+      forAll { sessionData: SessionData =>
+        validateCanReadAndWriteJson(sessionData)
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/utils/TraitFormatSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/utils/TraitFormatSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
+
+import org.scalacheck.Gen
+import org.scalacheck.magnolia._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.libs.json.Json
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.support.JsonFormatTest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.TraitFormat
+
+class TraitFormatSpec extends AnyWordSpec with JsonFormatTest with Matchers with ScalaCheckPropertyChecks {
+
+  trait Foo
+  case class Foo1(a: String) extends Foo
+  case class Foo2(a: Int, b: Boolean) extends Foo
+  case class Foo3(s: Seq[Foo2]) extends Foo
+
+  case class Bar(map: Map[String, Foo], option: Option[Foo])
+
+  object Foo extends TraitFormat[Foo] {
+    implicit val format1 = Json.format[Foo1]
+    implicit val format2 = Json.format[Foo2]
+    implicit val format3 = Json.format[Foo3]
+
+    override val members: Seq[Member[_ <: Foo]] = Seq(Member[Foo1], Member[Foo2], Member[Foo3])
+  }
+
+  object Bar {
+    implicit val format = Json.format[Bar]
+  }
+
+  implicit val fooGen: Gen[Foo] = Gen.oneOf[Foo](gen[Foo1].arbitrary, gen[Foo2].arbitrary, gen[Foo3].arbitrary)
+  implicit val barGen: Gen[Bar] = for {
+    map    <- Gen.mapOf(fooGen.map(v => (Foo.keyOf(v), v)))
+    option <- Gen.option(fooGen)
+  } yield Bar(map, option)
+
+  "TraitFormat" should {
+    "serialize entity into a JSON format" in {
+      forAll(barGen) { bar: Bar =>
+        validateCanReadAndWriteJson(bar)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR modifies how we access `SessionData`, replacing:
- value read op with the dedicated method `def journeyStatus ....`
- write op `.copy(` with `.copyWith(`

This change will enable the addition of new types of journeys to the `SessionData` in the following PRs.