### PR TITLE
improve CYA forwarding logic

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyBaseController.scala
@@ -66,6 +66,7 @@ abstract class JourneyBaseController[Journey](implicit ec: ExecutionContext)
 
   def getJourney(sessionData: SessionData): Option[Journey]
   def updateJourney(sessionData: SessionData, journey: Journey): SessionData
+  def userHasSeenCYAPage(journey: Journey): Boolean
   def hasCompleteAnswers(journey: Journey): Boolean
   def isFinalized(journey: Journey): Boolean
 
@@ -76,7 +77,8 @@ abstract class JourneyBaseController[Journey](implicit ec: ExecutionContext)
     Future.successful(
       if (result.header.status =!= 303) result
       else if (isFinalized(journey)) Redirect(claimSubmissionConfirmation)
-      else if (fastForwardToCYAEnabled && hasCompleteAnswers(journey)) Redirect(checkYourAnswers)
+      else if (userHasSeenCYAPage(journey) && fastForwardToCYAEnabled && hasCompleteAnswers(journey))
+        Redirect(checkYourAnswers)
       else result
     )
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/RejectedGoodsMultipleJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/RejectedGoodsMultipleJourneyBaseController.scala
@@ -43,6 +43,9 @@ abstract class RejectedGoodsMultipleJourneyBaseController(implicit ec: Execution
   final override def updateJourney(sessionData: SessionData, journey: RejectedGoodsMultipleJourney): SessionData =
     sessionData.copy(rejectedGoodsMultipleJourney = Some(journey))
 
+  final override def userHasSeenCYAPage(journey: RejectedGoodsMultipleJourney): Boolean =
+    journey.answers.checkYourAnswersChangeMode
+
   final override def hasCompleteAnswers(journey: RejectedGoodsMultipleJourney): Boolean =
     journey.hasCompleteAnswers
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/RejectedGoodsSingleJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/RejectedGoodsSingleJourneyBaseController.scala
@@ -43,6 +43,9 @@ abstract class RejectedGoodsSingleJourneyBaseController(implicit ec: ExecutionCo
   final override def updateJourney(sessionData: SessionData, journey: RejectedGoodsSingleJourney): SessionData =
     sessionData.copy(rejectedGoodsSingleJourney = Some(journey))
 
+  final override def userHasSeenCYAPage(journey: RejectedGoodsSingleJourney): Boolean =
+    journey.answers.checkYourAnswersChangeMode
+
   final override def hasCompleteAnswers(journey: RejectedGoodsSingleJourney): Boolean =
     journey.hasCompleteAnswers
 


### PR DESCRIPTION
This PR adds additional check before forwarding to CYA, it is now possible only after user has already seen CYA and journey is complete and action does not opt-out. It solves the problem with optional questions which user should be able to answer at least once. This should not be the concern of particular actions.