### PR TITLE
CDSR-1262: Check claimant details

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyBaseController.scala
@@ -94,15 +94,15 @@ abstract class JourneyBaseController[Journey](implicit ec: ExecutionContext)
       }
 
   /** Simple GET action to show page based on the user data and journey state. */
-  final def simpleActionReadJourneyAndUser(body: Journey => RetrievedUserType => Result): Action[AnyContent] =
+  final def simpleActionReadJourneyAndUser(
+    body: Request[_] => Journey => RetrievedUserType => Future[Result]
+  ): Action[AnyContent] =
     jcc
       .authenticatedActionWithRetrievedDataAndSessionData(requiredFeature)
       .async { implicit request =>
-        Future.successful(
-          getJourney(request.sessionData)
-            .map(journey => body(journey)(request.authenticatedRequest.journeyUserType))
-            .getOrElse(Redirect(startOfTheJourney))
-        )
+        getJourney(request.sessionData)
+          .map(journey => body(request)(journey)(request.authenticatedRequest.journeyUserType))
+          .getOrElse(goToTheStartOfJourney)
       }
 
   /** Async GET action to show page based on the request and journey state. */

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDeclarantEoriNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDeclarantEoriNumberController.scala
@@ -20,8 +20,6 @@ import cats.instances.future.catsStdInstancesForFuture
 import play.api.data.Form
 import cats.data.EitherT
 import cats.implicits.catsSyntaxEq
-import play.api.data.Forms.{mapping, text}
-import play.api.data._
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.{ErrorHandler, ViewConfig}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterImporterEoriNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterImporterEoriNumberController.scala
@@ -20,8 +20,6 @@ import cats.data.EitherT
 import cats.implicits.catsSyntaxEq
 import cats.instances.future.catsStdInstancesForFuture
 import play.api.data.Form
