### PR TITLE
make base journey controller to check feature switch and redirect to CYA if journey complete

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyBaseController.scala
@@ -16,85 +16,177 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers
 
-import play.api.mvc._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Call
+import play.api.mvc.MessagesControllerComponents
+import play.api.mvc.Request
+import play.api.mvc.Result
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType
 
-abstract class JourneyBaseController[Journey](
-  cc: MessagesControllerComponents
-)(implicit ec: ExecutionContext)
-    extends FrontendController(cc)
-    with WithAuthAndSessionDataAction
+/** Base journey controller providing common action behaviours:
+  *  - feature switch check
+  *  - user authorization
+  *  - user data retrieval
+  *  - sesion data retrieval and journey update
+  *  - journey completeness check and redirect to the CYA page
+  */
+abstract class JourneyBaseController[Journey](implicit ec: ExecutionContext)
+    extends FrontendBaseController
     with Logging
     with SessionUpdates {
 
-  val sessionStore: SessionCache
+  /** [Inject] Component expected to be injected by the implementing controller. */
+  val jcc: JourneyControllerComponents
+
+  /** [Config] Defines where to redirect when missing journey or missing session data after user has been authorized. */
+  val startOfTheJourney: Call
+
+  /** [Config] Defines where to redirect when journey is already complete, a.k.a CYA page. */
+  val checkYourAnswers: Call
+
+  /** [Config] Required feature flag or none. */
+  val requiredFeature: Option[Feature]
 
   def getJourney(sessionData: SessionData): Option[Journey]
-  def updateJourney(journey: Journey)(sessionData: SessionData): SessionData
+  def updateJourney(sessionData: SessionData, journey: Journey): SessionData
+  def isComplete(journey: Journey): Boolean
 
+  final override def controllerComponents: MessagesControllerComponents =
+    jcc.controllerComponents
+
+  private def resultOrCheckYourAnswers(result: Result, journey: Journey): Result =
+    if (isComplete(journey)) Redirect(checkYourAnswers) else result
+
+  /** Simple GET action to show page based on the journey state */
   final def simpleActionReadJourney(body: Journey => Result): Action[AnyContent] =
-    authenticatedActionWithSessionData.async { implicit request =>
-      Future.successful(
+    jcc
+      .authenticatedActionWithSessionData(requiredFeature)
+      .async { implicit request =>
+        Future.successful(
+          request.sessionData
+            .flatMap(getJourney)
+            .map(body)
+            .getOrElse(Redirect(startOfTheJourney))
+        )
+      }
+
+  /** Simple GET action to show page based on the user data and journey state. */
+  final def simpleActionReadJourneyAndUser(body: Journey => RetrievedUserType => Result): Action[AnyContent] =
+    jcc
+      .authenticatedActionWithRetrievedDataAndSessionData(requiredFeature)
+      .async { implicit request =>
+        Future.successful(
+          getJourney(request.sessionData)
+            .map(journey => body(journey)(request.authenticatedRequest.journeyUserType))
+            .getOrElse(Redirect(startOfTheJourney))
+        )
+      }
+
+  /** Async GET action to show page based on the request and journey state. */
+  final def actionReadJourney(body: Request[_] => Journey => Future[Result]): Action[AnyContent] =
+    jcc
+      .authenticatedActionWithSessionData(requiredFeature)
+      .async { implicit request =>
         request.sessionData
           .flatMap(getJourney)
-          .map(body)
-          .getOrElse(Redirect(uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.routes.StartController.start()))
-      )
-    }
-
-  final def actionReadJourney(body: Request[_] => Journey => Future[Result]): Action[AnyContent] =
-    authenticatedActionWithSessionData.async { implicit request =>
-      request.sessionData
-        .flatMap(getJourney)
-        .map(body(request))
-        .getOrElse(
-          Future.successful(
-            Redirect(uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.routes.StartController.start())
+          .map(body(request))
+          .getOrElse(
+            Future.successful(
+              Redirect(startOfTheJourney)
+            )
           )
-        )
-    }
+      }
 
+  /** Simple POST action to submit form and update journey. */
   final def simpleActionReadWriteJourney(
     body: Request[_] => Journey => (Journey, Result)
   ): Action[AnyContent] =
-    authenticatedActionWithSessionData.async { implicit request =>
-      request.sessionData
-        .flatMap(getJourney)
-        .map(body(request))
-        .map { case (modifiedJourney, result) =>
-          updateSession(sessionStore, request)(updateJourney(modifiedJourney))
-            .flatMap(_.fold(error => Future.failed(error.toException), _ => Future.successful(result)))
-        }
-        .getOrElse(
-          Future.successful(
-            Redirect(uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.routes.StartController.start())
+    jcc
+      .authenticatedActionWithSessionData(requiredFeature)
+      .async { implicit request =>
+        request.sessionData
+          .flatMap(sessionData =>
+            getJourney(sessionData)
+              .map(body(request))
+              .map { case (modifiedJourney, result) =>
+                jcc.sessionCache
+                  .store(updateJourney(sessionData, modifiedJourney))
+                  .flatMap(
+                    _.fold(
+                      error => Future.failed(error.toException),
+                      _ => Future.successful(resultOrCheckYourAnswers(result, modifiedJourney))
+                    )
+                  )
+              }
           )
-        )
-    }
+          .getOrElse(
+            Future.successful(
+              Redirect(startOfTheJourney)
+            )
+          )
+      }
 
+  /** Simple POST to submit form and update journey, comes with current user data. */
+  final def simpleActionReadWriteJourneyAndUser(
+    body: Request[_] => Journey => RetrievedUserType => (Journey, Result)
+  ): Action[AnyContent] =
+    jcc
+      .authenticatedActionWithRetrievedDataAndSessionData(requiredFeature)
+      .async { implicit request =>
+        getJourney(request.sessionData)
+          .map(journey => body(request)(journey)(request.authenticatedRequest.journeyUserType))
+          .map { case (modifiedJourney, result) =>
+            jcc.sessionCache
+              .store(updateJourney(request.sessionData, modifiedJourney))
+              .flatMap(
+                _.fold(
+                  error => Future.failed(error.toException),
+                  _ => Future.successful(resultOrCheckYourAnswers(result, modifiedJourney))
+                )
+              )
+          }
+          .getOrElse(
+            Future.successful(
+              Redirect(startOfTheJourney)
+            )
+          )
+      }
+
+  /** Async POST action to submit form and update journey. */
   final def actionReadWriteJourney(
     body: Request[_] => Journey => Future[(Journey, Result)]
   ): Action[AnyContent] =
-    authenticatedActionWithSessionData.async { implicit request =>
-      request.sessionData
-        .flatMap(getJourney)
-        .map(body(request))
-        .map(_.flatMap { case (modifiedJourney, result) =>
-          updateSession(sessionStore, request)(updateJourney(modifiedJourney))
-            .flatMap(_.fold(error => Future.failed(error.toException), _ => Future.successful(result)))
-        })
-        .getOrElse(
-          Future.successful(
-            Redirect(uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.routes.StartController.start())
+    jcc
+      .authenticatedActionWithSessionData(requiredFeature)
+      .async { implicit request =>
+        request.sessionData
+          .flatMap(sessionData =>
+            getJourney(sessionData)
+              .map(body(request))
+              .map(_.flatMap { case (modifiedJourney, result) =>
+                jcc.sessionCache
+                  .store(updateJourney(sessionData, modifiedJourney))
+                  .flatMap(
+                    _.fold(
+                      error => Future.failed(error.toException),
+                      _ => Future.successful(resultOrCheckYourAnswers(result, modifiedJourney))
+                    )
+                  )
+              })
           )
-        )
-    }
+          .getOrElse(
+            Future.successful(
+              Redirect(startOfTheJourney)
+            )
+          )
+
+      }
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyControllerComponents.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyControllerComponents.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers
+
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.mvc.ActionBuilder
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedActionWithRetrievedData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionDataAndRetrievedData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataActionWithRetrievedData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.FeatureSwitchProtectedAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+import scala.concurrent.ExecutionContext
+import play.api.mvc.MessagesRequest
+
+@Singleton
+class JourneyControllerComponents @Inject() (
+  authenticatedAction: AuthenticatedAction,
+  val sessionDataAction: SessionDataAction,
+  authenticatedActionWithRetrievedData: AuthenticatedActionWithRetrievedData,
+  sessionDataActionWithRetrievedData: SessionDataActionWithRetrievedData,
+  val controllerComponents: MessagesControllerComponents,
+  val sessionCache: SessionCache,
+  featureSwitchService: FeatureSwitchService,
+  val errorHandler: ErrorHandler
+)(implicit ec: ExecutionContext) {
+
+  final val actionBuilder: ActionBuilder[MessagesRequest, AnyContent] =
+    controllerComponents.messagesActionBuilder
+      .compose(controllerComponents.actionBuilder)
+
+  final def authenticatedActionWithSessionData(
+    featureOpt: Option[Feature]
+  ): ActionBuilder[RequestWithSessionData, AnyContent] =
+    featureOpt match {
+      case Some(feature) =>
+        actionBuilder
+          .andThen(new FeatureSwitchProtectedAction(feature, featureSwitchService, errorHandler))
+          .andThen(authenticatedAction)
+          .andThen(sessionDataAction)
+
+      case None =>
+        actionBuilder
+          .andThen(authenticatedAction)
+          .andThen(sessionDataAction)
+    }
+
+  final def authenticatedActionWithRetrievedDataAndSessionData(
+    featureOpt: Option[Feature]
+  ): ActionBuilder[RequestWithSessionDataAndRetrievedData, AnyContent] =
+    featureOpt match {
+      case Some(feature) =>
+        actionBuilder
+          .andThen(new FeatureSwitchProtectedAction(feature, featureSwitchService, errorHandler))
+          .andThen(authenticatedActionWithRetrievedData)
+          .andThen(sessionDataActionWithRetrievedData)
+
+      case None =>
+        actionBuilder
+          .andThen(authenticatedActionWithRetrievedData)
+          .andThen(sessionDataActionWithRetrievedData)
+
+    }
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/FeatureSwitchProtectedAction.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/FeatureSwitchProtectedAction.scala
@@ -31,9 +31,9 @@ class FeatureSwitchProtectedAction(feature: Feature, featureSwitch: FeatureSwitc
     with Logging { self =>
 
   override protected def refine[A](request: MessagesRequest[A]): Future[Either[Result, MessagesRequest[A]]] =
-    Future.successful(Option(featureSwitch.isEnabled(feature)) match {
-      case None    => Left(Results.NotFound(errorHandler.notFoundTemplate(request)))
-      case Some(_) => Right(request)
-    })
+    Future.successful(
+      if (featureSwitch.isEnabled(feature)) Right(request)
+      else Left(Results.NotFound(errorHandler.notFoundTemplate(request)))
+    )
 
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/FeatureSwitchProtectedAction.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/FeatureSwitchProtectedAction.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions
+
+import play.api.mvc._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+class FeatureSwitchProtectedAction(feature: Feature, featureSwitch: FeatureSwitchService, errorHandler: ErrorHandler)(
+  implicit val executionContext: ExecutionContext
+) extends ActionRefiner[MessagesRequest, MessagesRequest]
+    with Logging { self =>
+
+  override protected def refine[A](request: MessagesRequest[A]): Future[Either[Result, MessagesRequest[A]]] =
+    Future.successful(Option(featureSwitch.isEnabled(feature)) match {
+      case None    => Left(Results.NotFound(errorHandler.notFoundTemplate(request)))
+      case Some(_) => Right(request)
+    })
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataAction.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataAction.scala
@@ -57,6 +57,7 @@ final case class RequestWithSessionData[A](
 
   def routeToCheckAnswers(journeyBindable: JourneyBindable): NextPageBuilder =
     NextPageBuilder(ReimbursementRoutes(journeyBindable))
+
 }
 
 @Singleton

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckContactDetailsMrnController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckContactDetailsMrnController.scala
@@ -43,6 +43,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 
 @Singleton
 class CheckContactDetailsMrnController @Inject() (
@@ -220,7 +221,7 @@ class CheckContactDetailsMrnController @Inject() (
   )(implicit journey: JourneyBindable): Result =
     Redirect(
       router.CheckAnswers.when(fillingOutClaim.draftClaim.isComplete)(alternatively =
-        if (featureSwitch.NorthernIreland.isEnabled())
+        if (featureSwitch.isEnabled(Feature.NorthernIreland))
           routes.ClaimNorthernIrelandController.selectWhetherNorthernIrelandClaim(journey)
         else routes.SelectBasisForClaimController.selectBasisForClaim(journey)
       )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsController.scala
@@ -55,6 +55,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.check_eori_details
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
@@ -132,7 +133,7 @@ class CheckEoriDetailsController @Inject() (
                     _                  <- EitherT(updateSession(sessionStore, request)(saveSession(verifiedEmail)))
                                             .leftMap(logError.andThen(returnErrorPage))
                     result             <- EitherT.rightT[Future, Result](
-                                            if (featureSwitch.RejectedGoods.isEnabled())
+                                            if (featureSwitch.isEnabled(Feature.RejectedGoods))
                                               Redirect(routes.ChooseClaimTypeController.show())
                                             else
                                               Redirect(routes.SelectTypeOfClaimController.show())

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ChooseClaimTypeController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ChooseClaimTypeController.scala
@@ -24,7 +24,6 @@ import play.api.data.Forms.text
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.MessagesControllerComponents
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
@@ -37,14 +36,12 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
-import scala.concurrent.ExecutionContext
-
 @Singleton
 class ChooseClaimTypeController @Inject() (
   val authenticatedAction: AuthenticatedAction,
   val sessionDataAction: SessionDataAction,
   chooseClaimTypePage: pages.choose_claim_type
-)(implicit ec: ExecutionContext, viewConfig: ViewConfig, cc: MessagesControllerComponents, errorHandler: ErrorHandler)
+)(implicit viewConfig: ViewConfig, cc: MessagesControllerComponents)
     extends FrontendController(cc)
     with WithAuthAndSessionDataAction
     with SessionDataExtractor

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ClaimNorthernIrelandController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ClaimNorthernIrelandController.scala
@@ -36,6 +36,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.util.toFuture
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.claim_northern_ireland
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
@@ -61,18 +62,18 @@ class ClaimNorthernIrelandController @Inject() (
   implicit val dataExtractor: DraftClaim => Option[YesNo] = _.whetherNorthernIrelandAnswer
 
   def selectWhetherNorthernIrelandClaim(implicit journey: JourneyBindable): Action[AnyContent] =
-    (featureSwitch.NorthernIreland.hideIfNotEnabled andThen authenticatedActionWithSessionData).async {
-      implicit request =>
+    (featureSwitch.hideIfNotEnabled(Feature.NorthernIreland) andThen authenticatedActionWithSessionData)
+      .async { implicit request =>
         withAnswers[YesNo] { (_, answer) =>
           val emptyForm  = whetherNorthernIrelandClaim
           val filledForm = answer.fold(emptyForm)(emptyForm.fill)
           Ok(northernIrelandAnswerPage(filledForm))
         }
-    }
+      }
 
   def selectWhetherNorthernIrelandClaimSubmit(implicit journey: JourneyBindable): Action[AnyContent] =
-    (featureSwitch.NorthernIreland.hideIfNotEnabled andThen authenticatedActionWithSessionData).async {
-      implicit request =>
+    (featureSwitch.hideIfNotEnabled(Feature.NorthernIreland) andThen authenticatedActionWithSessionData)
+      .async { implicit request =>
         withAnswersAndRoutes[YesNo] { (fillingOutClaim, previousAnswer, routes) =>
           import routes._
 
@@ -107,7 +108,7 @@ class ClaimNorthernIrelandController @Inject() (
               }
             )
         }
-    }
+      }
 }
 
 object ClaimNorthernIrelandController {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/DummyExampleController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/DummyExampleController.scala
@@ -21,10 +21,7 @@ import com.google.inject.Singleton
 import play.api.data._
 import play.api.mvc._
 import play.twirl.api.Html
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -34,12 +31,9 @@ import scala.concurrent.Future
 /** Dummy controller to showcase different patterns of implementing actions. */
 @Singleton
 class DummyExampleController @Inject() (
-  val authenticatedAction: AuthenticatedAction,
-  val sessionDataAction: SessionDataAction,
-  val sessionStore: SessionCache,
-  cc: MessagesControllerComponents
-)(implicit viewConfig: ViewConfig, ec: ExecutionContext)
-    extends RejectedGoodsSingleJourneyBaseController(cc) {
+  val jcc: JourneyControllerComponents
+)(implicit ec: ExecutionContext)
+    extends RejectedGoodsSingleJourneyBaseController {
 
   // dummy API example
   def someApiCall(implicit hc: HeaderCarrier): Future[String] = ???

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/RejectedGoodsSingleJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/RejectedGoodsSingleJourneyBaseController.scala
@@ -16,23 +16,34 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsingle
 
-import play.api.mvc._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBaseController
 
 import scala.concurrent.ExecutionContext
+import play.api.mvc.Call
 
-abstract class RejectedGoodsSingleJourneyBaseController(
-  cc: MessagesControllerComponents
-)(implicit ec: ExecutionContext)
-    extends JourneyBaseController[RejectedGoodsSingleJourney](cc) {
+abstract class RejectedGoodsSingleJourneyBaseController(implicit ec: ExecutionContext)
+    extends JourneyBaseController[RejectedGoodsSingleJourney] {
 
-  override def getJourney(sessionData: SessionData): Option[RejectedGoodsSingleJourney] =
+  final override val requiredFeature: Option[Feature] =
+    Some(Feature.RejectedGoods)
+
+  final override val startOfTheJourney: Call =
+    uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.routes.StartController.start()
+
+  final override val checkYourAnswers: Call =
+    Call("GET", "/claim-for-reimbursement-of-import-duties/rejected-goods/single/check-your-answers") //FIXME
+
+  final override def getJourney(sessionData: SessionData): Option[RejectedGoodsSingleJourney] =
     sessionData.rejectedGoodsSingleJourney
 
-  override def updateJourney(journey: RejectedGoodsSingleJourney)(sessionData: SessionData): SessionData =
+  final override def updateJourney(sessionData: SessionData, journey: RejectedGoodsSingleJourney): SessionData =
     sessionData.copy(rejectedGoodsSingleJourney = Some(journey))
+
+  final override def isComplete(journey: RejectedGoodsSingleJourney): Boolean =
+    journey.isComplete
 
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/Feature.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/Feature.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.models
+
+import cats.syntax.eq._
+
+sealed trait Feature {
+  def name: String
+}
+
+object Feature {
+
+  case object BulkClaim extends Feature { val name = "bulk-claim" }
+  case object BulkMultiple extends Feature { val name = "bulk-multiple" }
+  case object NorthernIreland extends Feature { val name = "northern-ireland" }
+  case object RejectedGoods extends Feature { val name = "rejected-goods" }
+
+  def of(name: String): Option[Feature] =
+    Seq[Feature](
+      BulkMultiple,
+      BulkClaim,
+      NorthernIreland,
+      RejectedGoods
+    ).find(_.name === name)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/FeatureSwitchService.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/FeatureSwitchService.scala
@@ -22,61 +22,43 @@ import play.api.Configuration
 import play.api.mvc.Results.NotFound
 import play.api.mvc._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 
 import scala.concurrent.{ExecutionContext, Future}
+import java.util.concurrent.ConcurrentHashMap
 
 @Singleton
-class FeatureSwitchService @Inject() (configuration: Configuration) {
+class FeatureSwitchService @Inject() (
+  val configuration: Configuration,
+  errorHandler: ErrorHandler,
+  cc: MessagesControllerComponents
+) {
 
-  def of(name: String): Option[FeatureName] = Seq(
-    BulkMultiple,
-    BulkClaim,
-    NorthernIreland,
-    RejectedGoods
-  ).find(_.name === name)
+  private val features: ConcurrentHashMap[String, Boolean] =
+    new ConcurrentHashMap[String, Boolean]()
 
-  sealed trait FeatureName extends Product with Serializable {
+  def enable(feature: Feature): Boolean =
+    features.put(feature.name, true)
 
-    val name: String
-    val confPropertyName: String   = s"features.$name"
-    val systemPropertyName: String = s"features.$name"
+  def disable(feature: Feature): Boolean =
+    features.put(feature.name, false)
 
-    def isEnabled(): Boolean =
-      sys.props.get(systemPropertyName).map(_.toBoolean).getOrElse {
-        configuration.getOptional[Boolean](confPropertyName).getOrElse(false)
+  def isEnabled(feature: Feature): Boolean =
+    Option(features.get(feature.name))
+      .orElse(sys.props.get(s"features.${feature.name}").map(_.toBoolean))
+      .orElse(configuration.getOptional[Boolean](s"features.${feature.name}"))
+      .getOrElse(false)
+
+  def hideIfNotEnabled(feature: Feature): ActionBuilder[Request, AnyContent] with ActionFilter[Request] =
+    new ActionBuilder[Request, AnyContent] with ActionFilter[Request] {
+
+      def filter[A](input: Request[A]): Future[Option[Result]] = Future.successful {
+        Option(isEnabled(feature)).filter(_ === false) map (_ => NotFound(errorHandler.notFoundTemplate(input)))
       }
 
-    def enable(): Unit =
-      setProp(true)
+      override def parser: BodyParser[AnyContent] = cc.parsers.defaultBodyParser
 
-    def disable(): Unit =
-      setProp(false)
-
-    def setFlag(cond: Boolean): Unit =
-      if (cond) enable() else disable()
-
-    def setProp(value: Boolean): Unit = {
-      val _ = sys.props += (systemPropertyName -> value.toString)
+      override protected def executionContext: ExecutionContext = cc.executionContext
     }
 
-    def hideIfNotEnabled(implicit
-      errorHandler: ErrorHandler,
-      cc: MessagesControllerComponents
-    ): ActionBuilder[Request, AnyContent] with ActionFilter[Request] =
-      new ActionBuilder[Request, AnyContent] with ActionFilter[Request] {
-
-        def filter[A](input: Request[A]): Future[Option[Result]] = Future.successful {
-          Option(isEnabled()).filter(_ === false) map (_ => NotFound(errorHandler.notFoundTemplate(input)))
-        }
-
-        override def parser: BodyParser[AnyContent] = cc.parsers.defaultBodyParser
-
-        override protected def executionContext: ExecutionContext = cc.executionContext
-      }
-  }
-
-  case object BulkClaim extends { val name = "bulk-claim" } with FeatureName
-  case object BulkMultiple extends { val name = "bulk-multiple" } with FeatureName
-  case object NorthernIreland extends { val name = "northern-ireland" } with FeatureName
-  case object RejectedGoods extends { val name = "rejected-goods" } with FeatureName
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/testonly/controllers/FeatureSwitchController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/testonly/controllers/FeatureSwitchController.scala
@@ -20,22 +20,23 @@ import javax.inject.{Inject, Singleton}
 import play.api.mvc._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 
 @Singleton
 class FeatureSwitchController @Inject() (featureSwitch: FeatureSwitchService, mcc: MessagesControllerComponents)
     extends FrontendController(mcc) {
 
   def enable(featureName: String): Action[AnyContent] = Action {
-    featureSwitch
+    Feature
       .of(featureName)
-      .map(_.enable())
+      .map(featureSwitch.enable(_))
       .fold(NotFound(s"No $featureName feature exists"))(_ => Ok(s"Enabled feature $featureName"))
   }
 
   def disable(featureName: String): Action[AnyContent] = Action {
-    featureSwitch
+    Feature
       .of(featureName)
-      .map(_.disable())
+      .map(featureSwitch.disable(_))
       .fold(NotFound(s"No $featureName feature exists"))(_ => Ok(s"Disabled feature $featureName"))
   }
 }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckEoriDetailsControllerSpec.scala
@@ -185,7 +185,7 @@ class CheckEoriDetailsControllerSpec
       }
 
       "Redirect to SelectNumberOfClaims if user says details are correct and FeatureSwitch.RejectedGoods is disabled" in {
-        featureSwitch.RejectedGoods.disable()
+        featureSwitch.disable(Feature.RejectedGoods)
         val (session, fillingOutClaim, _) = sessionWithClaimState()
 
         inSequence {
@@ -200,7 +200,7 @@ class CheckEoriDetailsControllerSpec
       }
 
       "Redirect to ChooseClaimTypeController if user says details are correct and FeatureSwitch.RejectedGoods is enabled" in {
-        featureSwitch.RejectedGoods.enable()
+        featureSwitch.enable(Feature.RejectedGoods)
         val (session, fillingOutClaim, _) = sessionWithClaimState()
 
         inSequence {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckMovementReferenceNumbersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckMovementReferenceNumbersControllerSpec.scala
@@ -123,7 +123,7 @@ class CheckMovementReferenceNumbersControllerSpec
     def performActionWithData(data: Seq[(String, String)]): Future[Result] =
       controller.submitMrns()(FakeRequest().withFormUrlEncodedBody(data: _*))
 
-    featureSwitch.BulkClaim.enable()
+    featureSwitch.enable(Feature.BulkClaim)
 
     "redirect to the start of the journey" when {
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ChooseClaimTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ChooseClaimTypeControllerSpec.scala
@@ -16,26 +16,37 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
 
-import org.jsoup.nodes.{Document, Element}
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 import org.jsoup.select.Elements
-import play.api.{Logger, MarkerContext}
-import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
+import play.api.Logger
+import play.api.MarkerContext
+import play.api.http.Status.BAD_REQUEST
+import play.api.i18n.Lang
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
 import play.api.inject.bind
 import play.api.inject.guice.GuiceableModule
-import play.api.http.Status.BAD_REQUEST
-import play.api.mvc.{MessagesControllerComponents, Result}
+import play.api.mvc.MessagesControllerComponents
+import play.api.mvc.Result
 import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.{AuthenticatedAction, SessionDataAction}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.ChooseClaimTypeController._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.choose_claim_type
+
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+
 import collection.JavaConverters._
 
 class ChooseClaimTypeControllerSpec extends ControllerSpec with AuthSupport with SessionSupport {
@@ -86,7 +97,7 @@ class ChooseClaimTypeControllerSpec extends ControllerSpec with AuthSupport with
 
   "ChooseClaimTypeController" must {
 
-    featureSwitch.RejectedGoods.enable()
+    featureSwitch.enable(Feature.RejectedGoods)
 
     def performAction(): Future[Result] = controller.show()(FakeRequest())
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ClaimNorthernIrelandControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ClaimNorthernIrelandControllerSpec.scala
@@ -66,7 +66,7 @@ class ClaimNorthernIrelandControllerSpec
   private lazy val featureSwitch = instanceOf[FeatureSwitchService]
 
   override def beforeEach(): Unit =
-    featureSwitch.NorthernIreland.enable()
+    featureSwitch.enable(Feature.NorthernIreland)
 
   lazy val errorHandler: ErrorHandler                 = instanceOf[ErrorHandler]
   lazy val controller: ClaimNorthernIrelandController = instanceOf[ClaimNorthernIrelandController]
@@ -120,7 +120,7 @@ class ClaimNorthernIrelandControllerSpec
 
     "redirect to the error page" when {
       "the feature switch NorthernIreland is disabled" in forAll(journeys) { journey =>
-        featureSwitch.NorthernIreland.disable()
+        featureSwitch.disable(Feature.NorthernIreland)
         val result = controller.selectWhetherNorthernIrelandClaim(journey)(FakeRequest())
         status(result) shouldBe NOT_FOUND
       }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAssociatedMrnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAssociatedMrnControllerSpec.scala
@@ -134,7 +134,7 @@ class EnterAssociatedMrnControllerSpec
 
   "EnterAssociatedMrnController" must {
 
-    featureSwitch.BulkClaim.enable()
+    featureSwitch.enable(Feature.BulkClaim)
 
     def performAction(mrnIndex: AssociatedMrnIndex): Future[Result] =
       controller.enterMrn(mrnIndex)(FakeRequest())

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMovementReferenceNumberControllerSpec.scala
@@ -104,7 +104,7 @@ class EnterMovementReferenceNumberControllerSpec
       typeOfClaim: TypeOfClaimAnswer,
       expectedTitle: String
     ) = {
-      featureSwitch.BulkClaim.enable()
+      featureSwitch.enable(Feature.BulkClaim)
 
       val (session, _) = sessionWithMRNAndTypeOfClaimOnly(None, Some(typeOfClaim))
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBasisForClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBasisForClaimControllerSpec.scala
@@ -52,7 +52,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
   private lazy val featureSwitch = instanceOf[FeatureSwitchService]
 
-  featureSwitch.NorthernIreland.disable()
+  featureSwitch.disable(Feature.NorthernIreland)
 
   implicit lazy val messagesApi: MessagesApi = controller.messagesApi
 
@@ -104,7 +104,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
       "the user has not answered this question before and the NI feature switch is enabled" in {
         def performAction(): Future[Result] = controller.selectBasisForClaim(JourneyBindable.Single)(FakeRequest())
 
-        featureSwitch.NorthernIreland.enable()
+        featureSwitch.enable(Feature.NorthernIreland)
 
         val draftC285Claim                = sessionWithClaimState(None)._3
         val (session, fillingOutClaim, _) = sessionWithClaimState(None)
@@ -125,7 +125,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
       "the user has not answered this question before and the NI feature switch is disabled" in {
         def performAction(): Future[Result] = controller.selectBasisForClaim(JourneyBindable.Single)(FakeRequest())
 
-        featureSwitch.NorthernIreland.disable()
+        featureSwitch.disable(Feature.NorthernIreland)
 
         val draftC285Claim                = sessionWithClaimState(None)._3
         val (session, fillingOutClaim, _) = sessionWithClaimState(None)
@@ -146,7 +146,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
       "the user has answered this question before and the NI feature switch is enabled" in {
         def performAction(): Future[Result] = controller.selectBasisForClaim(JourneyBindable.Single)(FakeRequest())
 
-        featureSwitch.NorthernIreland.enable()
+        featureSwitch.enable(Feature.NorthernIreland)
         val basisOfClaimAnswer = BasisOfClaimAnswer.EndUseRelief.some
 
         val draftC285Claim                = sessionWithClaimState(basisOfClaimAnswer)._3
@@ -168,7 +168,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
       "the user has answered this question before and the NI feature switch is disabled" in {
         def performAction(): Future[Result] = controller.selectBasisForClaim(JourneyBindable.Single)(FakeRequest())
 
-        featureSwitch.NorthernIreland.disable()
+        featureSwitch.disable(Feature.NorthernIreland)
 
         val basisOfClaimAnswer = BasisOfClaimAnswer.EndUseRelief
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectTypeOfClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectTypeOfClaimControllerSpec.scala
@@ -19,24 +19,33 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
 import org.jsoup.nodes.Document
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
+import play.api.i18n.Lang
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
 import play.api.inject.bind
 import play.api.inject.guice.GuiceableModule
 import play.api.mvc.Result
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{BAD_REQUEST, _}
+import play.api.test.Helpers.BAD_REQUEST
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{AuthSupport, ControllerSpec, JourneyBindable, SessionSupport, routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.TypeOfClaimAnswer
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.{ContactName, Email}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.ContactName
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.Email
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.EmailGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.{Eori, GGCredId}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 
 import scala.collection.JavaConverters._
@@ -58,7 +67,7 @@ class SelectTypeOfClaimControllerSpec
   lazy val featureSwitch = instanceOf[FeatureSwitchService]
 
   override def beforeEach(): Unit =
-    featureSwitch.BulkClaim.enable()
+    featureSwitch.enable(Feature.BulkClaim)
 
   lazy val errorHandler: ErrorHandler              = instanceOf[ErrorHandler]
   lazy val controller: SelectTypeOfClaimController = instanceOf[SelectTypeOfClaimController]


### PR DESCRIPTION
This PR amends `JourneyBaseController` with new features:
 - current user retrieval
 - feature switch check if needed
 - automatic redirect to CYA when journey complete after modifications

The new `JourneyControllerComponents` is now the main required dependency on every journey controller.

Additionally bizarre feature switch model and service has been simplified.