### PR TITLE
[CDSR-1254][AO] add connector to submit rejected goods single claim

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/ClaimConnector.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/ClaimConnector.scala
@@ -17,23 +17,25 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
 
 import cats.data.EitherT
-import com.google.inject.{ImplementedBy, Inject}
-import play.api.http.HeaderNames.ACCEPT_LANGUAGE
-import play.api.i18n.Lang
+import com.google.inject.ImplementedBy
+import com.google.inject.Inject
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimRequest
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpClient
 import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.Singleton
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.util.control.NonFatal
 
 @ImplementedBy(classOf[DefaultClaimConnector])
 trait ClaimConnector {
-  def submitClaim(submitClaimRequest: SubmitClaimRequest, lang: Lang)(implicit
+  def submitClaim(submitClaimRequest: SubmitClaimRequest)(implicit
     hc: HeaderCarrier
   ): EitherT[Future, Error, HttpResponse]
 }
@@ -44,25 +46,23 @@ class DefaultClaimConnector @Inject() (http: HttpClient, servicesConfig: Service
 ) extends ClaimConnector
     with Logging {
 
-  private val baseUrl: String = servicesConfig.baseUrl("cds-reimbursement-claim")
+  private val baseUrl: String        = servicesConfig.baseUrl("cds-reimbursement-claim")
+  private val contextPath: String    =
+    servicesConfig.getConfString("cds-reimbursement-claim.context-path", "cds-reimbursement-claim")
+  private val submitClaimUrl: String = s"$baseUrl$contextPath/claim"
 
-  override def submitClaim(submitClaimRequest: SubmitClaimRequest, lang: Lang)(implicit
+  override def submitClaim(submitClaimRequest: SubmitClaimRequest)(implicit
     hc: HeaderCarrier
-  ): EitherT[Future, Error, HttpResponse] = {
-
-    val submitClaimUrl: String = s"$baseUrl/cds-reimbursement-claim/claim"
-
+  ): EitherT[Future, Error, HttpResponse] =
     EitherT[Future, Error, HttpResponse](
       http
         .POST[SubmitClaimRequest, HttpResponse](
           submitClaimUrl,
-          submitClaimRequest,
-          Seq(ACCEPT_LANGUAGE -> lang.language)
+          submitClaimRequest
         )
         .map(Right(_))
         .recover { case NonFatal(e) =>
           Left(Error(e))
         }
     )
-  }
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnector.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnector.scala
@@ -68,7 +68,9 @@ class RejectedGoodsSingleClaimConnectorImpl @Inject() (
   import RejectedGoodsSingleClaimConnector._
 
   val baseUrl: String                     = servicesConfig.baseUrl("cds-reimbursement-claim")
-  val claimUrl: String                    = s"$baseUrl/claims/rejected-goods-single"
+  val contextPath: String                 =
+    servicesConfig.getConfString("cds-reimbursement-claim.context-path", "cds-reimbursement-claim")
+  val claimUrl: String                    = s"$baseUrl$contextPath/claims/rejected-goods-single"
   val retryIntervals: Seq[FiniteDuration] = getConfIntervals("cds-reimbursement-claim", configuration)
 
   override def submitClaim(claimRequest: Request)(implicit

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnector.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnector.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
+
+import akka.actor.ActorSystem
+import cats.syntax.eq._
+import com.google.inject.ImplementedBy
+import com.google.inject.Inject
+import play.api.libs.json.Format
+import play.api.libs.json.Json
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.HttpResponseOps._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpClient
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import play.api.Configuration
+
+@ImplementedBy(classOf[RejectedGoodsSingleClaimConnectorImpl])
+trait RejectedGoodsSingleClaimConnector {
+
+  def submitClaim(claimRequest: RejectedGoodsSingleClaimConnector.Request)(implicit
+    hc: HeaderCarrier
+  ): Future[RejectedGoodsSingleClaimConnector.Response]
+}
+
+object RejectedGoodsSingleClaimConnector {
+
+  final case class Request(claim: RejectedGoodsSingleJourney.Output)
+  final case class Response(caseNumber: String)
+  final class Exception(msg: String) extends scala.RuntimeException(msg)
+
+  implicit val requestFormat: Format[Request]   = Json.format[Request]
+  implicit val responseFormat: Format[Response] = Json.format[Response]
+}
+
+@Singleton
+class RejectedGoodsSingleClaimConnectorImpl @Inject() (
+  http: HttpClient,
+  servicesConfig: ServicesConfig,
+  configuration: Configuration,
+  val actorSystem: ActorSystem
+)(implicit
+  ec: ExecutionContext
+) extends RejectedGoodsSingleClaimConnector
+    with Retries {
+
+  import RejectedGoodsSingleClaimConnector._
+
+  val baseUrl: String                     = servicesConfig.baseUrl("cds-reimbursement-claim")
+  val claimUrl: String                    = s"$baseUrl/claims/rejected-goods-single"
+  val retryIntervals: Seq[FiniteDuration] = getConfIntervals("cds-reimbursement-claim", configuration)
+
+  override def submitClaim(claimRequest: Request)(implicit
+    hc: HeaderCarrier
+  ): Future[Response] =
+    retry(retryIntervals: _*)(shouldRetry, retryReason)(
+      http
+        .POST[Request, HttpResponse](
+          claimUrl,
+          claimRequest
+        )
+    ).flatMap(response =>
+      if (response.status === 200)
+        response
+          .parseJSON[Response]()
+          .fold(error => Future.failed(new Exception(error)), Future.successful(_))
+      else
+        Future.failed(
+          new Exception(s"Request to POST $claimUrl failed because of $response")
+        )
+    )
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnector.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnector.scala
@@ -48,7 +48,7 @@ object RejectedGoodsSingleClaimConnector {
 
   final case class Request(claim: RejectedGoodsSingleJourney.Output)
   final case class Response(caseNumber: String)
-  final class Exception(msg: String) extends scala.RuntimeException(msg)
+  final case class Exception(msg: String) extends scala.RuntimeException(msg)
 
   implicit val requestFormat: Format[Request]   = Json.format[Request]
   implicit val responseFormat: Format[Response] = Json.format[Response]
@@ -87,7 +87,7 @@ class RejectedGoodsSingleClaimConnectorImpl @Inject() (
           .fold(error => Future.failed(new Exception(error)), Future.successful(_))
       else
         Future.failed(
-          new Exception(s"Request to POST $claimUrl failed because of $response")
+          new Exception(s"Request to POST $claimUrl failed because of $response ${response.body}")
         )
     )
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/Retries.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/Retries.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
+
+import akka.actor.ActorSystem
+import akka.pattern.after
+import play.api.Configuration
+import play.api.Logger
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.play.http.logging.Mdc
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scala.util.control.NonFatal
+
+trait Retries {
+
+  protected def actorSystem: ActorSystem
+
+  val shouldRetry: Try[HttpResponse] => Boolean =
+    _.fold(NonFatal(_), _.status >= 499)
+
+  val retryReason: HttpResponse => String =
+    response => s"received $response"
+
+  def retry[A](intervals: FiniteDuration*)(shouldRetry: Try[A] => Boolean, retryReason: A => String)(
+    block: => Future[A]
+  )(implicit ec: ExecutionContext): Future[A] = {
+
+    @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+    def loop(remainingIntervals: Seq[FiniteDuration])(mdcData: Map[String, String])(block: => Future[A]): Future[A] =
+      // scheduling will loose MDC data. Here we explicitly ensure it is available on block.
+      Mdc
+        .withMdc(block, mdcData)
+        .flatMap(result =>
+          if (remainingIntervals.nonEmpty && shouldRetry(Success(result))) {
+            val delay = remainingIntervals.headOption.getOrElse(FiniteDuration.apply(1, "s"))
+            Logger(getClass).warn(s"Will retry in $delay due to ${retryReason(result)}")
+            after(delay, actorSystem.scheduler)(loop(remainingIntervals.drop(1))(mdcData)(block))
+          } else
+            Future.successful(result)
+        )
+        .recoverWith { case e: Throwable =>
+          if (remainingIntervals.nonEmpty && shouldRetry(Failure(e))) {
+            val delay = remainingIntervals.headOption.getOrElse(FiniteDuration.apply(1, "s"))
+            Logger(getClass).warn(s"Will retry in $delay due to ${e.getClass.getName()}: ${e.getMessage()}")
+            after(delay, actorSystem.scheduler)(loop(remainingIntervals.drop(1))(mdcData)(block))
+          } else {
+            Logger(getClass).error(s"Limit of ${intervals.size} has been reached, still failing ...")
+            Future.failed(e)
+          }
+        }
+    loop(intervals)(Mdc.mdcData)(block)
+  }
+
+  def getConfIntervals(serviceKey: String, configuration: Configuration): Seq[FiniteDuration] =
+    configuration
+      .getOptional[Seq[String]](s"microservice.services.$serviceKey.retryIntervals")
+      .map(_.map(Duration.create).map(d => FiniteDuration(d.length, d.unit)))
+      .getOrElse(Seq.empty)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsController.scala
@@ -18,31 +18,47 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
 
 import cats.data.EitherT
 import com.google.inject.Inject
+import play.api.Configuration
+import play.api.Environment
 import play.api.data.Form
 import play.api.i18n.Messages
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-import play.api.{Configuration, Environment}
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import play.api.mvc.Result
 import play.twirl.api.HtmlFormat.Appendable
 import shapeless._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.{EnvironmentOps, ErrorHandler, ViewConfig}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.EnvironmentOps
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.YesOrNoQuestionForm
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.{AuthenticatedAction, RequestWithSessionData, SessionDataAction, WithAuthAndSessionDataAction}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckEoriDetailsController._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{JourneyBindable, SessionUpdates, routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DraftClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.{No, Yes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.No
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.Yes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.VerifiedEmail
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{DraftClaim, Error, SessionData, SignedInUserDetails}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.{CustomsDataStoreService, FeatureSwitchService}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.CustomsDataStoreService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.check_eori_details
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.Singleton
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 @Singleton
 class CheckEoriDetailsController @Inject() (

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ChooseClaimTypeController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ChooseClaimTypeController.scala
@@ -16,19 +16,28 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
 
-import com.google.inject.{Inject, Singleton}
+import com.google.inject.Inject
+import com.google.inject.Singleton
 import play.api.data.Form
-import play.api.data.Forms.{mapping, text}
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.{ErrorHandler, ViewConfig}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.{AuthenticatedAction, SessionDataAction, WithAuthAndSessionDataAction}
+import play.api.data.Forms.mapping
+import play.api.data.Forms.text
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.ChooseClaimTypeController._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{SessionDataExtractor, SessionUpdates}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import scala.concurrent.{ExecutionContext, Future}
+
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class ChooseClaimTypeController @Inject() (

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/ClaimService.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/ClaimService.scala
@@ -67,7 +67,7 @@ class DefaultClaimService @Inject() (
     submitClaimRequest: SubmitClaimRequest,
     lang: Lang
   )(implicit hc: HeaderCarrier): EitherT[Future, Error, SubmitClaimResponse] =
-    claimConnector.submitClaim(submitClaimRequest, lang).subflatMap { httpResponse =>
+    claimConnector.submitClaim(submitClaimRequest).subflatMap { httpResponse =>
       if (httpResponse.status === OK)
         httpResponse
           .parseJSON[SubmitClaimResponse]()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -111,6 +111,7 @@ microservice {
       protocol = http
       host = localhost
       port = 7501
+      context-path = "/cds-reimbursement-claim"
       retryIntervals = [1s, 2s]
     }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -111,6 +111,7 @@ microservice {
       protocol = http
       host = localhost
       port = 7501
+      retryIntervals = [1s, 2s]
     }
 
     auth {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/ClaimConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/ClaimConnectorSpec.scala
@@ -21,8 +21,6 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
-import play.api.i18n.Lang
-import play.api.test.Helpers.ACCEPT_LANGUAGE
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimRequest
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.SubmitClaimGen._
@@ -45,6 +43,7 @@ class ClaimConnectorSpec extends AnyWordSpec with Matchers with MockFactory with
         |        protocol = http
         |        host     = host3
         |        port     = 123
+        |        context-path = "/foo-claim"
         |      }
         |   }
         |}
@@ -57,15 +56,14 @@ class ClaimConnectorSpec extends AnyWordSpec with Matchers with MockFactory with
   "Claim Connector" when {
 
     implicit val hc: HeaderCarrier = HeaderCarrier()
-    val defaultLanguage            = Lang.defaultLang
     val submitClaimRequest         = sample[SubmitClaimRequest]
 
-    val url = "http://host3:123/cds-reimbursement-claim/claim"
+    val url = "http://host3:123/foo-claim/claim"
 
     "handling requests to submit claim" must {
       behave like connectorBehaviour(
-        mockPost(url, Seq(ACCEPT_LANGUAGE -> defaultLanguage.language), submitClaimRequest)(_),
-        () => connector.submitClaim(submitClaimRequest, defaultLanguage)
+        mockPost(url, Seq.empty, submitClaimRequest)(_),
+        () => connector.submitClaim(submitClaimRequest)
       )
     }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/HttpSupport.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/HttpSupport.scala
@@ -16,12 +16,17 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
 
+import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Writes
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpClient
+import uk.gov.hmrc.http.HttpReads
+import uk.gov.hmrc.http.HttpResponse
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 trait HttpSupport { this: MockFactory with Matchers ⇒
 
@@ -32,7 +37,7 @@ trait HttpSupport { this: MockFactory with Matchers ⇒
     url: String
   )(
     response: Option[A]
-  ) =
+  ): CallHandler[Future[A]] =
     (
       mockHttp
         .GET(_: String, _: Seq[(String, String)], _: Seq[(String, String)])(
@@ -69,7 +74,7 @@ trait HttpSupport { this: MockFactory with Matchers ⇒
     headers: Seq[(String, String)]
   )(
     response: Option[A]
-  ): Any =
+  ): CallHandler[Future[A]] =
     (mockHttp
       .GET(_: String, _: Seq[(String, String)], _: Seq[(String, String)])(
         _: HttpReads[A],
@@ -100,7 +105,7 @@ trait HttpSupport { this: MockFactory with Matchers ⇒
 
   def mockPost[A](url: String, headers: Seq[(String, String)], body: A)(
     result: Option[HttpResponse]
-  ): Any =
+  ): CallHandler[Future[HttpResponse]] =
     (mockHttp
       .POST(_: String, _: A, _: Seq[(String, String)])(
         _: Writes[A],
@@ -119,7 +124,7 @@ trait HttpSupport { this: MockFactory with Matchers ⇒
     url: String,
     body: A,
     headers: Seq[(String, String)] = Seq.empty
-  )(result: Option[HttpResponse]): Any =
+  )(result: Option[HttpResponse]): CallHandler[Future[HttpResponse]] =
     (mockHttp
       .PUT(_: String, _: A, _: Seq[(String, String)])(
         _: Writes[A],

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnectorSpec.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
+
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.Configuration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourneyGenerators
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import play.api.test.Helpers._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.FiniteDuration
+
+class RejectedGoodsSingleClaimConnectorSpec
+    extends AnyWordSpec
+    with Matchers
+    with MockFactory
+    with HttpSupport
+    with BeforeAndAfterAll {
+
+  val config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      """
+        | self {
+        |   url = host1.com
+        |  },
+        |  microservice {
+        |    services {
+        |      cds-reimbursement-claim {
+        |        protocol = http
+        |        host     = host3
+        |        port     = 123
+        |        retryIntervals = [10ms,50ms] 
+        |      }
+        |   }
+        |}
+        |""".stripMargin
+    )
+  )
+
+  val actorSystem = ActorSystem("test-RejectedGoodsSingleClaimConnector")
+
+  override protected def afterAll(): Unit =
+    actorSystem.terminate()
+
+  val connector =
+    new RejectedGoodsSingleClaimConnectorImpl(mockHttp, new ServicesConfig(config), config, actorSystem)
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  val expectedUrl = "http://host3:123/claims/rejected-goods-single"
+
+  val requestGen = for {
+    journey <- RejectedGoodsSingleJourneyGenerators.completeJourneyGen
+  } yield RejectedGoodsSingleClaimConnector.Request(
+    journey.toOutput.getOrElse(fail("Could not generate journey output!"))
+  )
+
+  val sampleRequest: RejectedGoodsSingleClaimConnector.Request = sample(requestGen)
+  val validResponseBody                                        = """{"caseNumber":"ABC123"}"""
+
+  "RejectedGoodsSingleClaimConnector" must {
+    "have retries defined" in {
+      connector.retryIntervals shouldBe Seq(FiniteDuration(10, "ms"), FiniteDuration(50, "ms"))
+    }
+
+    "return caseNumber when successful call" in {
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(200, validResponseBody))).once()
+      await(connector.submitClaim(sampleRequest)) shouldBe RejectedGoodsSingleClaimConnector.Response("ABC123")
+    }
+
+    "throw exception when empty response" in {
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(200, ""))).once()
+      a[RejectedGoodsSingleClaimConnector.Exception] shouldBe thrownBy {
+        await(connector.submitClaim(sampleRequest))
+      }
+    }
+
+    "throw exception when invalid response" in {
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(200, """{"case":"ABC123"}"""))).once()
+      a[RejectedGoodsSingleClaimConnector.Exception] shouldBe thrownBy {
+        await(connector.submitClaim(sampleRequest))
+      }
+    }
+
+    "throw exception when invalid success response status" in {
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(201, validResponseBody))).once()
+      a[RejectedGoodsSingleClaimConnector.Exception] shouldBe thrownBy {
+        await(connector.submitClaim(sampleRequest))
+      }
+    }
+
+    "throw exception when 4xx response status" in {
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(404, "case not found"))).once()
+      a[RejectedGoodsSingleClaimConnector.Exception] shouldBe thrownBy {
+        await(connector.submitClaim(sampleRequest))
+      }
+    }
+
+    "throw exception when 5xx response status in the third attempt" in {
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(500, ""))).repeat(3)
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(200, validResponseBody))).never()
+      a[RejectedGoodsSingleClaimConnector.Exception] shouldBe thrownBy {
+        await(connector.submitClaim(sampleRequest))
+      }
+    }
+
+    "accept valid response in a second attempt" in {
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(500, ""))).once()
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(200, validResponseBody))).once()
+      await(connector.submitClaim(sampleRequest)) shouldBe RejectedGoodsSingleClaimConnector.Response("ABC123")
+    }
+
+    "accept valid response in a third attempt" in {
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(500, ""))).repeat(2)
+      mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(200, validResponseBody))).once()
+      await(connector.submitClaim(sampleRequest)) shouldBe RejectedGoodsSingleClaimConnector.Response("ABC123")
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnectorSpec.scala
@@ -32,6 +32,8 @@ import play.api.test.Helpers._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+import scala.util.Failure
 
 class RejectedGoodsSingleClaimConnectorSpec
     extends AnyWordSpec
