### PR TITLE
[CDSR-1478][AO] always store BankAccountDetails in the journey, show account details masked

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterBankAccountDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterBankAccountDetailsController.scala
@@ -40,10 +40,9 @@ class EnterBankAccountDetailsController @Inject() (
   val formKey: String          = "enter-bank-details"
   private val postAction: Call = routes.EnterBankAccountDetailsController.submit()
 
-  val show: Action[AnyContent] = actionReadJourney { implicit request => journey =>
+  val show: Action[AnyContent] = actionReadJourney { implicit request => _ =>
     Future.successful {
-      val form = enterBankDetailsForm.withDefault(journey.answers.bankAccountDetails)
-
+      val form = enterBankDetailsForm
       Ok(enterBankAccountDetailsPage(form, postAction))
     }
   }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
@@ -155,7 +155,7 @@ final class RejectedGoodsMultipleJourney private (
   def getNdrcDetailsFor(mrn: MRN): Option[List[NdrcDetails]] =
     getDisplayDeclarationFor(mrn).flatMap(_.getNdrcDetailsList)
 
-  def getBankAccountDetails: Option[BankAccountDetails] =
+  def computeBankAccountDetails: Option[BankAccountDetails] =
     Stream(
       answers.bankAccountDetails,
       getLeadDisplayDeclaration.flatMap(_.displayResponseDetail.maskedBankDetails.flatMap(_.consigneeBankDetails)),
@@ -622,7 +622,10 @@ final class RejectedGoodsMultipleJourney private (
           Right(
             new RejectedGoodsMultipleJourney(
               answers
-                .copy(reimbursementMethod = Some(reimbursementMethodAnswer), bankAccountDetails = getBankAccountDetails)
+                .copy(
+                  reimbursementMethod = Some(reimbursementMethodAnswer),
+                  bankAccountDetails = computeBankAccountDetails
+                )
             )
           )
       } else

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
@@ -118,11 +118,11 @@ final class RejectedGoodsSingleJourney private (
   def getNdrcDetails: Option[List[NdrcDetails]] =
     answers.displayDeclaration.flatMap(_.getNdrcDetailsList)
 
-  def getBankAccountDetails: Option[BankAccountDetails] =
+  def computeBankAccountDetails: Option[BankAccountDetails] =
     Stream(
       answers.bankAccountDetails,
-      answers.displayDeclaration.flatMap(_.displayResponseDetail.maskedBankDetails.flatMap(_.consigneeBankDetails)),
-      answers.displayDeclaration.flatMap(_.displayResponseDetail.maskedBankDetails.flatMap(_.declarantBankDetails))
+      answers.displayDeclaration.flatMap(_.displayResponseDetail.bankDetails.flatMap(_.consigneeBankDetails)),
+      answers.displayDeclaration.flatMap(_.displayResponseDetail.bankDetails.flatMap(_.declarantBankDetails))
     ).find(_.nonEmpty).flatten
 
   def getNdrcDetailsFor(taxCode: TaxCode): Option[NdrcDetails] =
@@ -492,7 +492,7 @@ final class RejectedGoodsSingleJourney private (
             new RejectedGoodsSingleJourney(
               answers.copy(
                 reimbursementMethod = Some(reimbursementMethodAnswer),
-                bankAccountDetails = getBankAccountDetails
+                bankAccountDetails = computeBankAccountDetails
               )
             )
           )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/AccountNumber.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/AccountNumber.scala
@@ -20,8 +20,13 @@ import play.api.libs.json.Format
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.SimpleStringFormat
 
 import java.util.function.Predicate
+import play.api.i18n.Messages
 
-final case class AccountNumber(value: String) extends AnyVal
+final case class AccountNumber(value: String) extends AnyVal {
+
+  def masked(implicit messages: Messages): String =
+    messages("account-number.mask", value.takeRight(4))
+}
 
 object AccountNumber {
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/BankAccountDetails.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/BankAccountDetails.scala
@@ -16,21 +16,26 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.models
 
+import cats.Eq
 import cats.data.Validated.Valid
 import cats.data.Validated.invalidNel
 import cats.syntax.all._
-import cats.Eq
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.validation.IncorrectAnswerError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.validation.MissingAnswerError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.validation.Validator
+import play.api.i18n.Messages
 
 final case class BankAccountDetails(
   accountName: AccountName,
   sortCode: SortCode,
   accountNumber: AccountNumber
-)
+) {
+
+  def masked(implicit messages: Messages): BankAccountDetails =
+    BankAccountDetails(accountName, SortCode(sortCode.masked), AccountNumber(accountNumber.masked))
+}
 
 object BankAccountDetails {
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/SortCode.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/SortCode.scala
@@ -20,8 +20,13 @@ import play.api.libs.functional.syntax.toInvariantFunctorOps
 import play.api.libs.json.Format
 
 import java.util.function.Predicate
+import play.api.i18n.Messages
 
-final case class SortCode(value: String) extends AnyVal
+final case class SortCode(value: String) extends AnyVal {
+
+  def masked(implicit messages: Messages): String =
+    messages("sort-code.mask", value.takeRight(2))
+}
 
 object SortCode {
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/DisplayDeclaration.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/DisplayDeclaration.scala
@@ -57,6 +57,9 @@ final case class DisplayDeclaration(
   def withDeclarationId(declarationId: String): DisplayDeclaration =
     copy(displayResponseDetail = displayResponseDetail.copy(declarationId = declarationId))
 
+  def withBankDetails(bankDetails: Option[BankDetails]): DisplayDeclaration =
+    copy(displayResponseDetail = displayResponseDetail.copy(bankDetails = bankDetails))
+
 }
 
 object DisplayDeclaration {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/BankAccountDetailsSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/BankAccountDetailsSummary.scala
@@ -22,11 +22,6 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 import play.api.mvc.Call
 
-/** def changeCall =
-  *      if (key.contains(checkYourAnswersKey))
-  *        routes.BankAccountController.checkBankAccountDetails(journey)
-  *      else routes.SelectBankAccountTypeController.selectBankAccountType(journey)
-  */
 object BankAccountDetailsSummary extends AnswerSummary[BankAccountDetails] {
 
   override def render(
@@ -57,12 +52,12 @@ object BankAccountDetailsSummary extends AnswerSummary[BankAccountDetails] {
         ),
         SummaryListRow(
           key = Key(Text(messages(s"$key.sort-code.label"))),
-          value = Value(Text(bankAccountDetails.sortCode.value)),
+          value = Value(Text(bankAccountDetails.sortCode.masked)),
           classes = "govuk-summary-list__row--no-border"
         ),
         SummaryListRow(
           key = Key(Text(messages(s"$key.account-number.label"))),
-          value = Value(Text(bankAccountDetails.accountNumber.value))
+          value = Value(Text(bankAccountDetails.accountNumber.masked))
         )
       )
     )

--- a/conf/messages
+++ b/conf/messages
@@ -913,6 +913,8 @@ bank-details.sort-code.label=Sort code
 bank-details.account-number.label=Account number
 bank-details.change=Change
 bank-details.different-details-link=<a href="{0}" class="govuk-link">Enter different bank details</a>
+sort-code.mask=Ending with {0}
+account-number.mask=Ending with {0}
 
 #===================================================
 #  SELECT BANK ACCOUNT TYPE PAGE

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/ControllerSpec.scala
@@ -46,6 +46,7 @@ import scala.concurrent.Future
 import scala.reflect.ClassTag
 import org.scalactic.source.Position
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.TypeOfClaimAnswer
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 @Singleton
 class TestMessagesApi(
@@ -244,4 +245,16 @@ trait ControllerSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll wi
     val input = doc.select(s"input.govuk-input[checked]")
     if (input.size() =!= 0) Some(input.`val`()) else None
   }
+
+  def summaryKeyValueMap(doc: Document): Map[String, String] = {
+    val summaryKeys   = doc.select(".govuk-summary-list__key").eachText()
+    val summaryValues = doc.select(".govuk-summary-list__value").eachText()
+    summaryKeys.asScala.zip(summaryValues.asScala).toMap
+  }
+}
+
+trait PropertyBasedControllerSpec extends ControllerSpec with ScalaCheckPropertyChecks {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
 }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourSingleJourneyAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourSingleJourneyAnswersSpec.scala
@@ -200,11 +200,11 @@ class CheckYourSingleJourneyAnswersSpec extends CheckYourAnswersSummarySpec with
     ),
     (
       messages(s"$checkYourAnswersKey.bank-details.sort-code.label"),
-      bankAccountDetails.sortCode.value
+      bankAccountDetails.sortCode.masked
     ),
     (
       messages(s"$checkYourAnswersKey.bank-details.account-number.label"),
-      bankAccountDetails.accountNumber.value
+      bankAccountDetails.accountNumber.masked
     )
   )
 }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/CheckYourAnswersControllerSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsmulti
 
 import org.jsoup.nodes.Document
 import org.scalatest.BeforeAndAfterEach
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.i18n.Lang
 import play.api.i18n.Messages
 import play.api.i18n.MessagesApi
@@ -33,7 +32,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.RejectedGoodsMultipleClaimConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.UploadDocumentsConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.PropertyBasedControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsMultipleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsMultipleJourneyGenerators._
@@ -49,11 +48,10 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
 class CheckYourAnswersControllerSpec
-    extends ControllerSpec
+    extends PropertyBasedControllerSpec
     with AuthSupport
     with SessionSupport
-    with BeforeAndAfterEach
-    with ScalaCheckPropertyChecks {
+    with BeforeAndAfterEach {
 
   val mockConnector: RejectedGoodsMultipleClaimConnector     = mock[RejectedGoodsMultipleClaimConnector]
   val mockUploadDocumentsConnector: UploadDocumentsConnector = mock[UploadDocumentsConnector]
@@ -152,6 +150,8 @@ class CheckYourAnswersControllerSpec
       headers                          should contain("Bank details")
       summaryKeys                      should contain allOf ("Name on the account", "Sort code", "Account number")
       summary("Name on the account") shouldBe value.accountName.value
+      summary("Sort code")           shouldBe value.sortCode.masked
+      summary("Account number")      shouldBe value.accountNumber.masked
     }
 
     claim.basisOfClaimSpecialCircumstances.foreach { value =>

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckYourAnswersControllerSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingl
 
 import org.jsoup.nodes.Document
 import org.scalatest.BeforeAndAfterEach
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.i18n.Lang
 import play.api.i18n.Messages
 import play.api.i18n.MessagesApi
@@ -33,7 +32,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.RejectedGoodsSingleClaimConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.UploadDocumentsConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.PropertyBasedControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourneyGenerators._
@@ -49,11 +48,10 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
 class CheckYourAnswersControllerSpec
-    extends ControllerSpec
+    extends PropertyBasedControllerSpec
     with AuthSupport
     with SessionSupport
-    with BeforeAndAfterEach
-    with ScalaCheckPropertyChecks {
+    with BeforeAndAfterEach {
 
   val mockConnector: RejectedGoodsSingleClaimConnector       = mock[RejectedGoodsSingleClaimConnector]
   val mockUploadDocumentsConnector: UploadDocumentsConnector = mock[UploadDocumentsConnector]
@@ -136,6 +134,8 @@ class CheckYourAnswersControllerSpec
       headers                          should contain("Bank details")
       summaryKeys                      should contain allOf ("Name on the account", "Sort code", "Account number")
       summary("Name on the account") shouldBe value.accountName.value
+      summary("Sort code")           shouldBe value.sortCode.masked
+      summary("Account number")      shouldBe value.accountNumber.masked
     }
 
     claim.basisOfClaimSpecialCircumstances.foreach { value =>

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterBankAccountDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterBankAccountDetailsControllerSpec.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle
 
 import org.scalatest.BeforeAndAfterEach
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.i18n.Lang
 import play.api.i18n.Messages
 import play.api.i18n.MessagesApi
@@ -30,7 +29,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.PropertyBasedControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney
@@ -46,11 +45,10 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 import scala.concurrent.Future
 
 class EnterBankAccountDetailsControllerSpec
-    extends ControllerSpec
+    extends PropertyBasedControllerSpec
     with AuthSupport
     with SessionSupport
-    with BeforeAndAfterEach
-    with ScalaCheckPropertyChecks {
+    with BeforeAndAfterEach {
 
   override val overrideBindings: List[GuiceableModule] =
     List[GuiceableModule](
@@ -102,8 +100,7 @@ class EnterBankAccountDetailsControllerSpec
       }
 
       "the user has answered this question before" in forAll(completeJourneyNotCMAEligibleGen) { journey =>
-        val bankAccountDetails = journey.answers.bankAccountDetails
-        val updatedSession     = session.copy(rejectedGoodsSingleJourney = Some(journey))
+        val updatedSession = session.copy(rejectedGoodsSingleJourney = Some(journey))
 
         inSequence {
           mockAuthWithNoRetrievals()
@@ -114,13 +111,9 @@ class EnterBankAccountDetailsControllerSpec
           performAction(),
           messageFromMessageKey(s"$messagesKey.title"),
           doc => {
-            selectedInputBox(doc, "enter-bank-details.account-name")   shouldBe Some(
-              bankAccountDetails.get.accountName.value
-            )
-            selectedInputBox(doc, "enter-bank-details.sort-code")      shouldBe Some(bankAccountDetails.get.sortCode.value)
-            selectedInputBox(doc, "enter-bank-details.account-number") shouldBe Some(
-              bankAccountDetails.get.accountNumber.value
-            )
+            selectedInputBox(doc, "enter-bank-details.account-name")   shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-details.sort-code")      shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-details.account-number") shouldBe Some("")
           }
         )
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneyGenerators.scala
@@ -140,6 +140,9 @@ object RejectedGoodsMultipleJourneyGenerators extends JourneyGenerators with Rej
     submitConsigneeDetails: Boolean = true,
     submitContactDetails: Boolean = true,
     submitContactAddress: Boolean = true,
+    submitBankAccountDetails: Boolean = true,
+    submitBankAccountType: Boolean = true,
+    reimbursementMethod: Option[ReimbursementMethodAnswer] = None,
     minNumberOfMRNs: Int = 2,
     maxSize: Int = 5
   ): Gen[RejectedGoodsMultipleJourney] =
@@ -151,6 +154,9 @@ object RejectedGoodsMultipleJourneyGenerators extends JourneyGenerators with Rej
       submitConsigneeDetails = submitConsigneeDetails,
       submitContactDetails = submitContactDetails,
       submitContactAddress = submitContactAddress,
+      submitBankAccountDetails = submitBankAccountDetails,
+      submitBankAccountType = submitBankAccountType,
+      reimbursementMethod = reimbursementMethod,
       minNumberOfMRNs = minNumberOfMRNs,
       maxSize = maxSize
     ).map(
@@ -188,6 +194,7 @@ object RejectedGoodsMultipleJourneyGenerators extends JourneyGenerators with Rej
     submitContactAddress: Boolean = true,
     submitBankAccountDetails: Boolean = true,
     submitBankAccountType: Boolean = true,
+    reimbursementMethod: Option[ReimbursementMethodAnswer] = None,
     minNumberOfMRNs: Int = 2,
     maxSize: Int = 5
   ): Gen[Either[String, RejectedGoodsMultipleJourney]] =
@@ -200,7 +207,7 @@ object RejectedGoodsMultipleJourneyGenerators extends JourneyGenerators with Rej
       taxCodesWithAmounts <- Gen.sequence(mrns.map(_ => taxCodesAndAmountsGen(maxSize))).map(_.asScala)
       basisOfClaim        <- Gen.oneOf(BasisOfRejectedGoodsClaim.values)
       methodOfDisposal    <- Gen.oneOf(MethodOfDisposal.values)
-      reimbursementMethod <- Gen.oneOf(ReimbursementMethodAnswer.values)
+      reimbursementMethod <- reimbursementMethod.map(Gen.const).getOrElse(Gen.oneOf(ReimbursementMethodAnswer.values))
 
       numberOfSupportingEvidences <- Gen.choose(1, maxSize)
       numberOfDocumentTypes       <- Gen.choose(1, maxSize - 1)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneyGenerators.scala
@@ -122,7 +122,10 @@ object RejectedGoodsSingleJourneyGenerators extends JourneyGenerators with Rejec
     hasConsigneeDetailsInACC14: Boolean = true,
     submitConsigneeDetails: Boolean = true,
     submitContactDetails: Boolean = true,
-    submitContactAddress: Boolean = true
+    submitContactAddress: Boolean = true,
+    submitBankAccountDetails: Boolean = true,
+    submitBankAccountType: Boolean = true,
+    reimbursementMethod: Option[ReimbursementMethodAnswer] = None
   ): Gen[RejectedGoodsSingleJourney] =
     buildJourneyGen(
       acc14DeclarantMatchesUserEori,
@@ -131,7 +134,10 @@ object RejectedGoodsSingleJourneyGenerators extends JourneyGenerators with Rejec
       hasConsigneeDetailsInACC14,
       submitConsigneeDetails = submitConsigneeDetails,
       submitContactDetails = submitContactDetails,
-      submitContactAddress = submitContactAddress
+      submitContactAddress = submitContactAddress,
+      submitBankAccountType = submitBankAccountType,
+      submitBankAccountDetails = submitBankAccountDetails,
+      reimbursementMethod = reimbursementMethod
     ).map(
       _.fold(
         error =>
@@ -152,7 +158,8 @@ object RejectedGoodsSingleJourneyGenerators extends JourneyGenerators with Rejec
     submitContactDetails: Boolean = true,
     submitContactAddress: Boolean = true,
     submitBankAccountDetails: Boolean = true,
-    submitBankAccountType: Boolean = true
+    submitBankAccountType: Boolean = true,
+    reimbursementMethod: Option[ReimbursementMethodAnswer] = None
   ): Gen[Either[String, RejectedGoodsSingleJourney]] =
     for {
       userEoriNumber              <- IdGen.genEori
@@ -168,7 +175,7 @@ object RejectedGoodsSingleJourneyGenerators extends JourneyGenerators with Rejec
         )
       basisOfClaim                <- Gen.oneOf(BasisOfRejectedGoodsClaim.values)
       methodOfDisposal            <- Gen.oneOf(MethodOfDisposal.values)
-      reimbursementMethod         <- Gen.oneOf(ReimbursementMethodAnswer.values)
+      reimbursementMethod         <- reimbursementMethod.map(Gen.const).getOrElse(Gen.oneOf(ReimbursementMethodAnswer.values))
       numberOfSelectedTaxCodes    <- Gen.choose(1, numberOfTaxCodes)
       numberOfSupportingEvidences <- Gen.choose(1, 3)
       numberOfDocumentTypes       <- Gen.choose(1, 2)


### PR DESCRIPTION
This PR:
- fixes missing BankAccountDetails preventing CYA page when the user confirms bank account details existing in ACC14
- fixes rendering of bank account details in summaries
- renames getBankAccountDetails to computeBankAccountDetails
- adds more tests to CheckBankDetailsControllerSpec
- fixes flaky ChooseInspectionAddressTypeControllerSpec