### PR TITLE
CDSR-328: refactor check_declaration_details template and controller

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountController.scala
@@ -68,6 +68,7 @@ class BankAccountController @Inject() (
     authenticatedActionWithSessionData.async { implicit request =>
       request.using { case fillingOutClaim: FillingOutClaim =>
         implicit val router: ReimbursementRoutes = extractRoutes(fillingOutClaim.draftClaim, journey)
+        implicit val subKey: Option[String]      = router.subKey
         import router._
 
         fillingOutClaim.draftClaim.findNonEmptyBankAccountDetails

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDeclarationDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDeclarationDetailsController.scala
@@ -53,14 +53,14 @@ class CheckDeclarationDetailsController @Inject() (
   def show(implicit journey: JourneyBindable): Action[AnyContent] = authenticatedActionWithSessionData.async {
     implicit request =>
       withAnswersAndRoutes[DisplayDeclaration] { (_, maybeDeclaration, router) =>
-        val postAction: Call = router.submitUrlForCheckDeclarationDetails()
+        val postAction: Call                = router.submitUrlForCheckDeclarationDetails()
+        implicit val subKey: Option[String] = router.subKey
         maybeDeclaration.fold(Redirect(baseRoutes.IneligibleController.ineligible()))(declaration =>
           Ok(
             checkDeclarationDetailsPage(
               declaration,
               checkDeclarationDetailsAnswerForm,
               isDuplicate = false,
-              router.subKey,
               postAction
             )
           )
@@ -71,7 +71,8 @@ class CheckDeclarationDetailsController @Inject() (
   def submit(implicit journey: JourneyBindable): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
       withAnswersAndRoutes[DisplayDeclaration] { (fillingOutClaim, answer, router) =>
-        val postAction: Call = router.submitUrlForCheckDeclarationDetails()
+        val postAction: Call                = router.submitUrlForCheckDeclarationDetails()
+        implicit val subKey: Option[String] = router.subKey
         CheckDeclarationDetailsController.checkDeclarationDetailsAnswerForm
           .bindFromRequest()
           .fold(
@@ -84,7 +85,6 @@ class CheckDeclarationDetailsController @Inject() (
                         declaration,
                         formWithErrors,
                         isDuplicate = false,
-                        router.subKey,
                         postAction
                       )
                     )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDeclarationDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDeclarationDetailsController.scala
@@ -53,9 +53,16 @@ class CheckDeclarationDetailsController @Inject() (
   def show(implicit journey: JourneyBindable): Action[AnyContent] = authenticatedActionWithSessionData.async {
     implicit request =>
       withAnswersAndRoutes[DisplayDeclaration] { (_, maybeDeclaration, router) =>
+        val postAction: Call = router.submitUrlForCheckDeclarationDetails()
         maybeDeclaration.fold(Redirect(baseRoutes.IneligibleController.ineligible()))(declaration =>
           Ok(
-            checkDeclarationDetailsPage(declaration, checkDeclarationDetailsAnswerForm, isDuplicate = false, router)
+            checkDeclarationDetailsPage(
+              declaration,
+              checkDeclarationDetailsAnswerForm,
+              isDuplicate = false,
+              router.subKey,
+              postAction
+            )
           )
         )
       }
@@ -64,6 +71,7 @@ class CheckDeclarationDetailsController @Inject() (
   def submit(implicit journey: JourneyBindable): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
       withAnswersAndRoutes[DisplayDeclaration] { (fillingOutClaim, answer, router) =>
+        val postAction: Call = router.submitUrlForCheckDeclarationDetails()
         CheckDeclarationDetailsController.checkDeclarationDetailsAnswerForm
           .bindFromRequest()
           .fold(
@@ -71,7 +79,15 @@ class CheckDeclarationDetailsController @Inject() (
               answer
                 .map(declaration =>
                   Future.successful(
-                    BadRequest(checkDeclarationDetailsPage(declaration, formWithErrors, isDuplicate = false, router))
+                    BadRequest(
+                      checkDeclarationDetailsPage(
+                        declaration,
+                        formWithErrors,
+                        isDuplicate = false,
+                        router.subKey,
+                        postAction
+                      )
+                    )
                   )
                 )
                 .getOrElse(Future.successful(errorHandler.errorResult())),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDuplicateDeclarationDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDuplicateDeclarationDetailsController.scala
@@ -56,14 +56,14 @@ class CheckDuplicateDeclarationDetailsController @Inject() (
   def show(implicit journey: JourneyBindable): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
       withAnswersAndRoutes[DisplayDeclaration] { (_, maybeDeclaration, router) =>
-        val postAction: Call = router.submitUrlForCheckDuplicateDeclarationDetails()
+        val postAction: Call                = router.submitUrlForCheckDuplicateDeclarationDetails()
+        implicit val subKey: Option[String] = router.subKey
         maybeDeclaration.fold(Redirect(baseRoutes.IneligibleController.ineligible()))(declaration =>
           Ok(
             checkDeclarationDetailsPage(
               declaration,
               checkDeclarationDetailsAnswerForm,
               isDuplicate = true,
-              router.subKey,
               postAction
             )
           )
@@ -74,7 +74,8 @@ class CheckDuplicateDeclarationDetailsController @Inject() (
   def submit(implicit journey: JourneyBindable): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
       withAnswersAndRoutes[DisplayDeclaration] { (_, answer, router) =>
-        val postAction: Call = router.submitUrlForCheckDuplicateDeclarationDetails()
+        val postAction: Call                = router.submitUrlForCheckDuplicateDeclarationDetails()
+        implicit val subKey: Option[String] = router.subKey
         checkDeclarationDetailsAnswerForm
           .bindFromRequest()
           .fold(
@@ -87,7 +88,6 @@ class CheckDuplicateDeclarationDetailsController @Inject() (
                         declaration,
                         formWithErrors,
                         isDuplicate = true,
-                        router.subKey,
                         postAction
                       )
                     )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDuplicateDeclarationDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckDuplicateDeclarationDetailsController.scala
@@ -56,8 +56,17 @@ class CheckDuplicateDeclarationDetailsController @Inject() (
   def show(implicit journey: JourneyBindable): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
       withAnswersAndRoutes[DisplayDeclaration] { (_, maybeDeclaration, router) =>
+        val postAction: Call = router.submitUrlForCheckDuplicateDeclarationDetails()
         maybeDeclaration.fold(Redirect(baseRoutes.IneligibleController.ineligible()))(declaration =>
-          Ok(checkDeclarationDetailsPage(declaration, checkDeclarationDetailsAnswerForm, isDuplicate = true, router))
+          Ok(
+            checkDeclarationDetailsPage(
+              declaration,
+              checkDeclarationDetailsAnswerForm,
+              isDuplicate = true,
+              router.subKey,
+              postAction
+            )
+          )
         )
       }
     }
@@ -65,6 +74,7 @@ class CheckDuplicateDeclarationDetailsController @Inject() (
   def submit(implicit journey: JourneyBindable): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
       withAnswersAndRoutes[DisplayDeclaration] { (_, answer, router) =>
+        val postAction: Call = router.submitUrlForCheckDuplicateDeclarationDetails()
         checkDeclarationDetailsAnswerForm
           .bindFromRequest()
           .fold(
@@ -72,7 +82,15 @@ class CheckDuplicateDeclarationDetailsController @Inject() (
               answer
                 .map(declaration =>
                   Future.successful(
-                    BadRequest(checkDeclarationDetailsPage(declaration, formWithErrors, isDuplicate = true, router))
+                    BadRequest(
+                      checkDeclarationDetailsPage(
+                        declaration,
+                        formWithErrors,
+                        isDuplicate = true,
+                        router.subKey,
+                        postAction
+                      )
+                    )
                   )
                 )
                 .getOrElse(Future.successful(errorHandler.errorResult())),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckScheduledClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckScheduledClaimController.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.{AuthenticatedAction, SessionDataAction, WithAuthAndSessionDataAction}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckScheduledClaimController.whetherDutiesCorrectForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{SessionDataExtractor, SessionUpdates, YesOrNoQuestionForm}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{JourneyBindable, SessionDataExtractor, SessionUpdates, YesOrNoQuestionForm}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim.from
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.{ClaimedReimbursementsAnswer, SelectedDutyTaxCodesReimbursementAnswer, YesNo}
@@ -57,8 +57,9 @@ class CheckScheduledClaimController @Inject() (
 
   def showReimbursements(): Action[AnyContent] = authenticatedActionWithSessionData.async { implicit request =>
     withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (fillingOutClaim, maybeAnswer) =>
-      implicit val routes: ReimbursementRoutes =
-        extractRoutes(fillingOutClaim.draftClaim, Scheduled)
+      val routes: ReimbursementRoutes       = extractRoutes(fillingOutClaim.draftClaim, Scheduled)
+      implicit val journey: JourneyBindable = Scheduled
+      implicit val subKey: Option[String]   = routes.subKey
 
       def redirectToSelectDutiesPage: Future[Result] =
         Future.successful(Redirect(claimRoutes.SelectDutyTypesController.showDutyTypes()))
@@ -74,9 +75,9 @@ class CheckScheduledClaimController @Inject() (
 
   def submitReimbursements(): Action[AnyContent] = authenticatedActionWithSessionData.async { implicit request =>
     withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (fillingOutClaim, maybeAnswer) =>
-      implicit val routes: ReimbursementRoutes =
-        extractRoutes(fillingOutClaim.draftClaim, Scheduled)
-
+      val routes: ReimbursementRoutes       = extractRoutes(fillingOutClaim.draftClaim, Scheduled)
+      implicit val journey: JourneyBindable = Scheduled
+      implicit val subKey: Option[String]   = routes.subKey
       import routes._
 
       def selectDuties: Future[Result] =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourAnswersAndSubmitController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourAnswersAndSubmitController.scala
@@ -63,6 +63,7 @@ class CheckYourAnswersAndSubmitController @Inject() (
     authenticatedActionWithSessionData.async { implicit request =>
       request.using { case fillingOutClaim: FillingOutClaim =>
         implicit val router: ReimbursementRoutes = extractRoutes(fillingOutClaim.draftClaim, journey)
+        implicit val subKey: Option[String]      = router.subKey
         Ok(checkYourAnswersPage(fillingOutClaim.draftClaim, fillingOutClaim.signedInUserDetails.verifiedEmail))
       }
     }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_bank_account_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_bank_account_details.scala.html
@@ -18,10 +18,10 @@
 @import play.api.mvc.Call
 @import play.twirl.api.Html
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.AnswerSummaryOps
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 
 @this(
     layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
@@ -32,7 +32,7 @@
     summary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.summary
 )
 
-@(bankAccount: BankAccountDetails, continuePageUrl: Call)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig, router: ReimbursementRoutes)
+@(bankAccount: BankAccountDetails, continuePageUrl: Call)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig, subKey: Option[String], journey: JourneyBindable)
 
 @key = @{"bank-details"}
 @title = @{messages(s"$key.title")}
@@ -52,7 +52,7 @@
         )
     )
 
-    @summary(bankAccount.summary(key, router))
+    @summary(bankAccount.summary(key, subKey))
 
     @buttonLink("button.continue", Some(continuePageUrl.url))
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_declaration_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_declaration_details.scala.html
@@ -20,6 +20,7 @@
 @import play.api.mvc.Call
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkYourAnswersKey
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
@@ -38,7 +39,7 @@
         errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary
 )
 
-@(declaration: DisplayDeclaration, form: Form[YesNo], isDuplicate: Boolean, subKey: Option[String], postAction: Call)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(declaration: DisplayDeclaration, form: Form[YesNo], isDuplicate: Boolean, postAction: Call)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig, subKey: Option[String], journey: JourneyBindable)
 
 @key = @{"check-declaration-details"}
 @title = @{if(isDuplicate) messages(s"$key.duplicate.title") else messages(s"$key.title")}
@@ -55,7 +56,7 @@
 
     @formWithCSRF(postAction, 'novalidate -> "novalidate") {
 
-        @summary(declaration.summaryWithSubKey(s"$checkYourAnswersKey.declaration-details", subKey))
+        @summary(declaration.summary(s"$checkYourAnswersKey.declaration-details", subKey))
 
         @pageHeading(messages(s"$key.is-information-correct"), "govuk-heading-s govuk-!-margin-top-8", "h2")
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_declaration_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_declaration_details.scala.html
@@ -17,10 +17,10 @@
 @import play.api.i18n.Messages
 @import play.twirl.api.Html
 @import play.api.data.Form
+@import play.api.mvc.Call
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkYourAnswersKey
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.AnswerSummaryOps
@@ -38,11 +38,10 @@
         errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary
 )
 
-@(declaration: DisplayDeclaration, form: Form[YesNo], isDuplicate: Boolean, router: ReimbursementRoutes)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(declaration: DisplayDeclaration, form: Form[YesNo], isDuplicate: Boolean, subKey: Option[String], postAction: Call)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
 
 @key = @{"check-declaration-details"}
 @title = @{if(isDuplicate) messages(s"$key.duplicate.title") else messages(s"$key.title")}
-@postAction = @{if(isDuplicate) router.submitUrlForCheckDuplicateDeclarationDetails() else router.submitUrlForCheckDeclarationDetails() }
 
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
@@ -56,7 +55,7 @@
 
     @formWithCSRF(postAction, 'novalidate -> "novalidate") {
 
-        @summary(declaration.summary(s"$checkYourAnswersKey.declaration-details", router))
+        @summary(declaration.summaryWithSubKey(s"$checkYourAnswersKey.declaration-details", subKey))
 
         @pageHeading(messages(s"$key.is-information-correct"), "govuk-heading-s govuk-!-margin-top-8", "h2")
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_scheduled_claim_summary.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_scheduled_claim_summary.scala.html
@@ -20,7 +20,7 @@
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.{SelectedDutyTaxCodesReimbursementAnswer, YesNo}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.AnswerSummaryOps
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
@@ -37,7 +37,7 @@
     summary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.summary
 )
 
-@(answer: SelectedDutyTaxCodesReimbursementAnswer, form: Form[YesNo])(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig, routes: ReimbursementRoutes)
+@(answer: SelectedDutyTaxCodesReimbursementAnswer, form: Form[YesNo])(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig, subKey: Option[String], journey: JourneyBindable)
 
 @key = @{"check-claim-summary"}
 @title = @{messages(s"$key.scheduled.title")}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
@@ -20,6 +20,7 @@
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.AssociatedMRNsAnswer
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ReimbursementMethodAnswer.CurrentMonthAdjustment
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.TypeOfClaimAnswer
@@ -39,7 +40,7 @@
     formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 )
 
-@(claim: DraftClaim, verifiedEmal: Email)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig, router: ReimbursementRoutes)
+@(claim: DraftClaim, verifiedEmail: Email)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig, subKey: Option[String], journey: JourneyBindable)
 
 @key = @{"check-your-answers"}
 @title = @{messages(s"$key.title")}
@@ -58,7 +59,7 @@
 
 @cdsClaimantDetailsSummary = @{
     claim.extractEstablishmentAddress.map { cdsAddress =>
-        (claim.extractDetailsRegisteredWithCDS(verifiedEmal), cdsAddress, claim.mrnContactDetailsAnswer,claim.mrnContactAddressAnswer).summary(s"$key.claimant-details")
+        (claim.extractDetailsRegisteredWithCDS(verifiedEmail), cdsAddress, claim.mrnContactDetailsAnswer,claim.mrnContactAddressAnswer).summary(s"$key.claimant-details")
     }
 }
 
@@ -66,7 +67,7 @@
 
     @pageHeading(title)
 
-    @pageHeading(messages(lang(s"$key.reference-number", router.subKey, "h2")), "govuk-heading-m govuk-!-margin-top-7", "h2")
+    @pageHeading(messages(lang(s"$key.reference-number", subKey, "h2")), "govuk-heading-m govuk-!-margin-top-7", "h2")
     @summary(mrnSummary)
 
     @claim.scheduledDocumentAnswer.map { scheduledDocument =>
@@ -108,7 +109,7 @@
         @if(claim.typeOfClaim.isEmpty ||
             claim.typeOfClaim.contains(TypeOfClaimAnswer.Individual) ||
             claim.typeOfClaim.contains(TypeOfClaimAnswer.Scheduled)) {
-            @pageHeading(messages(lang(s"$key.claim-calculation", router.subKey, "h2")), "govuk-heading-m govuk-!-margin-top-9", "h2")
+            @pageHeading(messages(lang(s"$key.claim-calculation", subKey, "h2")), "govuk-heading-m govuk-!-margin-top-9", "h2")
             @summary(reimbursement.summary(s"$key.claim-calculation"))
         }
     }
@@ -138,7 +139,7 @@
     @pageHeading(messages(s"$key.confirmation-statement.h2"), "govuk-heading-m govuk-!-margin-top-9", "h2")
     @paragraph(Html(messages(s"$key.confirmation-statement")), Some("govuk-body"))
 
-    @formWithCSRF(claimRoutes.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit(router.journeyBindable), 'novalidate -> "novalidate") {
+    @formWithCSRF(claimRoutes.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit(journey), 'novalidate -> "novalidate") {
         @submitButton("button.accept-and-send")
     }
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/AnswerSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/AnswerSummary.scala
@@ -17,10 +17,13 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 
 trait AnswerSummary[A] {
-  def render(key: String, answer: A)(implicit router: ReimbursementRoutes, messages: Messages): SummaryList
-  def renderWithSubKey(key: String, answer: A)(implicit subKey: Option[String], messages: Messages): SummaryList
+  def render(key: String, answer: A)(implicit
+    subKey: Option[String],
+    journey: JourneyBindable,
+    messages: Messages
+  ): SummaryList
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/AnswerSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/AnswerSummary.scala
@@ -21,6 +21,6 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 
 trait AnswerSummary[A] {
-
   def render(key: String, answer: A)(implicit router: ReimbursementRoutes, messages: Messages): SummaryList
+  def renderWithSubKey(key: String, answer: A)(implicit subKey: Option[String], messages: Messages): SummaryList
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/BankAccountDetailsSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/BankAccountDetailsSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkYourAnswersKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
@@ -27,14 +27,15 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 class BankAccountDetailsSummary extends AnswerSummary[BankAccountDetails] {
 
   def render(key: String, bankAccountDetails: BankAccountDetails)(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList = {
 
     def changeCall =
       if (key.contains(checkYourAnswersKey))
-        routes.BankAccountController.checkBankAccountDetails(router.journeyBindable)
-      else routes.SelectBankAccountTypeController.selectBankAccountType(router.journeyBindable)
+        routes.BankAccountController.checkBankAccountDetails(journey)
+      else routes.SelectBankAccountTypeController.selectBankAccountType(journey)
 
     SummaryList(
       Seq(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/BasisOfClaimSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/BasisOfClaimSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.{BasisOfClaimAnswer, BasisOfClaims}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
@@ -26,7 +26,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 class BasisOfClaimSummary extends AnswerSummary[BasisOfClaimAnswer] {
 
   def render(key: String, answer: BasisOfClaimAnswer)(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList =
     SummaryList(
@@ -38,7 +39,7 @@ class BasisOfClaimSummary extends AnswerSummary[BasisOfClaimAnswer] {
             Actions(
               items = Seq(
                 ActionItem(
-                  href = routes.SelectBasisForClaimController.selectBasisForClaim(router.journeyBindable).url,
+                  href = routes.SelectBasisForClaimController.selectBasisForClaim(journey).url,
                   content = Text(messages("cya.change")),
                   visuallyHiddenText = Some(messages(s"$key.l0"))
                 )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/CdsClaimantDetailsSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/CdsClaimantDetailsSummary.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 import cats.implicits.toFunctorFilterOps
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
@@ -44,7 +44,8 @@ class CdsClaimantDetailsSummary
     key: String,
     answer: (NamePhoneEmail, EstablishmentAddress, Option[MrnContactDetails], Option[ContactAddress])
   )(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList = {
     val (cdsContact, cdsAddress, mrnContact, mrnAddress) = answer
@@ -64,7 +65,7 @@ class CdsClaimantDetailsSummary
             Actions(
               items = Seq(
                 ActionItem(
-                  href = s"${routes.CheckContactDetailsMrnController.show(router.journeyBindable).url}",
+                  href = s"${routes.CheckContactDetailsMrnController.show(journey).url}",
                   content = Text(messages("cya.change")),
                   visuallyHiddenText = Some(messages(s"$key.change-hint.contact"))
                 )
@@ -93,7 +94,7 @@ class CdsClaimantDetailsSummary
             Actions(
               items = Seq(
                 ActionItem(
-                  href = s"${routes.CheckContactDetailsMrnController.show(router.journeyBindable).url}",
+                  href = s"${routes.CheckContactDetailsMrnController.show(journey).url}",
                   content = Text(messages("cya.change")),
                   visuallyHiddenText = Some(messages(s"$key.change-hint.address"))
                 )
@@ -125,7 +126,7 @@ class CdsClaimantDetailsSummary
           Actions(
             items = Seq(
               ActionItem(
-                href = s"${routes.CheckContactDetailsMrnController.show(router.journeyBindable).url}",
+                href = s"${routes.CheckContactDetailsMrnController.show(journey).url}",
                 content = Text(messages("cya.change")),
                 visuallyHiddenText = Some(messages(s"$key.change-hint.contact"))
               )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ClaimTypeSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ClaimTypeSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectWhoIsMakingTheClaimController.whoIsMakingTheClaimKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.{DeclarantTypeAnswer, DeclarantTypeAnswers}
@@ -27,7 +27,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 class ClaimTypeSummary extends AnswerSummary[DeclarantTypeAnswer] {
 
   def render(key: String, answer: DeclarantTypeAnswer)(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList =
     SummaryList(
@@ -41,8 +42,7 @@ class ClaimTypeSummary extends AnswerSummary[DeclarantTypeAnswer] {
             Actions(
               items = Seq(
                 ActionItem(
-                  href =
-                    s"${routes.SelectWhoIsMakingTheClaimController.selectDeclarantType(router.journeyBindable).url}",
+                  href = s"${routes.SelectWhoIsMakingTheClaimController.selectDeclarantType(journey).url}",
                   content = Text(messages("cya.change")),
                   visuallyHiddenText = Some(messages(s"$key.l0"))
                 )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ClaimedReimbursementsAnswerSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ClaimedReimbursementsAnswerSummary.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 import cats.implicits.catsSyntaxEq
 import play.api.i18n.Messages
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ClaimedReimbursementsAnswer
@@ -29,12 +28,13 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 class ClaimedReimbursementsAnswerSummary extends AnswerSummary[ClaimedReimbursementsAnswer] {
 
   def render(key: String, reimbursements: ClaimedReimbursementsAnswer)(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList = {
 
     val amendCall =
-      if (router.journeyBindable === JourneyBindable.Scheduled)
+      if (journey === JourneyBindable.Scheduled)
         claimsRoutes.CheckScheduledClaimController.showReimbursements()
       else claimsRoutes.EnterSingleClaimController.checkClaimSummary()
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/CommodityDetailsSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/CommodityDetailsSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.CommodityDetailsAnswer
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
@@ -26,7 +26,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 class CommodityDetailsSummary extends AnswerSummary[CommodityDetailsAnswer] {
 
   def render(key: String, answer: CommodityDetailsAnswer)(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList = {
     val label = messages(s"$key.label")
@@ -40,8 +41,7 @@ class CommodityDetailsSummary extends AnswerSummary[CommodityDetailsAnswer] {
             Actions(
               items = Seq(
                 ActionItem(
-                  href =
-                    s"${routes.EnterCommoditiesDetailsController.enterCommoditiesDetails(router.journeyBindable).url}",
+                  href = s"${routes.EnterCommoditiesDetailsController.enterCommoditiesDetails(journey).url}",
                   content = Text(messages("cya.change")),
                   visuallyHiddenText = Some(label)
                 )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/DisplayDeclarationSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/DisplayDeclarationSummary.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import cats.implicits.catsSyntaxOptionId
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.utils.LanguageHelper.lang
@@ -28,8 +28,9 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryList,
 
 class DisplayDeclarationSummary extends AnswerSummary[DisplayDeclaration] {
 
-  def renderWithSubKey(key: String, declaration: DisplayDeclaration)(implicit
-    subKey: String,
+  def render(key: String, declaration: DisplayDeclaration)(implicit
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList = SummaryList(
     Seq(
@@ -38,7 +39,7 @@ class DisplayDeclarationSummary extends AnswerSummary[DisplayDeclaration] {
         value = Value()
       ).some,
       SummaryListRow(
-        key = Key(Text(messages(lang(key, Some(subKey), "mrn-label")))),
+        key = Key(Text(messages(lang(key, subKey, "mrn-label")))),
         value = Value(Text(declaration.displayResponseDetail.declarationId))
       ).some,
       SummaryListRow(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/DisplayDeclarationSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/DisplayDeclarationSummary.scala
@@ -28,8 +28,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryList,
 
 class DisplayDeclarationSummary extends AnswerSummary[DisplayDeclaration] {
 
-  def render(key: String, declaration: DisplayDeclaration)(implicit
-    router: ReimbursementRoutes,
+  def renderWithSubKey(key: String, declaration: DisplayDeclaration)(implicit
+    subKey: String,
     messages: Messages
   ): SummaryList = SummaryList(
     Seq(
@@ -38,7 +38,7 @@ class DisplayDeclarationSummary extends AnswerSummary[DisplayDeclaration] {
         value = Value()
       ).some,
       SummaryListRow(
-        key = Key(Text(messages(lang(key, router.subKey, "mrn-label")))),
+        key = Key(Text(messages(lang(key, Some(subKey), "mrn-label")))),
         value = Value(Text(declaration.displayResponseDetail.declarationId))
       ).some,
       SummaryListRow(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/DutyAndTaxCodeReimbursementSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/DutyAndTaxCodeReimbursementSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.SelectedDutyTaxCodesReimbursementAnswer
 import uk.gov.hmrc.govukfrontend.views.Aliases.{SummaryListRow, Value}
@@ -27,7 +27,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryList}
 class DutyAndTaxCodeReimbursementSummary extends AnswerSummary[SelectedDutyTaxCodesReimbursementAnswer] {
 
   def render(key: String, reimbursements: SelectedDutyTaxCodesReimbursementAnswer)(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList =
     SummaryList(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/MovementReferenceNumberSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/MovementReferenceNumberSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.utils.LanguageHelper.lang
@@ -26,20 +26,23 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 
 class MovementReferenceNumberSummary extends AnswerSummary[MRN] {
 
-  def render(key: String, answer: MRN)(implicit router: ReimbursementRoutes, messages: Messages): SummaryList =
+  def render(key: String, answer: MRN)(implicit
+    subKey: Option[String],
+    journey: JourneyBindable,
+    messages: Messages
+  ): SummaryList =
     SummaryList(
       Seq(
         SummaryListRow(
-          key = Key(Text(messages(lang(key, router.subKey, "label")))),
+          key = Key(Text(messages(lang(key, subKey, "label")))),
           value = Value(Text(answer.value)),
           actions = Some(
             Actions(
               items = Seq(
                 ActionItem(
-                  href =
-                    s"${routes.EnterMovementReferenceNumberController.enterJourneyMrn(router.journeyBindable).url}",
+                  href = s"${routes.EnterMovementReferenceNumberController.enterJourneyMrn(journey).url}",
                   content = Text(messages("cya.change")),
-                  visuallyHiddenText = Some(messages(lang(key, router.subKey, "label")))
+                  visuallyHiddenText = Some(messages(lang(key, subKey, "label")))
                 )
               )
             )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/MovementReferenceNumbersSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/MovementReferenceNumbersSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.{AssociatedMrn, LeadMrn}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.{AssociatedMrnIndex, MRN}
@@ -28,19 +28,20 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 class MovementReferenceNumbersSummary extends AnswerSummary[List[MRN]] {
 
   def render(key: String, mrns: List[MRN])(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList = {
 
     def toLeadMrnSummary: LeadMrn => SummaryListRow = leadMrn =>
       SummaryListRow(
-        key = Key(Text(messages(lang(key, router.subKey, "label")))),
+        key = Key(Text(messages(lang(key, subKey, "label")))),
         value = Value(Text(leadMrn.value)),
         actions = Some(
           Actions(items =
             Seq(
               ActionItem(
-                href = s"${routes.EnterMovementReferenceNumberController.enterJourneyMrn(router.journeyBindable).url}",
+                href = s"${routes.EnterMovementReferenceNumberController.enterJourneyMrn(journey).url}",
                 content = Text(messages("cya.change"))
               )
             )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/MultipleClaimsAnswerSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/MultipleClaimsAnswerSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ClaimedReimbursementsAnswer
@@ -29,7 +29,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 class MultipleClaimsAnswerSummary extends AnswerSummary[List[(MRN, ClaimedReimbursementsAnswer)]] {
 
   def render(key: String, mrnsWithClaimsList: List[(MRN, ClaimedReimbursementsAnswer)])(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList = {
     val amendCall =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/NorthernIrelandAnswerSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/NorthernIrelandAnswerSummary.scala
@@ -17,15 +17,19 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
 import uk.gov.hmrc.govukfrontend.views.Aliases.{ActionItem, Key, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Actions, SummaryList, SummaryListRow, Value}
 
 class NorthernIrelandAnswerSummary extends AnswerSummary[YesNo] {
 
-  def render(key: String, answer: YesNo)(implicit router: ReimbursementRoutes, messages: Messages): SummaryList =
+  def render(key: String, answer: YesNo)(implicit
+    subKey: Option[String],
+    journey: JourneyBindable,
+    messages: Messages
+  ): SummaryList =
     SummaryList(
       Seq(
         SummaryListRow(
@@ -35,8 +39,7 @@ class NorthernIrelandAnswerSummary extends AnswerSummary[YesNo] {
             Actions(
               items = Seq(
                 ActionItem(
-                  href =
-                    s"${routes.ClaimNorthernIrelandController.selectWhetherNorthernIrelandClaim(router.journeyBindable).url}",
+                  href = s"${routes.ClaimNorthernIrelandController.selectWhetherNorthernIrelandClaim(journey).url}",
                   content = Text(messages("cya.change")),
                   visuallyHiddenText = Some(messages(s"$key.label"))
                 )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ReimbursementMethodAnswerSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ReimbursementMethodAnswerSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ReimbursementMethodAnswer
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ReimbursementMethodAnswer._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
@@ -26,7 +26,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 
 class ReimbursementMethodAnswerSummary extends AnswerSummary[ReimbursementMethodAnswer] {
   def render(key: String, answer: ReimbursementMethodAnswer)(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList = {
     val label = messages(s"$key.label")

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ScheduledDocumentSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ScheduledDocumentSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.fileupload.routes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ScheduledDocumentAnswer
 import uk.gov.hmrc.govukfrontend.views.Aliases.Value
@@ -27,7 +27,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 class ScheduledDocumentSummary extends AnswerSummary[ScheduledDocumentAnswer] {
 
   def render(key: String, answer: ScheduledDocumentAnswer)(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList =
     SummaryList(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/SupportingEvidenceSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/SupportingEvidenceSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.fileupload.SupportingEvidenceController.supportingEvidenceKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.fileupload.routes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.SupportingEvidencesAnswer
@@ -29,7 +29,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 class SupportingEvidenceSummary extends AnswerSummary[SupportingEvidencesAnswer] {
 
   def render(key: String, answers: SupportingEvidencesAnswer)(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList =
     SummaryList(
@@ -58,7 +59,7 @@ class SupportingEvidenceSummary extends AnswerSummary[SupportingEvidencesAnswer]
             Actions(
               items = Seq(
                 ActionItem(
-                  href = s"${routes.SupportingEvidenceController.checkYourAnswers(router.journeyBindable).url}",
+                  href = s"${routes.SupportingEvidenceController.checkYourAnswers(journey).url}",
                   content = Text(messages("cya.change")),
                   visuallyHiddenText = Some(messages(s"$key.label"))
                 )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/TaxCodeReimbursementSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/TaxCodeReimbursementSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.SelectedDutyTaxCodesReimbursementAnswer.SelectedTaxCodesReimbursementOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{BigDecimalOps, DutyType, Reimbursement, TaxCode}
@@ -30,7 +30,8 @@ import scala.collection.SortedMap
 class TaxCodeReimbursementSummary extends AnswerSummary[(DutyType, SortedMap[TaxCode, Reimbursement])] {
 
   def render(key: String, answer: (DutyType, SortedMap[TaxCode, Reimbursement]))(implicit
-    router: ReimbursementRoutes,
+    subKey: Option[String],
+    journey: JourneyBindable,
     messages: Messages
   ): SummaryList = {
     val duty                      = answer._1

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/package.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/package.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 
 package object summary {
@@ -41,21 +41,21 @@ package object summary {
 
   implicit class AnswerSummaryOps[A](val answer: A) extends AnyVal {
 
-    def summary(key: String, router: ReimbursementRoutes)(implicit
+    def summary(key: String, subKey: Option[String])(implicit
       answerSummary: AnswerSummary[A],
+      journey: JourneyBindable,
       messages: Messages
     ): SummaryList =
-      answerSummary.render(key, answer)(router, messages)
-
-    def summaryWithSubKey(key: String, subKey: Option[String])(implicit
-      answerSummary: AnswerSummary[A],
-      messages: Messages
-    ): SummaryList =
-      answerSummary.renderWithSubKey(key, answer)(subKey, messages)
+      answerSummary.render(key, answer)(subKey, journey, messages)
 
     def summary(
       key: String
-    )(implicit answerSummary: AnswerSummary[A], router: ReimbursementRoutes, messages: Messages): SummaryList =
+    )(implicit
+      answerSummary: AnswerSummary[A],
+      subKey: Option[String],
+      journey: JourneyBindable,
+      messages: Messages
+    ): SummaryList =
       answerSummary.render(key, answer)
   }
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/package.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/package.scala
@@ -47,6 +47,12 @@ package object summary {
     ): SummaryList =
       answerSummary.render(key, answer)(router, messages)
 
+    def summaryWithSubKey(key: String, subKey: Option[String])(implicit
+      answerSummary: AnswerSummary[A],
+      messages: Messages
+    ): SummaryList =
+      answerSummary.renderWithSubKey(key, answer)(subKey, messages)
+
     def summary(
       key: String
     )(implicit answerSummary: AnswerSummary[A], router: ReimbursementRoutes, messages: Messages): SummaryList =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/utils/ClaimantDetailsHelper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/utils/ClaimantDetailsHelper.scala
@@ -25,7 +25,6 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.EstablishmentAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.NamePhoneEmail
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{ActionItem, Actions, Key, SummaryListRow, Value}


### PR DESCRIPTION
This PR includes a lot of refactoring to allow for removing ReimbursementRoutes from the check_declaration_details template.
Refactoring includes: 

- Removing ReimbursementRoutes from check_your_answers template and controller
- Removing ReimbursementRoutes from summary helpers
- Including JourneyBindable and subKey in summary helpers
- Including JourneyBindable and subKey as an implicit for render method
- Changing any subsequent templates that use the summary/render method (mini journey summary pages)