@@ -114,9 +116,11 @@ class RejectedGoodsSingleClaimConnectorSpec
 
     "throw exception when 4xx response status" in {
       mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(404, "case not found"))).once()
-      a[RejectedGoodsSingleClaimConnector.Exception] shouldBe thrownBy {
-        await(connector.submitClaim(sampleRequest))
-      }
+      Try(await(connector.submitClaim(sampleRequest))) shouldBe Failure(
+        new RejectedGoodsSingleClaimConnector.Exception(
+          "Request to POST http://host3:123/claims/rejected-goods-single failed because of HttpResponse status=404 case not found"
+        )
+      )
     }
 
     "throw exception when 5xx response status in the third attempt" in {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsSingleClaimConnectorSpec.scala
@@ -55,6 +55,7 @@ class RejectedGoodsSingleClaimConnectorSpec
         |        host     = host3
         |        port     = 123
         |        retryIntervals = [10ms,50ms] 
+        |        context-path = "/foo-claim"
         |      }
         |   }
         |}
@@ -72,7 +73,7 @@ class RejectedGoodsSingleClaimConnectorSpec
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
-  val expectedUrl = "http://host3:123/claims/rejected-goods-single"
+  val expectedUrl = "http://host3:123/foo-claim/claims/rejected-goods-single"
 
   val requestGen = for {
     journey <- RejectedGoodsSingleJourneyGenerators.completeJourneyGen
@@ -118,7 +119,7 @@ class RejectedGoodsSingleClaimConnectorSpec
       mockPost(expectedUrl, Seq.empty, sampleRequest)(Some(HttpResponse(404, "case not found"))).once()
       Try(await(connector.submitClaim(sampleRequest))) shouldBe Failure(
         new RejectedGoodsSingleClaimConnector.Exception(
-          "Request to POST http://host3:123/claims/rejected-goods-single failed because of HttpResponse status=404 case not found"
+          "Request to POST http://host3:123/foo-claim/claims/rejected-goods-single failed because of HttpResponse status=404 case not found"
         )
       )
     }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsControllerSpec.scala
