### PR TITLE
Update-rejected-goods-single-data-model

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsController.scala
@@ -18,31 +18,47 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
 
 import cats.data.EitherT
 import com.google.inject.Inject
+import play.api.Configuration
+import play.api.Environment
 import play.api.data.Form
 import play.api.i18n.Messages
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-import play.api.{Configuration, Environment}
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import play.api.mvc.Result
 import play.twirl.api.HtmlFormat.Appendable
 import shapeless._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.{EnvironmentOps, ErrorHandler, ViewConfig}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.EnvironmentOps
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.YesOrNoQuestionForm
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.{AuthenticatedAction, RequestWithSessionData, SessionDataAction, WithAuthAndSessionDataAction}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckEoriDetailsController._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{JourneyBindable, SessionUpdates, routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DraftClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.{No, Yes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.No
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.Yes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.VerifiedEmail
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{DraftClaim, Error, SessionData, SignedInUserDetails}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.{CustomsDataStoreService, FeatureSwitchService}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.CustomsDataStoreService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.check_eori_details
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.Singleton
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 @Singleton
 class CheckEoriDetailsController @Inject() (

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ChooseClaimTypeController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ChooseClaimTypeController.scala
@@ -16,19 +16,28 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
 
-import com.google.inject.{Inject, Singleton}
+import com.google.inject.Inject
+import com.google.inject.Singleton
 import play.api.data.Form
-import play.api.data.Forms.{mapping, text}
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.{ErrorHandler, ViewConfig}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.{AuthenticatedAction, SessionDataAction, WithAuthAndSessionDataAction}
+import play.api.data.Forms.mapping
+import play.api.data.Forms.text
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.ChooseClaimTypeController._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{SessionDataExtractor, SessionUpdates}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import scala.concurrent.{ExecutionContext, Future}
+
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class ChooseClaimTypeController @Inject() (

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsControllerSpec.scala
@@ -19,7 +19,10 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
 import cats.data.EitherT
 import org.jsoup.nodes.Document
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
+import play.api.i18n.Lang
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
 import play.api.inject.bind
 import play.api.inject.guice.GuiceableModule
 import play.api.mvc.Result
@@ -27,16 +30,23 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckEoriDetailsController.checkEoriDetailsKey
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{AuthSupport, ControllerSpec, JourneyBindable, SessionSupport, routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.{ContactName, Email, VerifiedEmail}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.ContactName
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.Email
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.VerifiedEmail
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.EmailGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.{Eori, GGCredId}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.{CustomsDataStoreService, FeatureSwitchService}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.CustomsDataStoreService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneySpec.scala
@@ -68,22 +68,22 @@ class RejectedGoodsSingleJourneySpec
         RejectedGoodsSingleJourney.validator.apply(journey) shouldBe Validated.Valid(())
         journey.isComplete                                  shouldBe true
         val output = journey.toOutput.getOrElse(fail("Journey output not defined."))
-        output.movementReferenceNumber             shouldBe journey.answers.movementReferenceNumber.get
-        output.declarantType                       shouldBe journey.getDeclarantType
-        output.basisOfClaim                        shouldBe journey.answers.basisOfClaim.get
-        output.methodOfDisposal                    shouldBe journey.answers.methodOfDisposal.get
-        output.detailsOfRejectedGoods              shouldBe journey.answers.detailsOfRejectedGoods.get
-        output.inspectionDate                      shouldBe journey.answers.inspectionDate.get
-        output.inspectionAddress                   shouldBe journey.answers.inspectionAddress.get
-        output.reimbursementMethod                 shouldBe journey.answers.reimbursementMethod
+        output.movementReferenceNumber  shouldBe journey.answers.movementReferenceNumber.get
+        output.declarantType            shouldBe journey.getDeclarantType
+        output.basisOfClaim             shouldBe journey.answers.basisOfClaim.get
+        output.methodOfDisposal         shouldBe journey.answers.methodOfDisposal.get
+        output.detailsOfRejectedGoods   shouldBe journey.answers.detailsOfRejectedGoods.get
+        output.inspectionDate           shouldBe journey.answers.inspectionDate.get
+        output.inspectionAddress        shouldBe journey.answers.inspectionAddress.get
+        output.reimbursementMethod      shouldBe journey.answers.reimbursementMethod
           .getOrElse(ReimbursementMethodAnswer.BankAccountTransfer)
-        output.reimbursementClaims                 shouldBe journey.answers.reimbursementClaims.get.mapValues(_.get)
-        output.supportingEvidences                 shouldBe journey.answers.supportingEvidences.get.mapValues(_.get)
-        output.consigneeEoriNumber                 shouldBe journey.getConsigneeEoriFromACC14.getOrElse(journey.answers.userEoriNumber)
-        output.declarantEoriNumber                 shouldBe journey.getDeclarantEoriFromACC14.getOrElse(journey.answers.userEoriNumber)
-        output.contactDetails                      shouldBe exampleContactDetails
-        output.contactAddress                      shouldBe exampleContactAddress
-        output.bankAccountDetailsAndType.isDefined shouldBe (journey.answers.bankAccountDetails.isDefined && journey.answers.bankAccountType.isDefined)
+        output.totalReimbursementAmount shouldBe journey.getTotalReimbursementAmount
+        output.supportingEvidences      shouldBe journey.answers.supportingEvidences.get.mapValues(_.get)
+        output.consigneeEoriNumber      shouldBe journey.getConsigneeEoriFromACC14.getOrElse(journey.answers.userEoriNumber)
+        output.declarantEoriNumber      shouldBe journey.getDeclarantEoriFromACC14.getOrElse(journey.answers.userEoriNumber)
+        output.contactDetails           shouldBe exampleContactDetails
+        output.contactAddress           shouldBe exampleContactAddress
+        output.bankAccountDetails       shouldBe journey.answers.bankAccountDetails
       }
     }
 


### PR DESCRIPTION
This PR updates rejected goods single journey output model:
- removes bankAccountType
- replaces reimbursementClaims map with single total amount