### PR TITLE
[AO] retrieve email when user is an Organisation and fix computeContactDetails function

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartController.scala
@@ -154,8 +154,8 @@ class StartController @Inject() (
       case RetrievedUserType.Individual(ggCredId, email, eori, name) =>
         handleSignedInUser(ggCredId, eori, email, name)
 
-      case RetrievedUserType.Organisation(ggCredId, eori, name) =>
-        handleSignedInUser(ggCredId, eori, None, name)
+      case RetrievedUserType.Organisation(ggCredId, email, eori, name) =>
+        handleSignedInUser(ggCredId, eori, email, name)
 
       case u: RetrievedUserType.NonGovernmentGatewayRetrievedUser =>
         handleNonGovernmentGatewayUser(u)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthenticatedActionWithRetrievedData.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthenticatedActionWithRetrievedData.scala
@@ -94,7 +94,7 @@ class AuthenticatedActionWithRetrievedData @Inject() (
             case Some(AffinityGroup.Organisation) =>
               handleIndividualOrOrganisation(
                 Left(AffinityGroup.Organisation),
-                None,
+                maybeEmail,
                 enrolments,
                 ggCredId,
                 name,
@@ -172,7 +172,8 @@ class AuthenticatedActionWithRetrievedData @Inject() (
 
       } else {
         AuthenticatedRequestWithRetrievedData(
-          RetrievedUserType.Organisation(ggCredId, eori, models.contactdetails.Name.fromGGName(name)),
+          RetrievedUserType
+            .Organisation(ggCredId, maybeEmail.map(Email(_)), eori, models.contactdetails.Name.fromGGName(name)),
           Some(userType),
           request
         )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
@@ -31,7 +31,6 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MethodOfDisposal
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Nonce
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType.Individual
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCodes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.UploadedFile
@@ -242,36 +241,35 @@ final class RejectedGoodsMultipleJourney private (
     getLeadDisplayDeclaration.flatMap(_.getDeclarantDetails.contactDetails),
     retrievedUser
   ) match {
-    case (details @ Some(_), _, _, _)                                                                       =>
+    case (details @ Some(_), _, _, _)                                                                              =>
       details
-    case (_, Some(consigneeContactDetails), _, individual: Individual)
-        if getConsigneeEoriFromACC14.contains(answers.userEoriNumber) =>
+    case (_, Some(consigneeContactDetails), _, user) if getConsigneeEoriFromACC14.contains(answers.userEoriNumber) =>
       Some(
         MrnContactDetails(
           consigneeContactDetails.contactName.getOrElse(""),
           consigneeContactDetails.emailAddress
-            .fold(individual.email.getOrElse(Email("")))(address => Email(address)),
+            .fold(user.email.getOrElse(Email("")))(address => Email(address)),
           consigneeContactDetails.telephone.map(PhoneNumber(_))
         )
       )
-    case (_, None, _, individual: Individual) if getConsigneeEoriFromACC14.contains(answers.userEoriNumber) =>
+    case (_, None, _, user) if getConsigneeEoriFromACC14.contains(answers.userEoriNumber)                          =>
       Some(
         MrnContactDetails(
-          individual.name.map(_.toFullName).getOrElse(""),
-          individual.email.getOrElse(Email("")),
+          user.name.map(_.toFullName).getOrElse(""),
+          user.email.getOrElse(Email("")),
           None
         )
       )
-    case (_, _, Some(declarantContactDetails), individual: Individual)                                      =>
+    case (_, _, Some(declarantContactDetails), user)                                                               =>
       Some(
         MrnContactDetails(
           declarantContactDetails.contactName.getOrElse(""),
           declarantContactDetails.emailAddress
-            .fold(individual.email.getOrElse(Email("")))(address => Email(address)),
+            .fold(user.email.getOrElse(Email("")))(address => Email(address)),
           declarantContactDetails.telephone.map(PhoneNumber(_))
         )
       )
-    case _                                                                                                  => None
+    case _                                                                                                         => None
   }
 
   def computeAddressDetails: Option[ContactAddress] = (

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/RetrievedUserType.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/RetrievedUserType.scala
@@ -22,7 +22,10 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.Email
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.Name
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids._
 
-sealed trait RetrievedUserType extends Product with Serializable
+sealed trait RetrievedUserType {
+  def name: Option[Name]
+  def email: Option[Email]
+}
 
 object RetrievedUserType {
 
@@ -35,11 +38,15 @@ object RetrievedUserType {
 
   final case class Organisation(
     ggCredId: GGCredId,
+    email: Option[Email],
     eori: Eori,
     name: Option[Name]
   ) extends RetrievedUserType
 
-  final case class NonGovernmentGatewayRetrievedUser(authProvider: String) extends RetrievedUserType
+  final case class NonGovernmentGatewayRetrievedUser(authProvider: String) extends RetrievedUserType {
+    override val name: Option[Name]   = None
+    override val email: Option[Email] = None
+  }
 
   object NonGovernmentGatewayRetrievedUser {
     implicit val format: OFormat[NonGovernmentGatewayRetrievedUser] = Json.format[NonGovernmentGatewayRetrievedUser]

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartControllerSpec.scala
@@ -227,6 +227,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
             AuthenticatedRequestWithRetrievedData(
               RetrievedUserType.Organisation(
                 GGCredId("gg-cred-id"),
+                Some(Email("email")),
                 Eori("AB12345678901234Z"),
                 Some(Name(Some("John Smith"), Some("Smith")))
               ),

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthenticatedActionWithRetrievedDataSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthenticatedActionWithRetrievedDataSpec.scala
@@ -185,6 +185,7 @@ class AuthenticatedActionWithRetrievedDataSpec
           RetrievedUserType
             .Organisation(
               GGCredId("id"),
+              Some(Email("email")),
               eori,
               None
             )

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneySpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ClaimantType
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ReimbursementMethodAnswer
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.NdrcDetails
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.RetrievedUserTypeGen.individualGen
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.RetrievedUserTypeGen.authenticatedUserGen
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators._
 
 import RejectedGoodsMultipleJourneyGenerators._
@@ -412,7 +412,7 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
 
     "get contact details" should {
       "return the specified details if they have been entered" in {
-        forAll(completeJourneyGen, individualGen) { (journey, signedInUser) =>
+        forAll(completeJourneyGen, authenticatedUserGen) { (journey, signedInUser) =>
           whenever(journey.answers.contactDetails.isDefined) {
             val result = journey.computeContactDetails(signedInUser)
             result shouldBe journey.answers.contactDetails
@@ -427,7 +427,7 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
             acc14DeclarantMatchesUserEori = false,
             submitContactDetails = false
           ),
-          individualGen
+          authenticatedUserGen
         ) { (journey, signedInUser) =>
           whenever(
             journey.getLeadDisplayDeclaration.flatMap(_.getConsigneeDetails.flatMap(_.contactDetails)).isDefined
@@ -453,7 +453,7 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
             submitConsigneeDetails = false,
             submitContactDetails = false
           ),
-          individualGen
+          authenticatedUserGen
         ) { (journey, signedInUser) =>
           whenever(
             journey.getLeadDisplayDeclaration.flatMap(_.getDeclarantDetails.contactDetails).isDefined &&
@@ -479,7 +479,7 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
             submitConsigneeDetails = true,
             submitContactDetails = false
           ),
-          individualGen
+          authenticatedUserGen
         ) { (journey, signedInUser) =>
           whenever(
             journey.getLeadDisplayDeclaration.flatMap(_.getDeclarantDetails.contactDetails).isDefined
@@ -505,7 +505,7 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
             submitConsigneeDetails = true,
             submitContactDetails = false
           ),
-          individualGen
+          authenticatedUserGen
         ) { (journey, signedInUser) =>
           whenever(
             journey.getLeadDisplayDeclaration.flatMap(_.getDeclarantDetails.contactDetails).isDefined

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneySpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ClaimantType
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ReimbursementMethodAnswer
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.NdrcDetails
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.RetrievedUserTypeGen.individualGen
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.RetrievedUserTypeGen.authenticatedUserGen
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators._
 
 import RejectedGoodsSingleJourneyGenerators._
@@ -302,7 +302,7 @@ class RejectedGoodsSingleJourneySpec extends AnyWordSpec with ScalaCheckProperty
 
     "get contact details" should {
       "return the specified details if they have been entered" in {
-        forAll(completeJourneyGen, individualGen) { (journey, signedInUser) =>
+        forAll(completeJourneyGen, authenticatedUserGen) { (journey, signedInUser) =>
           whenever(journey.answers.contactDetails.isDefined) {
             val result = journey.computeContactDetails(signedInUser)
             result shouldBe journey.answers.contactDetails
@@ -317,7 +317,7 @@ class RejectedGoodsSingleJourneySpec extends AnyWordSpec with ScalaCheckProperty
             acc14DeclarantMatchesUserEori = false,
             submitContactDetails = false
           ),
-          individualGen
+          authenticatedUserGen
         ) { (journey, signedInUser) =>
           whenever(
             journey.answers.displayDeclaration.flatMap(_.getConsigneeDetails.flatMap(_.contactDetails)).isDefined
@@ -343,7 +343,7 @@ class RejectedGoodsSingleJourneySpec extends AnyWordSpec with ScalaCheckProperty
             submitConsigneeDetails = false,
             submitContactDetails = false
           ),
-          individualGen
+          authenticatedUserGen
         ) { (journey, signedInUser) =>
           whenever(
             journey.answers.displayDeclaration.flatMap(_.getDeclarantDetails.contactDetails).isDefined &&
@@ -369,7 +369,7 @@ class RejectedGoodsSingleJourneySpec extends AnyWordSpec with ScalaCheckProperty
             submitConsigneeDetails = true,
             submitContactDetails = false
           ),
-          individualGen
+          authenticatedUserGen
         ) { (journey, signedInUser) =>
           whenever(
             journey.answers.displayDeclaration.flatMap(_.getDeclarantDetails.contactDetails).isDefined
@@ -395,7 +395,7 @@ class RejectedGoodsSingleJourneySpec extends AnyWordSpec with ScalaCheckProperty
             submitConsigneeDetails = true,
             submitContactDetails = false
           ),
-          individualGen
+          authenticatedUserGen
         ) { (journey, signedInUser) =>
           whenever(
             journey.answers.displayDeclaration.flatMap(_.getDeclarantDetails.contactDetails).isDefined

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/RetrievedUserTypeGen.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/RetrievedUserTypeGen.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators
 
 import org.scalacheck.Gen
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType.Individual
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.EmailGen._
 
@@ -30,4 +30,14 @@ object RetrievedUserTypeGen {
     eori     <- genEori
     name     <- genName
   } yield RetrievedUserType.Individual(ggCredId, Some(email), eori, Some(name))
+
+  lazy val organisationGen: Gen[Organisation] = for {
+    ggCredId <- genGGCredId
+    email    <- genEmail
+    eori     <- genEori
+    name     <- genName
+  } yield RetrievedUserType.Organisation(ggCredId, Some(email), eori, Some(name))
+
+  lazy val authenticatedUserGen: Gen[RetrievedUserType] =
+    Gen.oneOf[RetrievedUserType](individualGen, organisationGen)
 }


### PR DESCRIPTION
This PR fixes contact details retrieval for Organisation-type users, currently they cannot pass the claimant-details page.