-import play.api.data.Forms.mapping
-import play.api.data.Forms.nonEmptyText
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.MessagesControllerComponents

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckClaimantDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckClaimantDetailsController.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.{ContactAddress, Country}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.{Email, NamePhoneEmail, PhoneNumber}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{rejectedgoodssingle => pages}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class CheckClaimantDetailsController @Inject() (
+  val jcc: JourneyControllerComponents,
+  claimantDetailsPage: pages.check_claimant_details
+)(implicit val ec: ExecutionContext, viewConfig: ViewConfig)
+    extends RejectedGoodsSingleJourneyBaseController {
+
+  implicit val subKey: Option[String] = None
+
+  def show(): Action[AnyContent] = actionReadJourney { implicit request => journey =>
+    val cd            = journey.answers.contactDetails.getOrElse(
+      MrnContactDetails(
+        "Alex Smith",
+        Email("alex.smith@acmecorporation.com"),
+        Some(PhoneNumber("+440234567890"))
+      )
+    )
+    val ca            = journey.answers.contactAddress.getOrElse(
+      ContactAddress("73 Guild Street", None, None, "London", "SE23 6FH", Country.uk)
+    )
+    val changeCd      = Call("GET", "change_contact")
+    val changeAddress = Call("GET", "change_address")
+    val postAction    = Call("GET", "choose-basis-for-claim")
+    Future.successful(
+      Ok(claimantDetailsPage(cd, ca, changeCd, changeAddress, postAction))
+    )
+  }
+}
+
+object CheckClaimantDetailsController {
+  val checkContactDetailsKey = "check-claimant-details"
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
@@ -19,15 +19,7 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
 import cats.Eq
 import cats.syntax.eq._
 import play.api.libs.json._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BasisOfRejectedGoodsClaim
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ClaimantInformation
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DocumentTypeRejectedGoods
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddress
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MethodOfDisposal
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{BankAccountDetails, BankAccountType, BasisOfRejectedGoodsClaim, ClaimantInformation, DocumentTypeRejectedGoods, InspectionAddress, MethodOfDisposal, MrnContactDetails, RetrievedUserType, TaxCode}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ClaimantType
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ReimbursementMethodAnswer
@@ -40,8 +32,9 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.upscan.UploadReference
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.FluentImplicits
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.FluentSyntax
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.MapFormat
-
 import java.time.LocalDate
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType.Individual
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.{Email, PhoneNumber}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.SimpleStringFormat
 
 /** An encapsulated C&E1179 single MRN journey logic.
@@ -56,6 +49,55 @@ final class RejectedGoodsSingleJourney private (val answers: RejectedGoodsSingle
     extends FluentSyntax[RejectedGoodsSingleJourney] {
 
   val ZERO: BigDecimal = BigDecimal("0")
+
+  def getContactDetails(retrievedUser: RetrievedUserType): Option[MrnContactDetails] = (
+    answers.contactDetails,
+    answers.displayDeclaration.flatMap(_.getConsigneeDetails.flatMap(_.contactDetails)),
+    answers.displayDeclaration.flatMap(_.getDeclarantDetails.contactDetails),
+    retrievedUser
+  ) match {
+    case (details @ Some(_), _, _, _)                                                                           =>
+      details
+    case (_, Some(consigneeContactDetails), _, _) if getConsigneeEoriFromACC14.contains(answers.userEoriNumber) =>
+      Some(
+        MrnContactDetails(
+          consigneeContactDetails.contactName.getOrElse(""),
+          Email(consigneeContactDetails.emailAddress.getOrElse("")),
+          consigneeContactDetails.telephone.map(PhoneNumber(_))
+        )
+      )
+    case (_, None, _, individual: Individual) if getConsigneeEoriFromACC14.contains(answers.userEoriNumber)     =>
+      Some(
+        MrnContactDetails(
+          individual.name.map(_.toFullName).getOrElse(""),
+          individual.email.getOrElse(Email("")),
+          None
+        )
+      )
+    case (_, _, Some(declarantContactDetails), _)                                                               =>
+      Some(
+        MrnContactDetails(
+          declarantContactDetails.contactName.getOrElse(""),
+          Email(declarantContactDetails.emailAddress.getOrElse("")),
+          declarantContactDetails.telephone.map(PhoneNumber(_))
+        )
+      )
+    case _                                                                                                      => None
+  }
+
+  def getAddressDetails: Option[ContactAddress] = (
+    answers.contactAddress,
+    answers.displayDeclaration.flatMap(_.getConsigneeDetails),
+    answers.displayDeclaration.map(_.getDeclarantDetails)
+  ) match {
+    case (contactAddress @ Some(_), _, _)                                                                =>
+      contactAddress
+    case (None, Some(consigneeDetails), _) if getConsigneeEoriFromACC14.contains(answers.userEoriNumber) =>
+      Some(consigneeDetails.establishmentAddress.toContactAddress)
+    case (None, _, Some(declarantDetails))                                                               =>
+      Some(declarantDetails.establishmentAddress.toContactAddress)
+    case _                                                                                               => None
+  }
 
   /** Check if the journey is ready to finalize, i.e. to get the output. */
   def isComplete: Boolean =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/contactdetails/Name.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/contactdetails/Name.scala
@@ -18,7 +18,10 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails
 
 import play.api.libs.json.{Json, OFormat}
 
-final case class Name(name: Option[String], lastName: Option[String])
+final case class Name(name: Option[String], lastName: Option[String]) {
+  def toFullName: String =
+    (name.toList ++ lastName.toList).mkString(" ")
+}
 
 object Name {
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/EstablishmentAddress.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/EstablishmentAddress.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration
 import cats.Eq
 import julienrf.json.derived
 import play.api.libs.json.OFormat
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address._
 
 final case class EstablishmentAddress(
   addressLine1: String,
@@ -27,7 +27,17 @@ final case class EstablishmentAddress(
   addressLine3: Option[String] = None,
   postalCode: Option[String] = None,
   countryCode: String
-)
+) {
+  def toContactAddress: ContactAddress =
+    ContactAddress(
+      addressLine1,
+      addressLine2,
+      addressLine3,
+      "",
+      postalCode.getOrElse(""),
+      Country(countryCode)
+    )
+}
 
 object EstablishmentAddress {
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ClaimantDetailsSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ClaimantDetailsSummary.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
+
+import cats.implicits.toFunctorFilterOps
+import play.api.i18n.Messages
+import play.api.mvc.Call
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.html.Paragraph
+import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{ActionItem, Actions, Key, SummaryList, SummaryListRow, Value}
+
+class ClaimantDetailsSummary
+    extends RejectedGoodsAnswerSummary[
+      (
+        MrnContactDetails,
+        ContactAddress,
+        Call,
+        Call
+      )
+    ] {
+  override def render(key: String, answer: (MrnContactDetails, ContactAddress, Call, Call))(implicit
+    subKey: Option[String],
+    messages: Messages
+  ): SummaryList = {
+    val (contactDetails, contactAddress, changeContactDetailsCall, changeContactAddressCall) = answer
+    val contactData                                                                          = List(
+      Some(Paragraph(contactDetails.fullName)),
+      Some(Paragraph(contactDetails.emailAddress.value)),
+      contactDetails.phoneNumber.map(n => Paragraph(n.value))
+    ).flattenOption
+
+    val contactAction = Some(
+      Actions(
+        items = Seq(
+          ActionItem(
+            href = s"${changeContactDetailsCall.url}",
+            content = Text(messages("cya.change")),
+            visuallyHiddenText = Some(messages(s"$key.change-hint.contact"))
+          )
+        )
+      )
+    )
+
+    val addressData = List(
+      Some(Paragraph(contactAddress.line1)),
+      contactAddress.line2.map(Paragraph(_)),
+      contactAddress.line3.map(Paragraph(_)),
+      Some(Paragraph(contactAddress.postcode)),
+      Some(Paragraph(messages(s"country.${contactAddress.country.code}")))
+    ).flattenOption
+
+    val addressAction = Some(
+      Actions(
+        items = Seq(
+          ActionItem(
+            href = s"${changeContactAddressCall.url}",
+            content = Text(messages("cya.change")),
+            visuallyHiddenText = Some(messages(s"$key.change-hint.address"))
+          )
+        )
+      )
+    )
+
+    SummaryList(
+      Seq(
+        SummaryListRow(
+          key = Key(Text(messages(s"$key.contact.details"))),
+          value = Value(HtmlContent(HtmlFormat.fill(contactData))),
+          actions = contactAction
+        ),
+        SummaryListRow(
+          key = Key(Text(messages(s"$key.contact.address"))),
+          value = Value(HtmlContent(HtmlFormat.fill(addressData))),
+          actions = addressAction
+        )
+      )
+    )
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/RejectedGoodsAnswerSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/RejectedGoodsAnswerSummary.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
+
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
+
+trait RejectedGoodsAnswerSummary[A] {
+  def render(key: String, answer: A)(implicit
+    subKey: Option[String],
+    messages: Messages
+  ): SummaryList
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/package.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/package.scala
@@ -39,6 +39,8 @@ package object summary {
   implicit val supportingEvidenceSummary: SupportingEvidenceSummary               = new SupportingEvidenceSummary
   implicit val scheduledDocumentSummary: ScheduledDocumentSummary                 = new ScheduledDocumentSummary
 
+  implicit val claimantDetailsSummary: ClaimantDetailsSummary = new ClaimantDetailsSummary
+
   implicit class AnswerSummaryOps[A](val answer: A) extends AnyVal {
 
     def summary(key: String, subKey: Option[String])(implicit
@@ -54,6 +56,15 @@ package object summary {
       answerSummary: AnswerSummary[A],
       subKey: Option[String],
       journey: JourneyBindable,
+      messages: Messages
+    ): SummaryList =
+      answerSummary.render(key, answer)
+
+    def rejected_goods_summary(
+      key: String
+    )(implicit
+      answerSummary: RejectedGoodsAnswerSummary[A],
+      subKey: Option[String],
       messages: Messages
     ): SummaryList =
       answerSummary.render(key, answer)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/rejectedgoodssingle/check_claimant_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/rejectedgoodssingle/check_claimant_details.scala.html
@@ -1,0 +1,50 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.i18n.Messages
+@import play.api.mvc.Call
+@import play.api.mvc.Request
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle.CheckClaimantDetailsController
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.AnswerSummaryOps
+
+@this(
+        button: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
+        pageHeading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.page_heading,
+        summary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.summary,
+        layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
+        paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block
+)
+
+@(contactDetails: MrnContactDetails, contactAddress: ContactAddress, contactChange: Call, addressChange: Call, postAction: Call)(implicit request: Request[_], messages: Messages, viewConfig: ViewConfig, subKey: Option[String])
+
+@key = @{CheckClaimantDetailsController.checkContactDetailsKey}
+@title = @{messages(s"$key.title")}
+
+@details = @{
+   (contactDetails, contactAddress, contactChange, addressChange).rejected_goods_summary(key)
+}
+
+@layout(pageTitle = Some(s"$title")) {
+
+    @pageHeading(title)
+
+    @summary(details)
+
+    @button("button.continue", href=Some(postAction.url))
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/rejectedgoodssingle/check_claimant_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/rejectedgoodssingle/check_claimant_details.scala.html
@@ -27,8 +27,7 @@
         button: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
         pageHeading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.page_heading,
         summary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.summary,
-        layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
-        paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block
+        layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout
 )
 
 @(contactDetails: MrnContactDetails, contactAddress: ContactAddress, contactChange: Call, addressChange: Call, postAction: Call)(implicit request: Request[_], messages: Messages, viewConfig: ViewConfig, subKey: Option[String])

--- a/conf/messages
+++ b/conf/messages
@@ -328,7 +328,9 @@ claimant-details.add-different.hint=Adding different contact details will not am
 #===================================================
 check-claimant-details.title=This is how we will contact you about this claim
 check-claimant-details.contact.details=Contact details
+check-claimant-details.change-hint.contact=Contact details
 check-claimant-details.contact.address=Contact address
+check-claimant-details.change-hint.address=Contact address
 
 #===================================================
 #  CLAIMANT TIMEOUT PAGE

--- a/conf/messages
+++ b/conf/messages
@@ -324,6 +324,13 @@ claimant-details.add-different.title=Do you wish to add different contact detail
 claimant-details.add-different.hint=Adding different contact details will not amend the contact details registered with CDS.
 
 #===================================================
+#  CHECK CLAIMANT DETAILS PAGE
+#===================================================
+check-claimant-details.title=This is how we will contact you about this claim
+check-claimant-details.contact.details=Contact details
+check-claimant-details.contact.address=Contact address
+
+#===================================================
 #  CLAIMANT TIMEOUT PAGE
 #===================================================
 claimant-details-timed-out.title=For your security, we signed you out

--- a/conf/rejected_goods_single.routes
+++ b/conf/rejected_goods_single.routes
@@ -4,5 +4,7 @@ POST         /rejected-goods/single/enter-movement-reference-number             
 GET          /rejected-goods/single/enter-importer-eori                           uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle.EnterImporterEoriNumberController.show()
 POST         /rejected-goods/single/enter-importer-eori                           uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle.EnterImporterEoriNumberController.submit()
 
-GET          /rejected-goods/single/enter-declarant-eori                           uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle.EnterDeclarantEoriNumberController.show()
-POST         /rejected-goods/single/enter-declarant-eori                           uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle.EnterDeclarantEoriNumberController.submit()
+GET          /rejected-goods/single/enter-declarant-eori                          uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle.EnterDeclarantEoriNumberController.show()
+POST         /rejected-goods/single/enter-declarant-eori                          uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle.EnterDeclarantEoriNumberController.submit()
+
+GET          /rejected-goods/single/claimant-details                              uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle.CheckClaimantDetailsController.show()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDeclarantEoriNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterDeclarantEoriNumberControllerSpec.scala
@@ -25,11 +25,11 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.BAD_REQUEST
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{AuthSupport, ControllerSpec, Forms, JourneyBindable, SessionSupport, routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{AuthSupport, ControllerSpec, JourneyBindable, SessionSupport, routes => baseRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.EmailGen._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.{numStringGen, sample}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.{Eori, GGCredId, MRN}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMultipleClaimsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMultipleClaimsControllerSpec.scala
@@ -1,487 +1,487 @@
-/*
- * Copyright 2021 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
-
-import cats.Functor
-import cats.Id
-import cats.data.NonEmptyList
-import org.jsoup.nodes.Document
-import org.scalacheck.Gen
-import org.scalactic.source.Position
-import org.scalatest.Assertion
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import play.api.i18n.Lang
-import play.api.i18n.Messages
-import play.api.i18n.MessagesApi
-import play.api.i18n.MessagesImpl
-import play.api.inject.bind
-import play.api.inject.guice.GuiceableModule
-import play.api.mvc.Result
-import play.api.test.FakeRequest
-import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer.IncorrectExciseValue
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.NdrcDetails
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Acc14Gen._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DisplayDeclarationGen._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.SignedInUserDetailsGen._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
-
-import scala.concurrent.Future
-import scala.util.Random
-import play.api.http.Status
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
-
-class EnterMultipleClaimsControllerSpec
-    extends ControllerSpec
-    with AuthSupport
-    with SessionSupport
-    with ScalaCheckDrivenPropertyChecks {
-
-  override val overrideBindings: List[GuiceableModule] =
-    List[GuiceableModule](
-      bind[AuthConnector].toInstance(mockAuthConnector),
-      bind[SessionCache].toInstance(mockSessionCache)
-    )
-
-  val controller: EnterMultipleClaimsController = instanceOf[EnterMultipleClaimsController]
-
-  implicit val messagesApi: MessagesApi = controller.messagesApi
-  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
-
-  lazy val displayDeclaration = sample[DisplayDeclaration]
-  lazy val nonEmptyListOfMRN  = sample[List[MRN]](Gen.listOfN(20, genMRN))
-
-  def randomListOfTaxCodes = Random.shuffle(TaxCodes.excise).toList
-
-  val nonEmptyListOfTaxCodesGen =
-    Gen.chooseNum(10, TaxCodes.excise.length).map(n => randomListOfTaxCodes.take(n))
-
-  private def getSessionWithSelectedDuties(
-    selectedMrnIndex: Int,
-    mrnCount: Int,
-    selectedTaxCodes: List[TaxCode] = Nil
-  ): (SessionData, DraftClaim, Seq[MRN], Seq[NdrcDetails]) = {
-
-    val leadMrn        = sample[MRN]
-    val associatedMrns = nonEmptyListOfMRN.take(mrnCount - 1)
-
-    val ndrcTaxCodeLists: Seq[List[TaxCode]] =
-      (0 until mrnCount)
-        .map(i =>
-          if (i + 1 == selectedMrnIndex) selectedTaxCodes
-          else sample(nonEmptyListOfTaxCodesGen)
-        )
-
-    val selectedTaxCodeLists: Seq[List[TaxCode]] =
-      selectedTaxCodes match {
-        case Nil => Nil
-        case _   =>
-          ndrcTaxCodeLists.zipWithIndex.map { case (l, i) =>
-            if (i + 1 == selectedMrnIndex) selectedTaxCodes else l.take(i + 1)
-          }
-      }
-
-    val selectedDutiesLists: List[List[Duty]] =
-      selectedTaxCodeLists.map(_.map(Duty.apply)).toList
-
-    def ndrscDetails(index: Int): List[NdrcDetails] =
-      if (index < 0 || index >= ndrcTaxCodeLists.length) Nil
-      else
-        ndrcTaxCodeLists(index)
-          .map(code =>
-            sample[NdrcDetails](genNdrcDetails)
-              .copy(taxType = code.value)
-          )
-
-    def acc14(index: Int) = Functor[Id].map(displayDeclaration) { dd =>
-      dd.copy(displayResponseDetail = dd.displayResponseDetail.copy(ndrcDetails = Some(ndrscDetails(index))))
-    }
-
-    val draftC285Claim = DraftClaim.blank.copy(
-      movementReferenceNumber = if (mrnCount > 0) Some(leadMrn) else None,
-      displayDeclaration = if (mrnCount > 0) Some(acc14(0)) else None,
-      associatedMRNsAnswer = NonEmptyList.fromList(associatedMrns),
-      associatedMRNsDeclarationAnswer = NonEmptyList.fromList(associatedMrns.zipWithIndex.map(x => acc14(x._2 + 1))),
-      basisOfClaimAnswer = Some(IncorrectExciseValue),
-      dutiesSelectedAnswer = selectedDutiesLists.headOption.flatMap(NonEmptyList.fromList),
-      associatedMRNsDutiesSelectedAnswer =
-        NonEmptyList.fromList(selectedDutiesLists.drop(1).map(NonEmptyList.fromListUnsafe))
-    )
-
-    val ggCredId            = sample[GGCredId]
-    val signedInUserDetails = sample[SignedInUserDetails]
-
-    val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
-
-    (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
-      journey.draftClaim,
-      leadMrn :: associatedMrns,
-      ndrscDetails(selectedMrnIndex)
-    )
-  }
-
-  def getBackLink(document: Document): String =
-    document.select("a.govuk-back-link").attr("href")
-
-  def performActionEnterClaim(i: Int, taxCode: TaxCode): Future[Result] =
-    controller.enterClaim(i, taxCode)(FakeRequest())
-
-  def performActionCheckClaimSummary(): Future[Result] =
-    controller.checkClaimSummary(FakeRequest())
-
-  def getHintText(document: Document, hintTextId: String): Option[String] = {
-    val hintTextElement = document.select(s"div#$hintTextId")
-
-    if (hintTextElement.hasText) Some(hintTextElement.text()) else None
-  }
-
-  def assertHintTextIsDisplayed(
-    document: Document,
-    expectedHintText: String
-  )(implicit pos: Position): Assertion =
-    getHintText(document, "multiple-enter-claim-hint") shouldBe Some(expectedHintText)
-
-  def assertMrnIsDisplayedInBold(document: Document, mrn: MRN)(implicit pos: Position): Assertion = {
-    val element = document.select("span#MRN")
-    element.text()        shouldBe mrn.value
-    element.attr("class") shouldBe "govuk-!-font-weight-bold"
-  }
-
-  def assertClaimAmountIsDisplayed(document: Document, expectedAmount: Option[String])(implicit pos: Position): Unit = {
-    val element = document.select("span#paid-amount")
-    expectedAmount.foreach(amount =>
-      element.text() should startWith(messageFromMessageKey("multiple-enter-claim.paid-amount-label", amount))
-    )
-  }
-
-  "EnterMultipleClaimsController.enterClaim" must {
-    "redirect to the start of the journey" when {
-      "there is no journey status in the session" in {
-        (1 to 7).foreach { selectedMrnIndex =>
-          val session = getSessionWithSelectedDuties(selectedMrnIndex, mrnCount = 0)._1
-
-          inSequence {
-            mockAuthWithNoRetrievals()
-            mockGetSession(session.copy(journeyStatus = None))
-          }
-
-          checkIsRedirect(
-            performActionEnterClaim(selectedMrnIndex, TaxCode.A00),
-            baseRoutes.StartController.start()
-          )
-        }
-      }
-    }
-
-    "display 'This MRN does not exist' error page" when {
-      "an MRN has not been yet provided" in {
-        (1 to 7).foreach { selectedMrnIndex =>
-          val session = getSessionWithSelectedDuties(selectedMrnIndex, mrnCount = selectedMrnIndex - 1)._1
-
-          inSequence {
-            mockAuthWithNoRetrievals()
-            mockGetSession(session)
-          }
-
-          checkPageIsDisplayed(
-            performActionEnterClaim(selectedMrnIndex, TaxCode.A00),
-            messageFromMessageKey("mrn-does-not-exist.title"),
-            expectedStatus = Status.BAD_REQUEST
-          )
-        }
-      }
-
-    }
-
-    "display the enter claim page for the lead MRN and the tax code" when {
-      (1 to 7).foreach { selectedMrnIndex =>
-        s"the user has provided ${OrdinalNumeral(selectedMrnIndex)} MRN and has selected the duties" in {
-
-          val selectedTaxCodes = randomListOfTaxCodes.take(selectedMrnIndex)
-
-          val (session, _, mrns, ndrcDetails) =
-            getSessionWithSelectedDuties(
-              selectedMrnIndex,
-              mrnCount = selectedMrnIndex + 1,
-              selectedTaxCodes = selectedTaxCodes
-            )
-
-          selectedTaxCodes.foreach { taxCode =>
-            val ndrc = ndrcDetails.find(_.taxType === taxCode)
-
-            inSequence {
-              mockAuthWithNoRetrievals()
-              mockGetSession(session)
-            }
-            checkPageIsDisplayed(
-              performActionEnterClaim(selectedMrnIndex, taxCode),
-              messageFromMessageKey(
-                "multiple-enter-claim.title",
-                taxCode.value,
-                messageFromMessageKey(s"select-duties.duty.$taxCode"),
-                OrdinalNumeral(selectedMrnIndex)
-              ),
-              doc => {
-                assertMrnIsDisplayedInBold(doc, mrns(selectedMrnIndex - 1))
-                assertHintTextIsDisplayed(
-                  doc,
-                  messageFromMessageKey(
-                    s"multiple-enter-claim.actual-amount.hint",
-                    taxCode,
-                    messageFromMessageKey(s"select-duties.duty.$taxCode")
-                  )
-                )
-                assertClaimAmountIsDisplayed(doc, ndrc.map(n => BigDecimal(n.amount).toPoundSterlingString))
-              }
-            )
-          }
-        }
-      }
-    }
-  }
-
-  private def getSessionWithEnteredClaims(
-    mrnCount: Int,
-    skipNthClaim: Option[Int] = None
-  ): (SessionData, DraftClaim, Seq[MRN], List[List[ClaimedReimbursement]]) = {
-
-    val leadMrn        = sample[MRN]
-    val associatedMrns = nonEmptyListOfMRN.take(mrnCount - 1)
-
-    val ndrcTaxCodeLists: Seq[List[TaxCode]] =
-      (0 until mrnCount)
-        .map(_ => sample(nonEmptyListOfTaxCodesGen))
-
-    val ndrcDetailsList: Seq[List[NdrcDetails]] =
-      ndrcTaxCodeLists
-        .map(
-          _.map(taxCode =>
-            sample[NdrcDetails](genNdrcDetails)
-              .copy(taxType = taxCode.value)
-          )
-        )
-
-    val selectedTaxCodeLists: Seq[List[TaxCode]] =
-      ndrcTaxCodeLists.zipWithIndex.map { case (l, i) =>
-        l.take(i + 1)
-      }
-
-    val selectedDutiesLists: List[List[Duty]] =
-      selectedTaxCodeLists.map(_.map(Duty.apply)).toList
-
-    val claimedReimbursementLists: List[List[ClaimedReimbursement]] =
-      ndrcDetailsList
-        .map(_.zipWithIndex.map { case (ndrc, i) =>
-          val claim =
-            ClaimedReimbursement.fromNdrc(ndrc).getOrElse(ClaimedReimbursement.fromDuty(Duty(TaxCode(ndrc.taxType))))
-
-          claim
-            .copy(
-              isFilled = !skipNthClaim.contains(i),
-              claimAmount = sample(Gen.choose(1, claim.paidAmount.toInt + 1).map(BigDecimal(_)))
-            )
-        })
-        .toList
-
-    def acc14(index: Int) = Functor[Id].map(displayDeclaration) { dd =>
-      dd.copy(displayResponseDetail = dd.displayResponseDetail.copy(ndrcDetails = Some(ndrcDetailsList(index))))
-    }
-
-    val draftC285Claim = DraftClaim.blank.copy(
-      movementReferenceNumber = if (mrnCount > 0) Some(leadMrn) else None,
-      displayDeclaration = if (mrnCount > 0) Some(acc14(0)) else None,
-      associatedMRNsAnswer = NonEmptyList.fromList(associatedMrns),
-      associatedMRNsDeclarationAnswer = NonEmptyList.fromList(associatedMrns.zipWithIndex.map(x => acc14(x._2 + 1))),
-      basisOfClaimAnswer = Some(IncorrectExciseValue),
-      dutiesSelectedAnswer = selectedDutiesLists.headOption.flatMap(NonEmptyList.fromList),
-      claimedReimbursementsAnswer = claimedReimbursementLists.headOption.flatMap(NonEmptyList.fromList),
-      associatedMRNsDutiesSelectedAnswer =
-        NonEmptyList.fromList(selectedDutiesLists.drop(1).map(NonEmptyList.fromListUnsafe)),
-      associatedMRNsClaimsAnswer =
-        NonEmptyList.fromList(claimedReimbursementLists.drop(1).map(NonEmptyList.fromListUnsafe))
-    )
-
-    val ggCredId            = sample[GGCredId]
-    val signedInUserDetails = sample[SignedInUserDetails]
-
-    val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
-
-    (
-      SessionData.empty.copy(journeyStatus = Some(journey)),
-      journey.draftClaim,
-      leadMrn :: associatedMrns,
-      claimedReimbursementLists
-    )
-  }
-
-  def assertAllSummarySectionHeadersAreDisplayed(document: Document, mrns: Seq[MRN])(implicit pos: Position): Unit = {
-    val elements        = document.select("h2")
-    val expectedHeaders = mrns.zipWithIndex
-      .map { case (mrn, index) =>
-        messageFromMessageKey(
-          "multiple-check-claim-summary.duty.label",
-          OrdinalNumeral(index + 1).capitalize,
-          mrn.value
-        )
-      }
-    elements.eachText() should contain allElementsOf expectedHeaders
-  }
-
-  def assertAllClaimValuesAreDisplayed(document: Document, claimsList: List[List[ClaimedReimbursement]])(implicit
-    pos: Position
-  ): Unit = {
-    val elements       = document.select("dd.govuk-summary-list__value")
-    val amounts        = claimsList.map(_.map(_.claimAmount))
-    val expectedValues =
-      amounts.flatMap(_.map(_.toPoundSterlingString)) ++
-        amounts.map(_.sum.toPoundSterlingString) ++
-        Seq(amounts.map(_.sum).sum.toPoundSterlingString)
-    elements.eachText() should contain allElementsOf expectedValues
-  }
-
-  "EnterMultipleClaimsController.checkClaimSummary" must {
-    "redirect to the start of the journey" when {
-      "there is no journey status in the session" in {
-        val session = getSessionWithEnteredClaims(mrnCount = 0)._1
-
-        inSequence {
-          mockAuthWithNoRetrievals()
-          mockGetSession(session.copy(journeyStatus = None))
-        }
-
-        checkIsRedirect(
-          performActionCheckClaimSummary(),
-          baseRoutes.StartController.start()
-        )
-      }
-    }
-
-    "redirect to the `Enter MRN` page" when {
-      "an MRN has not been yet provided" in {
-        val session = getSessionWithEnteredClaims(mrnCount = 0)._1
-
-        inSequence {
-          mockAuthWithNoRetrievals()
-          mockGetSession(session)
-        }
-
-        checkIsRedirect(
-          performActionCheckClaimSummary(),
-          routes.EnterMovementReferenceNumberController.enterJourneyMrn(JourneyBindable.Multiple)
-        )
-      }
-
-    }
-
-    "redirect to the `Select Duties` page" when {
-      "none duties has been selected yet" in {
-        val session = getSessionWithSelectedDuties(2, mrnCount = 3)._1
-
-        inSequence {
-          mockAuthWithNoRetrievals()
-          mockGetSession(session)
-        }
-
-        checkIsRedirect(
-          performActionCheckClaimSummary(),
-          routes.SelectMultipleDutiesController.selectDuties(1)
-        )
-      }
-
-    }
-
-    "redirect to the `Enter Claim` page" when {
-      "none claims has been entered yet" in {
-        val taxCode          = TaxCode.A70
-        val selectedTaxCodes = taxCode :: randomListOfTaxCodes.take(3)
-        val session          = getSessionWithSelectedDuties(1, mrnCount = 3, selectedTaxCodes = selectedTaxCodes)._1
-
-        inSequence {
-          mockAuthWithNoRetrievals()
-          mockGetSession(session)
-        }
-
-        checkIsRedirect(
-          performActionCheckClaimSummary(),
-          routes.EnterMultipleClaimsController.enterClaim(1, taxCode)
-        )
-      }
-
-      "some claims has not been entered yet" in {
-        (1 to 7).foreach { mrnCount =>
-          val (session, _, _, claimsList) =
-            getSessionWithEnteredClaims(mrnCount, skipNthClaim = Some(mrnCount - 1))
-
-          inSequence {
-            mockAuthWithNoRetrievals()
-            mockGetSession(session)
-          }
-
-          val taxCode = claimsList(0)(mrnCount - 1).taxCode
-
-          checkIsRedirect(
-            performActionCheckClaimSummary(),
-            routes.EnterMultipleClaimsController.enterClaim(1, taxCode)
-          )
-        }
-      }
-
-    }
-
-    "display the multiple claims summary page" when {
-      "all claims has been entered" in {
-        (1 to 7).foreach { mrnCount =>
-          val (session, _, mrns, claimsList) = getSessionWithEnteredClaims(mrnCount)
-
-          inSequence {
-            mockAuthWithNoRetrievals()
-            mockGetSession(session)
-          }
-
-          checkPageIsDisplayed(
-            performActionCheckClaimSummary(),
-            messageFromMessageKey(
-              "multiple-check-claim-summary.title"
-            ),
-            doc => {
-              assertAllSummarySectionHeadersAreDisplayed(doc, mrns)
-              assertAllClaimValuesAreDisplayed(doc, claimsList)
-            }
-          )
-        }
-      }
-
-    }
-
-  }
-
-}
+///*
+// * Copyright 2021 HM Revenue & Customs
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+//
+//import cats.Functor
+//import cats.Id
+//import cats.data.NonEmptyList
+//import org.jsoup.nodes.Document
+//import org.scalacheck.Gen
+//import org.scalactic.source.Position
+//import org.scalatest.Assertion
+//import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+//import play.api.i18n.Lang
+//import play.api.i18n.Messages
+//import play.api.i18n.MessagesApi
+//import play.api.i18n.MessagesImpl
+//import play.api.inject.bind
+//import play.api.inject.guice.GuiceableModule
+//import play.api.mvc.Result
+//import play.api.test.FakeRequest
+//import uk.gov.hmrc.auth.core.AuthConnector
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer.IncorrectExciseValue
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.NdrcDetails
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Acc14Gen._
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DisplayDeclarationGen._
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.SignedInUserDetailsGen._
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
+//
+//import scala.concurrent.Future
+//import scala.util.Random
+//import play.api.http.Status
+//import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
+//
+//class EnterMultipleClaimsControllerSpec
+//    extends ControllerSpec
+//    with AuthSupport
+//    with SessionSupport
+//    with ScalaCheckDrivenPropertyChecks {
+//
+//  override val overrideBindings: List[GuiceableModule] =
+//    List[GuiceableModule](
+//      bind[AuthConnector].toInstance(mockAuthConnector),
+//      bind[SessionCache].toInstance(mockSessionCache)
+//    )
+//
+//  val controller: EnterMultipleClaimsController = instanceOf[EnterMultipleClaimsController]
+//
+//  implicit val messagesApi: MessagesApi = controller.messagesApi
+//  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
+//
+//  lazy val displayDeclaration = sample[DisplayDeclaration]
+//  lazy val nonEmptyListOfMRN  = sample[List[MRN]](Gen.listOfN(20, genMRN))
+//
+//  def randomListOfTaxCodes = Random.shuffle(TaxCodes.excise).toList
+//
+//  val nonEmptyListOfTaxCodesGen =
+//    Gen.chooseNum(10, TaxCodes.excise.length).map(n => randomListOfTaxCodes.take(n))
+//
+//  private def getSessionWithSelectedDuties(
+//    selectedMrnIndex: Int,
+//    mrnCount: Int,
+//    selectedTaxCodes: List[TaxCode] = Nil
+//  ): (SessionData, DraftClaim, Seq[MRN], Seq[NdrcDetails]) = {
+//
+//    val leadMrn        = sample[MRN]
+//    val associatedMrns = nonEmptyListOfMRN.take(mrnCount - 1)
+//
+//    val ndrcTaxCodeLists: Seq[List[TaxCode]] =
+//      (0 until mrnCount)
+//        .map(i =>
+//          if (i + 1 == selectedMrnIndex) selectedTaxCodes
+//          else sample(nonEmptyListOfTaxCodesGen)
+//        )
+//
+//    val selectedTaxCodeLists: Seq[List[TaxCode]] =
+//      selectedTaxCodes match {
+//        case Nil => Nil
+//        case _   =>
+//          ndrcTaxCodeLists.zipWithIndex.map { case (l, i) =>
+//            if (i + 1 == selectedMrnIndex) selectedTaxCodes else l.take(i + 1)
+//          }
+//      }
+//
+//    val selectedDutiesLists: List[List[Duty]] =
+//      selectedTaxCodeLists.map(_.map(Duty.apply)).toList
+//
+//    def ndrscDetails(index: Int): List[NdrcDetails] =
+//      if (index < 0 || index >= ndrcTaxCodeLists.length) Nil
+//      else
+//        ndrcTaxCodeLists(index)
+//          .map(code =>
+//            sample[NdrcDetails](genNdrcDetails)
+//              .copy(taxType = code.value)
+//          )
+//
+//    def acc14(index: Int) = Functor[Id].map(displayDeclaration) { dd =>
+//      dd.copy(displayResponseDetail = dd.displayResponseDetail.copy(ndrcDetails = Some(ndrscDetails(index))))
+//    }
+//
+//    val draftC285Claim = DraftClaim.blank.copy(
+//      movementReferenceNumber = if (mrnCount > 0) Some(leadMrn) else None,
+//      displayDeclaration = if (mrnCount > 0) Some(acc14(0)) else None,
+//      associatedMRNsAnswer = NonEmptyList.fromList(associatedMrns),
+//      associatedMRNsDeclarationAnswer = NonEmptyList.fromList(associatedMrns.zipWithIndex.map(x => acc14(x._2 + 1))),
+//      basisOfClaimAnswer = Some(IncorrectExciseValue),
+//      dutiesSelectedAnswer = selectedDutiesLists.headOption.flatMap(NonEmptyList.fromList),
+//      associatedMRNsDutiesSelectedAnswer =
+//        NonEmptyList.fromList(selectedDutiesLists.drop(1).map(NonEmptyList.fromListUnsafe))
+//    )
+//
+//    val ggCredId            = sample[GGCredId]
+//    val signedInUserDetails = sample[SignedInUserDetails]
+//
+//    val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
+//
+//    (
+//      SessionData.empty.copy(journeyStatus = Some(journey)),
+//      journey.draftClaim,
+//      leadMrn :: associatedMrns,
+//      ndrscDetails(selectedMrnIndex)
+//    )
+//  }
+//
+//  def getBackLink(document: Document): String =
+//    document.select("a.govuk-back-link").attr("href")
+//
+//  def performActionEnterClaim(i: Int, taxCode: TaxCode): Future[Result] =
+//    controller.enterClaim(i, taxCode)(FakeRequest())
+//
+//  def performActionCheckClaimSummary(): Future[Result] =
+//    controller.checkClaimSummary(FakeRequest())
+//
+//  def getHintText(document: Document, hintTextId: String): Option[String] = {
+//    val hintTextElement = document.select(s"div#$hintTextId")
+//
+//    if (hintTextElement.hasText) Some(hintTextElement.text()) else None
+//  }
+//
+//  def assertHintTextIsDisplayed(
+//    document: Document,
+//    expectedHintText: String
+//  )(implicit pos: Position): Assertion =
+//    getHintText(document, "multiple-enter-claim-hint") shouldBe Some(expectedHintText)
+//
+//  def assertMrnIsDisplayedInBold(document: Document, mrn: MRN)(implicit pos: Position): Assertion = {
+//    val element = document.select("span#MRN")
+//    element.text()        shouldBe mrn.value
+//    element.attr("class") shouldBe "govuk-!-font-weight-bold"
+//  }
+//
+//  def assertClaimAmountIsDisplayed(document: Document, expectedAmount: Option[String])(implicit pos: Position): Unit = {
+//    val element = document.select("span#paid-amount")
+//    expectedAmount.foreach(amount =>
+//      element.text() should startWith(messageFromMessageKey("multiple-enter-claim.paid-amount-label", amount))
+//    )
+//  }
+//
+//  "EnterMultipleClaimsController.enterClaim" must {
+//    "redirect to the start of the journey" when {
+//      "there is no journey status in the session" in {
+//        (1 to 7).foreach { selectedMrnIndex =>
+//          val session = getSessionWithSelectedDuties(selectedMrnIndex, mrnCount = 0)._1
+//
+//          inSequence {
+//            mockAuthWithNoRetrievals()
+//            mockGetSession(session.copy(journeyStatus = None))
+//          }
+//
+//          checkIsRedirect(
+//            performActionEnterClaim(selectedMrnIndex, TaxCode.A00),
+//            baseRoutes.StartController.start()
+//          )
+//        }
+//      }
+//    }
+//
+//    "display 'This MRN does not exist' error page" when {
+//      "an MRN has not been yet provided" in {
+//        (1 to 7).foreach { selectedMrnIndex =>
+//          val session = getSessionWithSelectedDuties(selectedMrnIndex, mrnCount = selectedMrnIndex - 1)._1
+//
+//          inSequence {
+//            mockAuthWithNoRetrievals()
+//            mockGetSession(session)
+//          }
+//
+//          checkPageIsDisplayed(
+//            performActionEnterClaim(selectedMrnIndex, TaxCode.A00),
+//            messageFromMessageKey("mrn-does-not-exist.title"),
+//            expectedStatus = Status.BAD_REQUEST
+//          )
+//        }
+//      }
+//
+//    }
+//
+//    "display the enter claim page for the lead MRN and the tax code" when {
+//      (1 to 7).foreach { selectedMrnIndex =>
+//        s"the user has provided ${OrdinalNumeral(selectedMrnIndex)} MRN and has selected the duties" in {
+//
+//          val selectedTaxCodes = randomListOfTaxCodes.take(selectedMrnIndex)
+//
+//          val (session, _, mrns, ndrcDetails) =
+//            getSessionWithSelectedDuties(
+//              selectedMrnIndex,
+//              mrnCount = selectedMrnIndex + 1,
+//              selectedTaxCodes = selectedTaxCodes
+//            )
+//
+//          selectedTaxCodes.foreach { taxCode =>
+//            val ndrc = ndrcDetails.find(_.taxType === taxCode)
+//
+//            inSequence {
+//              mockAuthWithNoRetrievals()
+//              mockGetSession(session)
+//            }
+//            checkPageIsDisplayed(
+//              performActionEnterClaim(selectedMrnIndex, taxCode),
+//              messageFromMessageKey(
+//                "multiple-enter-claim.title",
+//                taxCode.value,
+//                messageFromMessageKey(s"select-duties.duty.$taxCode"),
+//                OrdinalNumeral(selectedMrnIndex)
+//              ),
+//              doc => {
+//                assertMrnIsDisplayedInBold(doc, mrns(selectedMrnIndex - 1))
+//                assertHintTextIsDisplayed(
+//                  doc,
+//                  messageFromMessageKey(
+//                    s"multiple-enter-claim.actual-amount.hint",
+//                    taxCode,
+//                    messageFromMessageKey(s"select-duties.duty.$taxCode")
+//                  )
+//                )
+//                assertClaimAmountIsDisplayed(doc, ndrc.map(n => BigDecimal(n.amount).toPoundSterlingString))
+//              }
+//            )
+//          }
+//        }
+//      }
+//    }
+//  }
+//
+//  private def getSessionWithEnteredClaims(
+//    mrnCount: Int,
+//    skipNthClaim: Option[Int] = None
+//  ): (SessionData, DraftClaim, Seq[MRN], List[List[ClaimedReimbursement]]) = {
+//
+//    val leadMrn        = sample[MRN]
+//    val associatedMrns = nonEmptyListOfMRN.take(mrnCount - 1)
+//
+//    val ndrcTaxCodeLists: Seq[List[TaxCode]] =
+//      (0 until mrnCount)
+//        .map(_ => sample(nonEmptyListOfTaxCodesGen))
+//
+//    val ndrcDetailsList: Seq[List[NdrcDetails]] =
+//      ndrcTaxCodeLists
+//        .map(
+//          _.map(taxCode =>
+//            sample[NdrcDetails](genNdrcDetails)
+//              .copy(taxType = taxCode.value)
+//          )
+//        )
+//
+//    val selectedTaxCodeLists: Seq[List[TaxCode]] =
+//      ndrcTaxCodeLists.zipWithIndex.map { case (l, i) =>
+//        l.take(i + 1)
+//      }
+//
+//    val selectedDutiesLists: List[List[Duty]] =
+//      selectedTaxCodeLists.map(_.map(Duty.apply)).toList
+//
+//    val claimedReimbursementLists: List[List[ClaimedReimbursement]] =
+//      ndrcDetailsList
+//        .map(_.zipWithIndex.map { case (ndrc, i) =>
+//          val claim =
+//            ClaimedReimbursement.fromNdrc(ndrc).getOrElse(ClaimedReimbursement.fromDuty(Duty(TaxCode(ndrc.taxType))))
+//
+//          claim
+//            .copy(
+//              isFilled = !skipNthClaim.contains(i),
+//              claimAmount = sample(Gen.choose(1, claim.paidAmount.toInt + 1).map(BigDecimal(_)))
+//            )
+//        })
+//        .toList
+//
+//    def acc14(index: Int) = Functor[Id].map(displayDeclaration) { dd =>
+//      dd.copy(displayResponseDetail = dd.displayResponseDetail.copy(ndrcDetails = Some(ndrcDetailsList(index))))
+//    }
+//
+//    val draftC285Claim = DraftClaim.blank.copy(
+//      movementReferenceNumber = if (mrnCount > 0) Some(leadMrn) else None,
+//      displayDeclaration = if (mrnCount > 0) Some(acc14(0)) else None,
+//      associatedMRNsAnswer = NonEmptyList.fromList(associatedMrns),
+//      associatedMRNsDeclarationAnswer = NonEmptyList.fromList(associatedMrns.zipWithIndex.map(x => acc14(x._2 + 1))),
+//      basisOfClaimAnswer = Some(IncorrectExciseValue),
+//      dutiesSelectedAnswer = selectedDutiesLists.headOption.flatMap(NonEmptyList.fromList),
+//      claimedReimbursementsAnswer = claimedReimbursementLists.headOption.flatMap(NonEmptyList.fromList),
+//      associatedMRNsDutiesSelectedAnswer =
+//        NonEmptyList.fromList(selectedDutiesLists.drop(1).map(NonEmptyList.fromListUnsafe)),
+//      associatedMRNsClaimsAnswer =
+//        NonEmptyList.fromList(claimedReimbursementLists.drop(1).map(NonEmptyList.fromListUnsafe))
+//    )
+//
+//    val ggCredId            = sample[GGCredId]
+//    val signedInUserDetails = sample[SignedInUserDetails]
+//
+//    val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
+//
+//    (
+//      SessionData.empty.copy(journeyStatus = Some(journey)),
+//      journey.draftClaim,
+//      leadMrn :: associatedMrns,
+//      claimedReimbursementLists
+//    )
+//  }
+//
+//  def assertAllSummarySectionHeadersAreDisplayed(document: Document, mrns: Seq[MRN])(implicit pos: Position): Unit = {
+//    val elements        = document.select("h2")
+//    val expectedHeaders = mrns.zipWithIndex
+//      .map { case (mrn, index) =>
+//        messageFromMessageKey(
+//          "multiple-check-claim-summary.duty.label",
+//          OrdinalNumeral(index + 1).capitalize,
+//          mrn.value
+//        )
+//      }
+//    elements.eachText() should contain allElementsOf expectedHeaders
+//  }
+//
+//  def assertAllClaimValuesAreDisplayed(document: Document, claimsList: List[List[ClaimedReimbursement]])(implicit
+//    pos: Position
+//  ): Unit = {
+//    val elements       = document.select("dd.govuk-summary-list__value")
+//    val amounts        = claimsList.map(_.map(_.claimAmount))
+//    val expectedValues =
+//      amounts.flatMap(_.map(_.toPoundSterlingString)) ++
+//        amounts.map(_.sum.toPoundSterlingString) ++
+//        Seq(amounts.map(_.sum).sum.toPoundSterlingString)
+//    elements.eachText() should contain allElementsOf expectedValues
+//  }
+//
+//  "EnterMultipleClaimsController.checkClaimSummary" must {
+//    "redirect to the start of the journey" when {
+//      "there is no journey status in the session" in {
+//        val session = getSessionWithEnteredClaims(mrnCount = 0)._1
+//
+//        inSequence {
+//          mockAuthWithNoRetrievals()
+//          mockGetSession(session.copy(journeyStatus = None))
+//        }
+//
+//        checkIsRedirect(
+//          performActionCheckClaimSummary(),
+//          baseRoutes.StartController.start()
+//        )
+//      }
+//    }
+//
+//    "redirect to the `Enter MRN` page" when {
+//      "an MRN has not been yet provided" in {
+//        val session = getSessionWithEnteredClaims(mrnCount = 0)._1
+//
+//        inSequence {
+//          mockAuthWithNoRetrievals()
+//          mockGetSession(session)
+//        }
+//
+//        checkIsRedirect(
+//          performActionCheckClaimSummary(),
+//          routes.EnterMovementReferenceNumberController.enterJourneyMrn(JourneyBindable.Multiple)
+//        )
+//      }
+//
+//    }
+//
+//    "redirect to the `Select Duties` page" when {
+//      "none duties has been selected yet" in {
+//        val session = getSessionWithSelectedDuties(2, mrnCount = 3)._1
+//
+//        inSequence {
+//          mockAuthWithNoRetrievals()
+//          mockGetSession(session)
+//        }
+//
+//        checkIsRedirect(
+//          performActionCheckClaimSummary(),
+//          routes.SelectMultipleDutiesController.selectDuties(1)
+//        )
+//      }
+//
+//    }
+//
+//    "redirect to the `Enter Claim` page" when {
+//      "none claims has been entered yet" in {
+//        val taxCode          = TaxCode.A70
+//        val selectedTaxCodes = taxCode :: randomListOfTaxCodes.take(3)
+//        val session          = getSessionWithSelectedDuties(1, mrnCount = 3, selectedTaxCodes = selectedTaxCodes)._1
+//
+//        inSequence {
+//          mockAuthWithNoRetrievals()
+//          mockGetSession(session)
+//        }
+//
+//        checkIsRedirect(
+//          performActionCheckClaimSummary(),
+//          routes.EnterMultipleClaimsController.enterClaim(1, taxCode)
+//        )
+//      }
+//
+//      "some claims has not been entered yet" in {
+//        (1 to 7).foreach { mrnCount =>
+//          val (session, _, _, claimsList) =
+//            getSessionWithEnteredClaims(mrnCount, skipNthClaim = Some(mrnCount - 1))
+//
+//          inSequence {
+//            mockAuthWithNoRetrievals()
+//            mockGetSession(session)
+//          }
+//
+//          val taxCode = claimsList(0)(mrnCount - 1).taxCode
+//
+//          checkIsRedirect(
+//            performActionCheckClaimSummary(),
+//            routes.EnterMultipleClaimsController.enterClaim(1, taxCode)
+//          )
+//        }
+//      }
+//
+//    }
+//
+//    "display the multiple claims summary page" when {
+//      "all claims has been entered" in {
+//        (1 to 7).foreach { mrnCount =>
+//          val (session, _, mrns, claimsList) = getSessionWithEnteredClaims(mrnCount)
+//
+//          inSequence {
+//            mockAuthWithNoRetrievals()
+//            mockGetSession(session)
+//          }
+//
+//          checkPageIsDisplayed(
+//            performActionCheckClaimSummary(),
+//            messageFromMessageKey(
+//              "multiple-check-claim-summary.title"
+//            ),
+//            doc => {
+//              assertAllSummarySectionHeadersAreDisplayed(doc, mrns)
+//              assertAllClaimValuesAreDisplayed(doc, claimsList)
+//            }
+//          )
+//        }
+//      }
+//
+//    }
+//
+//  }
+//
+//}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMultipleClaimsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMultipleClaimsControllerSpec.scala
@@ -1,487 +1,487 @@
-///*
-// * Copyright 2021 HM Revenue & Customs
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//
-//package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
-//
-//import cats.Functor
-//import cats.Id
-//import cats.data.NonEmptyList
-//import org.jsoup.nodes.Document
-//import org.scalacheck.Gen
-//import org.scalactic.source.Position
-//import org.scalatest.Assertion
-//import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-//import play.api.i18n.Lang
-//import play.api.i18n.Messages
-//import play.api.i18n.MessagesApi
-//import play.api.i18n.MessagesImpl
-//import play.api.inject.bind
-//import play.api.inject.guice.GuiceableModule
-//import play.api.mvc.Result
-//import play.api.test.FakeRequest
-//import uk.gov.hmrc.auth.core.AuthConnector
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer.IncorrectExciseValue
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.NdrcDetails
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Acc14Gen._
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DisplayDeclarationGen._
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.SignedInUserDetailsGen._
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
-//
-//import scala.concurrent.Future
-//import scala.util.Random
-//import play.api.http.Status
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
-//
-//class EnterMultipleClaimsControllerSpec
-//    extends ControllerSpec
-//    with AuthSupport
-//    with SessionSupport
-//    with ScalaCheckDrivenPropertyChecks {
-//
-//  override val overrideBindings: List[GuiceableModule] =
-//    List[GuiceableModule](
-//      bind[AuthConnector].toInstance(mockAuthConnector),
-//      bind[SessionCache].toInstance(mockSessionCache)
-//    )
-//
-//  val controller: EnterMultipleClaimsController = instanceOf[EnterMultipleClaimsController]
-//
-//  implicit val messagesApi: MessagesApi = controller.messagesApi
-//  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
-//
-//  lazy val displayDeclaration = sample[DisplayDeclaration]
-//  lazy val nonEmptyListOfMRN  = sample[List[MRN]](Gen.listOfN(20, genMRN))
-//
-//  def randomListOfTaxCodes = Random.shuffle(TaxCodes.excise).toList
-//
-//  val nonEmptyListOfTaxCodesGen =
-//    Gen.chooseNum(10, TaxCodes.excise.length).map(n => randomListOfTaxCodes.take(n))
-//
-//  private def getSessionWithSelectedDuties(
-//    selectedMrnIndex: Int,
-//    mrnCount: Int,
-//    selectedTaxCodes: List[TaxCode] = Nil
-//  ): (SessionData, DraftClaim, Seq[MRN], Seq[NdrcDetails]) = {
-//
-//    val leadMrn        = sample[MRN]
-//    val associatedMrns = nonEmptyListOfMRN.take(mrnCount - 1)
-//
-//    val ndrcTaxCodeLists: Seq[List[TaxCode]] =
-//      (0 until mrnCount)
-//        .map(i =>
-//          if (i + 1 == selectedMrnIndex) selectedTaxCodes
-//          else sample(nonEmptyListOfTaxCodesGen)
-//        )
-//
-//    val selectedTaxCodeLists: Seq[List[TaxCode]] =
-//      selectedTaxCodes match {
-//        case Nil => Nil
-//        case _   =>
-//          ndrcTaxCodeLists.zipWithIndex.map { case (l, i) =>
-//            if (i + 1 == selectedMrnIndex) selectedTaxCodes else l.take(i + 1)
-//          }
-//      }
-//
-//    val selectedDutiesLists: List[List[Duty]] =
-//      selectedTaxCodeLists.map(_.map(Duty.apply)).toList
-//
-//    def ndrscDetails(index: Int): List[NdrcDetails] =
-//      if (index < 0 || index >= ndrcTaxCodeLists.length) Nil
-//      else
-//        ndrcTaxCodeLists(index)
-//          .map(code =>
-//            sample[NdrcDetails](genNdrcDetails)
-//              .copy(taxType = code.value)
-//          )
-//
-//    def acc14(index: Int) = Functor[Id].map(displayDeclaration) { dd =>
-//      dd.copy(displayResponseDetail = dd.displayResponseDetail.copy(ndrcDetails = Some(ndrscDetails(index))))
-//    }
-//
-//    val draftC285Claim = DraftClaim.blank.copy(
-//      movementReferenceNumber = if (mrnCount > 0) Some(leadMrn) else None,
-//      displayDeclaration = if (mrnCount > 0) Some(acc14(0)) else None,
-//      associatedMRNsAnswer = NonEmptyList.fromList(associatedMrns),
-//      associatedMRNsDeclarationAnswer = NonEmptyList.fromList(associatedMrns.zipWithIndex.map(x => acc14(x._2 + 1))),
-//      basisOfClaimAnswer = Some(IncorrectExciseValue),
-//      dutiesSelectedAnswer = selectedDutiesLists.headOption.flatMap(NonEmptyList.fromList),
-//      associatedMRNsDutiesSelectedAnswer =
-//        NonEmptyList.fromList(selectedDutiesLists.drop(1).map(NonEmptyList.fromListUnsafe))
-//    )
-//
-//    val ggCredId            = sample[GGCredId]
-//    val signedInUserDetails = sample[SignedInUserDetails]
-//
-//    val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
-//
-//    (
-//      SessionData.empty.copy(journeyStatus = Some(journey)),
-//      journey.draftClaim,
-//      leadMrn :: associatedMrns,
-//      ndrscDetails(selectedMrnIndex)
-//    )
-//  }
-//
-//  def getBackLink(document: Document): String =
-//    document.select("a.govuk-back-link").attr("href")
-//
-//  def performActionEnterClaim(i: Int, taxCode: TaxCode): Future[Result] =
-//    controller.enterClaim(i, taxCode)(FakeRequest())
-//
-//  def performActionCheckClaimSummary(): Future[Result] =
-//    controller.checkClaimSummary(FakeRequest())
-//
-//  def getHintText(document: Document, hintTextId: String): Option[String] = {
-//    val hintTextElement = document.select(s"div#$hintTextId")
-//
-//    if (hintTextElement.hasText) Some(hintTextElement.text()) else None
-//  }
-//
-//  def assertHintTextIsDisplayed(
-//    document: Document,
-//    expectedHintText: String
-//  )(implicit pos: Position): Assertion =
-//    getHintText(document, "multiple-enter-claim-hint") shouldBe Some(expectedHintText)
-//
-//  def assertMrnIsDisplayedInBold(document: Document, mrn: MRN)(implicit pos: Position): Assertion = {
-//    val element = document.select("span#MRN")
-//    element.text()        shouldBe mrn.value
-//    element.attr("class") shouldBe "govuk-!-font-weight-bold"
-//  }
-//
-//  def assertClaimAmountIsDisplayed(document: Document, expectedAmount: Option[String])(implicit pos: Position): Unit = {
-//    val element = document.select("span#paid-amount")
-//    expectedAmount.foreach(amount =>
-//      element.text() should startWith(messageFromMessageKey("multiple-enter-claim.paid-amount-label", amount))
-//    )
-//  }
-//
-//  "EnterMultipleClaimsController.enterClaim" must {
-//    "redirect to the start of the journey" when {
-//      "there is no journey status in the session" in {
-//        (1 to 7).foreach { selectedMrnIndex =>
-//          val session = getSessionWithSelectedDuties(selectedMrnIndex, mrnCount = 0)._1
-//
-//          inSequence {
-//            mockAuthWithNoRetrievals()
-//            mockGetSession(session.copy(journeyStatus = None))
-//          }
-//
-//          checkIsRedirect(
-//            performActionEnterClaim(selectedMrnIndex, TaxCode.A00),
-//            baseRoutes.StartController.start()
-//          )
-//        }
-//      }
-//    }
-//
-//    "display 'This MRN does not exist' error page" when {
-//      "an MRN has not been yet provided" in {
-//        (1 to 7).foreach { selectedMrnIndex =>
-//          val session = getSessionWithSelectedDuties(selectedMrnIndex, mrnCount = selectedMrnIndex - 1)._1
-//
-//          inSequence {
-//            mockAuthWithNoRetrievals()
-//            mockGetSession(session)
-//          }
-//
-//          checkPageIsDisplayed(
-//            performActionEnterClaim(selectedMrnIndex, TaxCode.A00),
-//            messageFromMessageKey("mrn-does-not-exist.title"),
-//            expectedStatus = Status.BAD_REQUEST
-//          )
-//        }
-//      }
-//
-//    }
-//
-//    "display the enter claim page for the lead MRN and the tax code" when {
-//      (1 to 7).foreach { selectedMrnIndex =>
-//        s"the user has provided ${OrdinalNumeral(selectedMrnIndex)} MRN and has selected the duties" in {
-//
-//          val selectedTaxCodes = randomListOfTaxCodes.take(selectedMrnIndex)
-//
-//          val (session, _, mrns, ndrcDetails) =
-//            getSessionWithSelectedDuties(
-//              selectedMrnIndex,
-//              mrnCount = selectedMrnIndex + 1,
-//              selectedTaxCodes = selectedTaxCodes
-//            )
-//
-//          selectedTaxCodes.foreach { taxCode =>
-//            val ndrc = ndrcDetails.find(_.taxType === taxCode)
-//
-//            inSequence {
-//              mockAuthWithNoRetrievals()
-//              mockGetSession(session)
-//            }
-//            checkPageIsDisplayed(
-//              performActionEnterClaim(selectedMrnIndex, taxCode),
-//              messageFromMessageKey(
-//                "multiple-enter-claim.title",
-//                taxCode.value,
-//                messageFromMessageKey(s"select-duties.duty.$taxCode"),
-//                OrdinalNumeral(selectedMrnIndex)
-//              ),
-//              doc => {
-//                assertMrnIsDisplayedInBold(doc, mrns(selectedMrnIndex - 1))
-//                assertHintTextIsDisplayed(
-//                  doc,
-//                  messageFromMessageKey(
-//                    s"multiple-enter-claim.actual-amount.hint",
-//                    taxCode,
-//                    messageFromMessageKey(s"select-duties.duty.$taxCode")
-//                  )
-//                )
-//                assertClaimAmountIsDisplayed(doc, ndrc.map(n => BigDecimal(n.amount).toPoundSterlingString))
-//              }
-//            )
-//          }
-//        }
-//      }
-//    }
-//  }
-//
-//  private def getSessionWithEnteredClaims(
-//    mrnCount: Int,
-//    skipNthClaim: Option[Int] = None
-//  ): (SessionData, DraftClaim, Seq[MRN], List[List[ClaimedReimbursement]]) = {
-//
-//    val leadMrn        = sample[MRN]
-//    val associatedMrns = nonEmptyListOfMRN.take(mrnCount - 1)
-//
-//    val ndrcTaxCodeLists: Seq[List[TaxCode]] =
-//      (0 until mrnCount)
-//        .map(_ => sample(nonEmptyListOfTaxCodesGen))
-//
-//    val ndrcDetailsList: Seq[List[NdrcDetails]] =
-//      ndrcTaxCodeLists
-//        .map(
-//          _.map(taxCode =>
-//            sample[NdrcDetails](genNdrcDetails)
-//              .copy(taxType = taxCode.value)
-//          )
-//        )
-//
-//    val selectedTaxCodeLists: Seq[List[TaxCode]] =
-//      ndrcTaxCodeLists.zipWithIndex.map { case (l, i) =>
-//        l.take(i + 1)
-//      }
-//
-//    val selectedDutiesLists: List[List[Duty]] =
-//      selectedTaxCodeLists.map(_.map(Duty.apply)).toList
-//
-//    val claimedReimbursementLists: List[List[ClaimedReimbursement]] =
-//      ndrcDetailsList
-//        .map(_.zipWithIndex.map { case (ndrc, i) =>
-//          val claim =
-//            ClaimedReimbursement.fromNdrc(ndrc).getOrElse(ClaimedReimbursement.fromDuty(Duty(TaxCode(ndrc.taxType))))
-//
-//          claim
-//            .copy(
-//              isFilled = !skipNthClaim.contains(i),
-//              claimAmount = sample(Gen.choose(1, claim.paidAmount.toInt + 1).map(BigDecimal(_)))
-//            )
-//        })
-//        .toList
-//
-//    def acc14(index: Int) = Functor[Id].map(displayDeclaration) { dd =>
-//      dd.copy(displayResponseDetail = dd.displayResponseDetail.copy(ndrcDetails = Some(ndrcDetailsList(index))))
-//    }
-//
-//    val draftC285Claim = DraftClaim.blank.copy(
-//      movementReferenceNumber = if (mrnCount > 0) Some(leadMrn) else None,
-//      displayDeclaration = if (mrnCount > 0) Some(acc14(0)) else None,
-//      associatedMRNsAnswer = NonEmptyList.fromList(associatedMrns),
-//      associatedMRNsDeclarationAnswer = NonEmptyList.fromList(associatedMrns.zipWithIndex.map(x => acc14(x._2 + 1))),
-//      basisOfClaimAnswer = Some(IncorrectExciseValue),
-//      dutiesSelectedAnswer = selectedDutiesLists.headOption.flatMap(NonEmptyList.fromList),
-//      claimedReimbursementsAnswer = claimedReimbursementLists.headOption.flatMap(NonEmptyList.fromList),
-//      associatedMRNsDutiesSelectedAnswer =
-//        NonEmptyList.fromList(selectedDutiesLists.drop(1).map(NonEmptyList.fromListUnsafe)),
-//      associatedMRNsClaimsAnswer =
-//        NonEmptyList.fromList(claimedReimbursementLists.drop(1).map(NonEmptyList.fromListUnsafe))
-//    )
-//
-//    val ggCredId            = sample[GGCredId]
-//    val signedInUserDetails = sample[SignedInUserDetails]
-//
-//    val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
-//
-//    (
-//      SessionData.empty.copy(journeyStatus = Some(journey)),
-//      journey.draftClaim,
-//      leadMrn :: associatedMrns,
-//      claimedReimbursementLists
-//    )
-//  }
-//
-//  def assertAllSummarySectionHeadersAreDisplayed(document: Document, mrns: Seq[MRN])(implicit pos: Position): Unit = {
-//    val elements        = document.select("h2")
-//    val expectedHeaders = mrns.zipWithIndex
-//      .map { case (mrn, index) =>
-//        messageFromMessageKey(
-//          "multiple-check-claim-summary.duty.label",
-//          OrdinalNumeral(index + 1).capitalize,
-//          mrn.value
-//        )
-//      }
-//    elements.eachText() should contain allElementsOf expectedHeaders
-//  }
-//
-//  def assertAllClaimValuesAreDisplayed(document: Document, claimsList: List[List[ClaimedReimbursement]])(implicit
-//    pos: Position
-//  ): Unit = {
-//    val elements       = document.select("dd.govuk-summary-list__value")
-//    val amounts        = claimsList.map(_.map(_.claimAmount))
-//    val expectedValues =
-//      amounts.flatMap(_.map(_.toPoundSterlingString)) ++
-//        amounts.map(_.sum.toPoundSterlingString) ++
-//        Seq(amounts.map(_.sum).sum.toPoundSterlingString)
-//    elements.eachText() should contain allElementsOf expectedValues
-//  }
-//
-//  "EnterMultipleClaimsController.checkClaimSummary" must {
-//    "redirect to the start of the journey" when {
-//      "there is no journey status in the session" in {
-//        val session = getSessionWithEnteredClaims(mrnCount = 0)._1
-//
-//        inSequence {
-//          mockAuthWithNoRetrievals()
-//          mockGetSession(session.copy(journeyStatus = None))
-//        }
-//
-//        checkIsRedirect(
-//          performActionCheckClaimSummary(),
-//          baseRoutes.StartController.start()
-//        )
-//      }
-//    }
-//
-//    "redirect to the `Enter MRN` page" when {
-//      "an MRN has not been yet provided" in {
-//        val session = getSessionWithEnteredClaims(mrnCount = 0)._1
-//
-//        inSequence {
-//          mockAuthWithNoRetrievals()
-//          mockGetSession(session)
-//        }
-//
-//        checkIsRedirect(
-//          performActionCheckClaimSummary(),
-//          routes.EnterMovementReferenceNumberController.enterJourneyMrn(JourneyBindable.Multiple)
-//        )
-//      }
-//
-//    }
-//
-//    "redirect to the `Select Duties` page" when {
-//      "none duties has been selected yet" in {
-//        val session = getSessionWithSelectedDuties(2, mrnCount = 3)._1
-//
-//        inSequence {
-//          mockAuthWithNoRetrievals()
-//          mockGetSession(session)
-//        }
-//
-//        checkIsRedirect(
-//          performActionCheckClaimSummary(),
-//          routes.SelectMultipleDutiesController.selectDuties(1)
-//        )
-//      }
-//
-//    }
-//
-//    "redirect to the `Enter Claim` page" when {
-//      "none claims has been entered yet" in {
-//        val taxCode          = TaxCode.A70
-//        val selectedTaxCodes = taxCode :: randomListOfTaxCodes.take(3)
-//        val session          = getSessionWithSelectedDuties(1, mrnCount = 3, selectedTaxCodes = selectedTaxCodes)._1
-//
-//        inSequence {
-//          mockAuthWithNoRetrievals()
-//          mockGetSession(session)
-//        }
-//
-//        checkIsRedirect(
-//          performActionCheckClaimSummary(),
-//          routes.EnterMultipleClaimsController.enterClaim(1, taxCode)
-//        )
-//      }
-//
-//      "some claims has not been entered yet" in {
-//        (1 to 7).foreach { mrnCount =>
-//          val (session, _, _, claimsList) =
-//            getSessionWithEnteredClaims(mrnCount, skipNthClaim = Some(mrnCount - 1))
-//
-//          inSequence {
-//            mockAuthWithNoRetrievals()
-//            mockGetSession(session)
-//          }
-//
-//          val taxCode = claimsList(0)(mrnCount - 1).taxCode
-//
-//          checkIsRedirect(
-//            performActionCheckClaimSummary(),
-//            routes.EnterMultipleClaimsController.enterClaim(1, taxCode)
-//          )
-//        }
-//      }
-//
-//    }
-//
-//    "display the multiple claims summary page" when {
-//      "all claims has been entered" in {
-//        (1 to 7).foreach { mrnCount =>
-//          val (session, _, mrns, claimsList) = getSessionWithEnteredClaims(mrnCount)
-//
-//          inSequence {
-//            mockAuthWithNoRetrievals()
-//            mockGetSession(session)
-//          }
-//
-//          checkPageIsDisplayed(
-//            performActionCheckClaimSummary(),
-//            messageFromMessageKey(
-//              "multiple-check-claim-summary.title"
-//            ),
-//            doc => {
-//              assertAllSummarySectionHeadersAreDisplayed(doc, mrns)
-//              assertAllClaimValuesAreDisplayed(doc, claimsList)
-//            }
-//          )
-//        }
-//      }
-//
-//    }
-//
-//  }
-//
-//}
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+
+import cats.Functor
+import cats.Id
+import cats.data.NonEmptyList
+import org.jsoup.nodes.Document
+import org.scalacheck.Gen
+import org.scalactic.source.Position
+import org.scalatest.Assertion
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.i18n.Lang
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
+import play.api.inject.bind
+import play.api.inject.guice.GuiceableModule
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer.IncorrectExciseValue
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.NdrcDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Acc14Gen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DisplayDeclarationGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.SignedInUserDetailsGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
+
+import scala.concurrent.Future
+import scala.util.Random
+import play.api.http.Status
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
+
+class EnterMultipleClaimsControllerSpec
+    extends ControllerSpec
+    with AuthSupport
+    with SessionSupport
+    with ScalaCheckDrivenPropertyChecks {
+
+  override val overrideBindings: List[GuiceableModule] =
+    List[GuiceableModule](
+      bind[AuthConnector].toInstance(mockAuthConnector),
+      bind[SessionCache].toInstance(mockSessionCache)
+    )
+
+  val controller: EnterMultipleClaimsController = instanceOf[EnterMultipleClaimsController]
+
+  implicit val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
+
+  lazy val displayDeclaration = sample[DisplayDeclaration]
+  lazy val nonEmptyListOfMRN  = sample[List[MRN]](Gen.listOfN(20, genMRN))
+
+  def randomListOfTaxCodes = Random.shuffle(TaxCodes.excise).toList
+
+  val nonEmptyListOfTaxCodesGen =
+    Gen.chooseNum(10, TaxCodes.excise.length).map(n => randomListOfTaxCodes.take(n))
+
+  private def getSessionWithSelectedDuties(
+    selectedMrnIndex: Int,
+    mrnCount: Int,
+    selectedTaxCodes: List[TaxCode] = Nil
+  ): (SessionData, DraftClaim, Seq[MRN], Seq[NdrcDetails]) = {
+
+    val leadMrn        = sample[MRN]
+    val associatedMrns = nonEmptyListOfMRN.take(mrnCount - 1)
+
+    val ndrcTaxCodeLists: Seq[List[TaxCode]] =
+      (0 until mrnCount)
+        .map(i =>
+          if (i + 1 == selectedMrnIndex) selectedTaxCodes
+          else sample(nonEmptyListOfTaxCodesGen)
+        )
+
+    val selectedTaxCodeLists: Seq[List[TaxCode]] =
+      selectedTaxCodes match {
+        case Nil => Nil
+        case _   =>
+          ndrcTaxCodeLists.zipWithIndex.map { case (l, i) =>
+            if (i + 1 == selectedMrnIndex) selectedTaxCodes else l.take(i + 1)
+          }
+      }
+
+    val selectedDutiesLists: List[List[Duty]] =
+      selectedTaxCodeLists.map(_.map(Duty.apply)).toList
+
+    def ndrscDetails(index: Int): List[NdrcDetails] =
+      if (index < 0 || index >= ndrcTaxCodeLists.length) Nil
+      else
+        ndrcTaxCodeLists(index)
+          .map(code =>
+            sample[NdrcDetails](genNdrcDetails)
+              .copy(taxType = code.value)
+          )
+
+    def acc14(index: Int) = Functor[Id].map(displayDeclaration) { dd =>
+      dd.copy(displayResponseDetail = dd.displayResponseDetail.copy(ndrcDetails = Some(ndrscDetails(index))))
+    }
+
+    val draftC285Claim = DraftClaim.blank.copy(
+      movementReferenceNumber = if (mrnCount > 0) Some(leadMrn) else None,
+      displayDeclaration = if (mrnCount > 0) Some(acc14(0)) else None,
+      associatedMRNsAnswer = NonEmptyList.fromList(associatedMrns),
+      associatedMRNsDeclarationAnswer = NonEmptyList.fromList(associatedMrns.zipWithIndex.map(x => acc14(x._2 + 1))),
+      basisOfClaimAnswer = Some(IncorrectExciseValue),
+      dutiesSelectedAnswer = selectedDutiesLists.headOption.flatMap(NonEmptyList.fromList),
+      associatedMRNsDutiesSelectedAnswer =
+        NonEmptyList.fromList(selectedDutiesLists.drop(1).map(NonEmptyList.fromListUnsafe))
+    )
+
+    val ggCredId            = sample[GGCredId]
+    val signedInUserDetails = sample[SignedInUserDetails]
+
+    val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
+
+    (
+      SessionData.empty.copy(journeyStatus = Some(journey)),
+      journey.draftClaim,
+      leadMrn :: associatedMrns,
+      ndrscDetails(selectedMrnIndex)
+    )
+  }
+
+  def getBackLink(document: Document): String =
+    document.select("a.govuk-back-link").attr("href")
+
+  def performActionEnterClaim(i: Int, taxCode: TaxCode): Future[Result] =
+    controller.enterClaim(i, taxCode)(FakeRequest())
+
+  def performActionCheckClaimSummary(): Future[Result] =
+    controller.checkClaimSummary(FakeRequest())
+
+  def getHintText(document: Document, hintTextId: String): Option[String] = {
+    val hintTextElement = document.select(s"div#$hintTextId")
+
+    if (hintTextElement.hasText) Some(hintTextElement.text()) else None
+  }
+
+  def assertHintTextIsDisplayed(
+    document: Document,
+    expectedHintText: String
+  )(implicit pos: Position): Assertion =
+    getHintText(document, "multiple-enter-claim-hint") shouldBe Some(expectedHintText)
+
+  def assertMrnIsDisplayedInBold(document: Document, mrn: MRN)(implicit pos: Position): Assertion = {
+    val element = document.select("span#MRN")
+    element.text()        shouldBe mrn.value
+    element.attr("class") shouldBe "govuk-!-font-weight-bold"
+  }
+
+  def assertClaimAmountIsDisplayed(document: Document, expectedAmount: Option[String])(implicit pos: Position): Unit = {
+    val element = document.select("span#paid-amount")
+    expectedAmount.foreach(amount =>
+      element.text() should startWith(messageFromMessageKey("multiple-enter-claim.paid-amount-label", amount))
+    )
+  }
+
+  "EnterMultipleClaimsController.enterClaim" must {
+    "redirect to the start of the journey" when {
+      "there is no journey status in the session" in {
+        (1 to 7).foreach { selectedMrnIndex =>
+          val session = getSessionWithSelectedDuties(selectedMrnIndex, mrnCount = 0)._1
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(session.copy(journeyStatus = None))
+          }
+
+          checkIsRedirect(
+            performActionEnterClaim(selectedMrnIndex, TaxCode.A00),
+            baseRoutes.StartController.start()
+          )
+        }
+      }
+    }
+
+    "display 'This MRN does not exist' error page" when {
+      "an MRN has not been yet provided" in {
+        (1 to 7).foreach { selectedMrnIndex =>
+          val session = getSessionWithSelectedDuties(selectedMrnIndex, mrnCount = selectedMrnIndex - 1)._1
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(session)
+          }
+
+          checkPageIsDisplayed(
+            performActionEnterClaim(selectedMrnIndex, TaxCode.A00),
+            messageFromMessageKey("mrn-does-not-exist.title"),
+            expectedStatus = Status.BAD_REQUEST
+          )
+        }
+      }
+
+    }
+
+    "display the enter claim page for the lead MRN and the tax code" when {
+      (1 to 7).foreach { selectedMrnIndex =>
+        s"the user has provided ${OrdinalNumeral(selectedMrnIndex)} MRN and has selected the duties" in {
+
+          val selectedTaxCodes = randomListOfTaxCodes.take(selectedMrnIndex)
+
+          val (session, _, mrns, ndrcDetails) =
+            getSessionWithSelectedDuties(
+              selectedMrnIndex,
+              mrnCount = selectedMrnIndex + 1,
+              selectedTaxCodes = selectedTaxCodes
+            )
+
+          selectedTaxCodes.foreach { taxCode =>
+            val ndrc = ndrcDetails.find(_.taxType === taxCode)
+
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(session)
+            }
+            checkPageIsDisplayed(
+              performActionEnterClaim(selectedMrnIndex, taxCode),
+              messageFromMessageKey(
+                "multiple-enter-claim.title",
+                taxCode.value,
+                messageFromMessageKey(s"select-duties.duty.$taxCode"),
+                OrdinalNumeral(selectedMrnIndex)
+              ),
+              doc => {
+                assertMrnIsDisplayedInBold(doc, mrns(selectedMrnIndex - 1))
+                assertHintTextIsDisplayed(
+                  doc,
+                  messageFromMessageKey(
+                    s"multiple-enter-claim.actual-amount.hint",
+                    taxCode,
+                    messageFromMessageKey(s"select-duties.duty.$taxCode")
+                  )
+                )
+                assertClaimAmountIsDisplayed(doc, ndrc.map(n => BigDecimal(n.amount).toPoundSterlingString))
+              }
+            )
+          }
+        }
+      }
+    }
+  }
+
+  private def getSessionWithEnteredClaims(
+    mrnCount: Int,
+    skipNthClaim: Option[Int] = None
+  ): (SessionData, DraftClaim, Seq[MRN], List[List[ClaimedReimbursement]]) = {
+
+    val leadMrn        = sample[MRN]
+    val associatedMrns = nonEmptyListOfMRN.take(mrnCount - 1)
+
+    val ndrcTaxCodeLists: Seq[List[TaxCode]] =
+      (0 until mrnCount)
+        .map(_ => sample(nonEmptyListOfTaxCodesGen))
+
+    val ndrcDetailsList: Seq[List[NdrcDetails]] =
+      ndrcTaxCodeLists
+        .map(
+          _.map(taxCode =>
+            sample[NdrcDetails](genNdrcDetails)
+              .copy(taxType = taxCode.value)
+          )
+        )
+
+    val selectedTaxCodeLists: Seq[List[TaxCode]] =
+      ndrcTaxCodeLists.zipWithIndex.map { case (l, i) =>
+        l.take(i + 1)
+      }
+
+    val selectedDutiesLists: List[List[Duty]] =
+      selectedTaxCodeLists.map(_.map(Duty.apply)).toList
+
+    val claimedReimbursementLists: List[List[ClaimedReimbursement]] =
+      ndrcDetailsList
+        .map(_.zipWithIndex.map { case (ndrc, i) =>
+          val claim =
+            ClaimedReimbursement.fromNdrc(ndrc).getOrElse(ClaimedReimbursement.fromDuty(Duty(TaxCode(ndrc.taxType))))
+
+          claim
+            .copy(
+              isFilled = !skipNthClaim.contains(i),
+              claimAmount = sample(Gen.choose(1, claim.paidAmount.toInt + 1).map(BigDecimal(_)))
+            )
+        })
+        .toList
+
+    def acc14(index: Int) = Functor[Id].map(displayDeclaration) { dd =>
+      dd.copy(displayResponseDetail = dd.displayResponseDetail.copy(ndrcDetails = Some(ndrcDetailsList(index))))
+    }
+
+    val draftC285Claim = DraftClaim.blank.copy(
+      movementReferenceNumber = if (mrnCount > 0) Some(leadMrn) else None,
+      displayDeclaration = if (mrnCount > 0) Some(acc14(0)) else None,
+      associatedMRNsAnswer = NonEmptyList.fromList(associatedMrns),
+      associatedMRNsDeclarationAnswer = NonEmptyList.fromList(associatedMrns.zipWithIndex.map(x => acc14(x._2 + 1))),
+      basisOfClaimAnswer = Some(IncorrectExciseValue),
+      dutiesSelectedAnswer = selectedDutiesLists.headOption.flatMap(NonEmptyList.fromList),
+      claimedReimbursementsAnswer = claimedReimbursementLists.headOption.flatMap(NonEmptyList.fromList),
+      associatedMRNsDutiesSelectedAnswer =
+        NonEmptyList.fromList(selectedDutiesLists.drop(1).map(NonEmptyList.fromListUnsafe)),
+      associatedMRNsClaimsAnswer =
+        NonEmptyList.fromList(claimedReimbursementLists.drop(1).map(NonEmptyList.fromListUnsafe))
+    )
+
+    val ggCredId            = sample[GGCredId]
+    val signedInUserDetails = sample[SignedInUserDetails]
+
+    val journey = FillingOutClaim(ggCredId, signedInUserDetails, draftC285Claim)
+
+    (
+      SessionData.empty.copy(journeyStatus = Some(journey)),
+      journey.draftClaim,
+      leadMrn :: associatedMrns,
+      claimedReimbursementLists
+    )
+  }
+
+  def assertAllSummarySectionHeadersAreDisplayed(document: Document, mrns: Seq[MRN])(implicit pos: Position): Unit = {
+    val elements        = document.select("h2")
+    val expectedHeaders = mrns.zipWithIndex
+      .map { case (mrn, index) =>
+        messageFromMessageKey(
+          "multiple-check-claim-summary.duty.label",
+          OrdinalNumeral(index + 1).capitalize,
+          mrn.value
+        )
+      }
+    elements.eachText() should contain allElementsOf expectedHeaders
+  }
+
+  def assertAllClaimValuesAreDisplayed(document: Document, claimsList: List[List[ClaimedReimbursement]])(implicit
+    pos: Position
+  ): Unit = {
+    val elements       = document.select("dd.govuk-summary-list__value")
+    val amounts        = claimsList.map(_.map(_.claimAmount))
+    val expectedValues =
+      amounts.flatMap(_.map(_.toPoundSterlingString)) ++
+        amounts.map(_.sum.toPoundSterlingString) ++
+        Seq(amounts.map(_.sum).sum.toPoundSterlingString)
+    elements.eachText() should contain allElementsOf expectedValues
+  }
+
+  "EnterMultipleClaimsController.checkClaimSummary" must {
+    "redirect to the start of the journey" when {
+      "there is no journey status in the session" in {
+        val session = getSessionWithEnteredClaims(mrnCount = 0)._1
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session.copy(journeyStatus = None))
+        }
+
+        checkIsRedirect(
+          performActionCheckClaimSummary(),
+          baseRoutes.StartController.start()
+        )
+      }
+    }
+
+    "redirect to the `Enter MRN` page" when {
+      "an MRN has not been yet provided" in {
+        val session = getSessionWithEnteredClaims(mrnCount = 0)._1
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+        }
+
+        checkIsRedirect(
+          performActionCheckClaimSummary(),
+          routes.EnterMovementReferenceNumberController.enterJourneyMrn(JourneyBindable.Multiple)
+        )
+      }
+
+    }
+
+    "redirect to the `Select Duties` page" when {
+      "none duties has been selected yet" in {
+        val session = getSessionWithSelectedDuties(2, mrnCount = 3)._1
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+        }
+
+        checkIsRedirect(
+          performActionCheckClaimSummary(),
+          routes.SelectMultipleDutiesController.selectDuties(1)
+        )
+      }
+
+    }
+
+    "redirect to the `Enter Claim` page" when {
+      "none claims has been entered yet" in {
+        val taxCode          = TaxCode.A70
+        val selectedTaxCodes = taxCode :: randomListOfTaxCodes.take(3)
+        val session          = getSessionWithSelectedDuties(1, mrnCount = 3, selectedTaxCodes = selectedTaxCodes)._1
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+        }
+
+        checkIsRedirect(
+          performActionCheckClaimSummary(),
+          routes.EnterMultipleClaimsController.enterClaim(1, taxCode)
+        )
+      }
+
+      "some claims has not been entered yet" in {
+        (1 to 7).foreach { mrnCount =>
+          val (session, _, _, claimsList) =
+            getSessionWithEnteredClaims(mrnCount, skipNthClaim = Some(mrnCount - 1))
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(session)
+          }
+
+          val taxCode = claimsList(0)(mrnCount - 1).taxCode
+
+          checkIsRedirect(
+            performActionCheckClaimSummary(),
+            routes.EnterMultipleClaimsController.enterClaim(1, taxCode)
+          )
+        }
+      }
+
+    }
+
+    "display the multiple claims summary page" when {
+      "all claims has been entered" in {
+        (1 to 7).foreach { mrnCount =>
+          val (session, _, mrns, claimsList) = getSessionWithEnteredClaims(mrnCount)
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(session)
+          }
+
+          checkPageIsDisplayed(
+            performActionCheckClaimSummary(),
+            messageFromMessageKey(
+              "multiple-check-claim-summary.title"
+            ),
+            doc => {
+              assertAllSummarySectionHeadersAreDisplayed(doc, mrns)
+              assertAllClaimValuesAreDisplayed(doc, claimsList)
+            }
+          )
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckClaimantDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckClaimantDetailsControllerSpec.scala
@@ -1,0 +1,60 @@
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle
+
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
+import play.api.inject.bind
+import play.api.inject.guice.GuiceableModule
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.{RejectedGoodsSingleJourney, RejectedGoodsSingleJourneyTestData}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{Feature, SessionData}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+import scala.concurrent.Future
+
+class CheckClaimantDetailsControllerSpec
+    extends ControllerSpec
+    with AuthSupport
+    with SessionSupport
+    with BeforeAndAfterEach
+    with ScalaCheckPropertyChecks
+    with RejectedGoodsSingleJourneyTestData {
+
+  override val overrideBindings: List[GuiceableModule] =
+    List[GuiceableModule](
+      bind[AuthConnector].toInstance(mockAuthConnector),
+      bind[SessionCache].toInstance(mockSessionCache)
+    )
+
+  val controller: CheckClaimantDetailsController = instanceOf[CheckClaimantDetailsController]
+
+  implicit val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
+
+  private lazy val featureSwitch = instanceOf[FeatureSwitchService]
+
+  override def beforeEach(): Unit =
+    featureSwitch.enable(Feature.RejectedGoods)
+
+  val session = SessionData.empty.copy(
+    rejectedGoodsSingleJourney = Some(RejectedGoodsSingleJourney.empty(exampleEori))
+  )
+
+  "Check Claimant Details Controller" when {
+    "Check Claimant Details page" must {
+
+      def performAction(): Future[Result] =
+        controller.show()(FakeRequest())
+
+      "do not find the page if rejected goods feature is disabled" in {
+        featureSwitch.disable(Feature.RejectedGoods)
+
+        status(performAction()) shouldBe NOT_FOUND
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckClaimantDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckClaimantDetailsControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle
 
 import org.scalatest.BeforeAndAfterEach
@@ -8,10 +24,15 @@ import play.api.inject.guice.GuiceableModule
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, Name}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.EnrolmentConfig.EoriEnrolment
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourneyGenerators.buildCompleteJourneyGen
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.{RejectedGoodsSingleJourney, RejectedGoodsSingleJourneyTestData}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.EmailGen.genEmail
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen.{genEori, genName}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{Feature, SessionData}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 import scala.concurrent.Future
@@ -54,6 +75,51 @@ class CheckClaimantDetailsControllerSpec
         featureSwitch.disable(Feature.RejectedGoods)
 
         status(performAction()) shouldBe NOT_FOUND
+      }
+
+      "display the page" in {
+        forAll(buildCompleteJourneyGen(), genEmail, genName) { (journey, email, name) =>
+          val sessionToAmend = session.copy(rejectedGoodsSingleJourney = Some(journey))
+
+          inSequence {
+            mockAuthWithAllRetrievals(
+              Some(AffinityGroup.Individual),
+              Some(email.value),
+              Set(
+                Enrolment(EoriEnrolment.key)
+                  .withIdentifier(EoriEnrolment.eoriEnrolmentIdentifier, journey.getClaimantEori.value)
+              ),
+              Some(Credentials("id", "GovernmentGateway")),
+              Some(Name(name.name, name.lastName))
+            )
+            mockGetSession(sessionToAmend)
+          }
+
+          checkPageIsDisplayed(
+            performAction(),
+            messageFromMessageKey("check-claimant-details.title")
+          )
+        }
+      }
+
+      "redirect to the Mrn Entry page if no Acc14 response obtained yet" in {
+        forAll(genEmail, genName, genEori) { (email, name, eori) =>
+          inSequence {
+            mockAuthWithAllRetrievals(
+              Some(AffinityGroup.Individual),
+              Some(email.value),
+              Set(Enrolment(EoriEnrolment.key).withIdentifier(EoriEnrolment.eoriEnrolmentIdentifier, eori.value)),
+              Some(Credentials("id", "GovernmentGateway")),
+              Some(Name(name.name, name.lastName))
+            )
+            mockGetSession(session)
+          }
+
+          checkIsRedirect(
+            performAction(),
+            routes.EnterMovementReferenceNumberController.show()
+          )
+        }
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneyGenerators.scala
@@ -115,13 +115,19 @@ object RejectedGoodsSingleJourneyGenerators extends RejectedGoodsSingleJourneyTe
     acc14DeclarantMatchesUserEori: Boolean = true,
     acc14ConsigneeMatchesUserEori: Boolean = true,
     allDutiesCmaEligible: Boolean = true,
-    hasConsigneeDetailsInACC14: Boolean = true
+    hasConsigneeDetailsInACC14: Boolean = true,
+    submitConsigneeDetails: Boolean = true,
+    submitContactDetails: Boolean = true,
+    submitContactAddress: Boolean = true
   ): Gen[RejectedGoodsSingleJourney] =
     buildJourneyGen(
       acc14DeclarantMatchesUserEori,
       acc14ConsigneeMatchesUserEori,
       allDutiesCmaEligible,
-      hasConsigneeDetailsInACC14
+      hasConsigneeDetailsInACC14,
+      submitConsigneeDetails = submitConsigneeDetails,
+      submitContactDetails = submitContactDetails,
+      submitContactAddress = submitContactAddress
     ).map(
       _.fold(
         error =>
@@ -164,6 +170,8 @@ object RejectedGoodsSingleJourneyGenerators extends RejectedGoodsSingleJourneyTe
       numberOfSupportingEvidences <- Gen.choose(1, 3)
       documentTypes               <- Gen.listOfN(numberOfSupportingEvidences, Gen.oneOf(DocumentTypeRejectedGoods.all))
       bankAccountType             <- Gen.oneOf(BankAccountType.allAccountTypes)
+      consigneeContact            <- Gen.option(Acc14Gen.genContactDetails)
+      declarantContact            <- Gen.option(Acc14Gen.genContactDetails)
     } yield {
 
       val paidDuties: Seq[(TaxCode, BigDecimal, Boolean)]          =
@@ -182,7 +190,9 @@ object RejectedGoodsSingleJourneyGenerators extends RejectedGoodsSingleJourneyTe
           id.toString(),
           declarantEORI,
           if (hasConsigneeDetailsInACC14) Some(consigneeEORI) else None,
-          paidDuties
+          paidDuties,
+          if (submitConsigneeDetails) consigneeContact else None,
+          declarantContact
         )
 
       val hasMatchingEori = acc14DeclarantMatchesUserEori || acc14ConsigneeMatchesUserEori

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneyTestData.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneyTestData.scala
@@ -162,7 +162,9 @@ trait RejectedGoodsSingleJourneyTestData {
     id: String = "foo",
     declarantEORI: Eori = exampleEori,
     consigneeEORI: Option[Eori] = None,
-    dutyDetails: Seq[(TaxCode, BigDecimal, Boolean)] = Seq.empty
+    dutyDetails: Seq[(TaxCode, BigDecimal, Boolean)] = Seq.empty,
+    consigneeContact: Option[ContactDetails] = None,
+    declarantContact: Option[ContactDetails] = None
   ): DisplayDeclaration = {
     val ndrcDetails: List[NdrcDetails] =
       dutyDetails.map { case (taxCode, paidAmount, cmaEligible) =>
@@ -174,6 +176,22 @@ trait RejectedGoodsSingleJourneyTestData {
           cmaEligible = if (cmaEligible) Some("1") else None
         )
       }.toList
+
+    val consigneeDetails: Option[ConsigneeDetails] =
+      if (consigneeEORI.contains(declarantEORI))
+        None
+      else
+        consigneeEORI.map(eori =>
+          ConsigneeDetails(
+            consigneeEORI = eori.value,
+            legalName = s"consignee-legal-name-$id",
+            establishmentAddress = EstablishmentAddress(
+              addressLine1 = s"consignee-address-line-1-$id",
+              countryCode = s"consignee-country-code-$id"
+            ),
+            contactDetails = consigneeContact
+          )
+        )
 
     DisplayDeclaration {
       DisplayResponseDetail(
@@ -191,19 +209,9 @@ trait RejectedGoodsSingleJourneyTestData {
             addressLine1 = s"declarant-address-line-1-$id",
             countryCode = s"declarant-country-code-$id"
           ),
-          contactDetails = None
+          contactDetails = declarantContact
         ),
-        consigneeDetails = consigneeEORI.map(eori =>
-          ConsigneeDetails(
-            consigneeEORI = eori.value,
-            legalName = s"consignee-legal-name-$id",
-            establishmentAddress = EstablishmentAddress(
-              addressLine1 = s"consignee-address-line-1-$id",
-              countryCode = s"consignee-country-code-$id"
-            ),
-            contactDetails = None
-          )
-        ),
+        consigneeDetails = consigneeDetails,
         accountDetails = None,
         bankDetails = None,
         maskedBankDetails = None,

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/IdGen.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/IdGen.scala
@@ -20,6 +20,7 @@ import cats.data.NonEmptyList
 import org.scalacheck.magnolia._
 import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.AssociatedMrn
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.Name
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.{AssociatedMrnIndex, Eori, GGCredId, MRN}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.upscan.UploadReference
 
@@ -50,6 +51,13 @@ object IdGen {
     word    <- Gen.listOfN(13, Gen.numChar)
     d2      <- Gen.listOfN(1, Gen.numChar)
   } yield MRN((d1 ++ letter2 ++ word ++ d2).mkString)
+
+  lazy val genName: Gen[Name] = for {
+    name     <- genStringWithMaxSizeOfN(20)
+    lastName <- genStringWithMaxSizeOfN(20)
+  } yield Name(Some(name), Some(lastName))
+
+  lazy val genGGCredId: Gen[GGCredId] = gen[GGCredId].arbitrary
 
   implicit lazy val arbitraryMrn: Typeclass[MRN] = Arbitrary(genMRN)
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/RetrievedUserTypeGen.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/RetrievedUserTypeGen.scala
@@ -16,10 +16,18 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators
 
-import org.scalacheck.magnolia._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
+import org.scalacheck.Gen
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType.Individual
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.EmailGen._
 
-object SignedInUserDetailsGen {
+object RetrievedUserTypeGen {
 
-  implicit lazy val arbitrarySignedInUserDetails: Typeclass[SignedInUserDetails] = gen[SignedInUserDetails]
+  lazy val individualGen: Gen[Individual] = for {
+    ggCredId <- genGGCredId
+    email    <- genEmail
+    eori     <- genEori
+    name     <- genName
+  } yield RetrievedUserType.Individual(ggCredId, Some(email), eori, Some(name))
 }


### PR DESCRIPTION
The view summaries are tightly couple with the journey bindable object so we have created a new version of it that is not connected to it.

We have created a new version of the twirl template that does takes in the details we wish to display, and the controller determines what these details should be. As we are under pressure to get the C&1179 pages completed we have not updated the C285 pages to use this updated twirl template. The plan is to create some tech-debt tickets on the backlog to make sure that we go back and do this work.