@@ -19,7 +19,10 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
 import cats.data.EitherT
 import org.jsoup.nodes.Document
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
+import play.api.i18n.Lang
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
 import play.api.inject.bind
 import play.api.inject.guice.GuiceableModule
 import play.api.mvc.Result
@@ -27,16 +30,23 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckEoriDetailsController.checkEoriDetailsKey
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{AuthSupport, ControllerSpec, JourneyBindable, SessionSupport, routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.{ContactName, Email, VerifiedEmail}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.ContactName
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.Email
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.VerifiedEmail
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.EmailGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.{Eori, GGCredId}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.{CustomsDataStoreService, FeatureSwitchService}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.CustomsDataStoreService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/ClaimServiceSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/ClaimServiceSpec.scala
@@ -18,27 +18,37 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.services
 
 import cats.data.EitherT
 import cats.instances.future._
-import org.scalamock.handlers.{CallHandler2, CallHandler3}
+import org.scalamock.handlers.CallHandler2
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.i18n.Lang
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
 import play.api.mvc.Request
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.{CDSReimbursementClaimConnector, ClaimConnector}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.CDSReimbursementClaimConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ClaimConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.{BarsBusinessAssessRequest, BarsPersonalAssessRequest}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.{BusinessCompleteResponse, PersonalCompleteResponse, ReputationErrorResponse}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.{SubmitClaimRequest, SubmitClaimResponse}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.{DeclarantDetails, DisplayDeclaration, DisplayResponseDetail, EstablishmentAddress}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsBusinessAssessRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsPersonalAssessRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.BusinessCompleteResponse
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.PersonalCompleteResponse
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationErrorResponse
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResponse
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DeclarantDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayResponseDetail
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.EstablishmentAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.BankAccountReputationGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.SubmitClaimGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpResponse
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -112,10 +122,10 @@ class ClaimServiceSpec extends AnyWordSpec with Matchers with MockFactory {
 
   def mockSubmitClaim(submitClaimRequest: SubmitClaimRequest)(
     response: Either[Error, HttpResponse]
-  ): CallHandler3[SubmitClaimRequest, Lang, HeaderCarrier, EitherT[Future, Error, HttpResponse]] =
+  ): CallHandler2[SubmitClaimRequest, HeaderCarrier, EitherT[Future, Error, HttpResponse]] =
     (mockClaimConnector
-      .submitClaim(_: SubmitClaimRequest, _: Lang)(_: HeaderCarrier))
-      .expects(submitClaimRequest, *, *)
+      .submitClaim(_: SubmitClaimRequest)(_: HeaderCarrier))
+      .expects(submitClaimRequest, *)
       .returning(EitherT.fromEither[Future](response))
 
   def mockGetDisplayDeclaration(mrn: MRN)(


### PR DESCRIPTION
This PR adds new connector to the backend endpoint `/claims/rejected-goods-single`.