### PR TITLE
CDSR-1332-fix-second-mrn-removal

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/RejectedGoodsMultipleJourneyRouter.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/RejectedGoodsMultipleJourneyRouter.scala
@@ -26,7 +26,8 @@ trait RejectedGoodsMultipleJourneyRouter {
   def routeForValidationError(error: String): Call =
     error match {
       case JOURNEY_ALREADY_FINALIZED                                => routes.CheckYourAnswersController.showConfirmation()
-      case MISSING_MOVEMENT_REFERENCE_NUMBER                        => undefined //routes.EnterMovementReferenceNumberController.show()
+      case MISSING_FIRST_MOVEMENT_REFERENCE_NUMBER                  => undefined //routes.EnterMovementReferenceNumberController.show()
+      case MISSING_SECOND_MOVEMENT_REFERENCE_NUMBER                 => undefined //routes.EnterMovementReferenceNumberController.show()
       case MISSING_DISPLAY_DECLARATION                              => undefined //routes.EnterMovementReferenceNumberController.show()
       case MISSING_BASIS_OF_CLAIM                                   => undefined //routes.BasisForClaimController.show()
       case MISSING_DETAILS_OF_REJECTED_GOODS                        => undefined

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
@@ -377,9 +377,11 @@ final class RejectedGoodsMultipleJourney private (
   def removeMovementReferenceNumberAndDisplayDeclaration(mrn: MRN): Either[String, RejectedGoodsMultipleJourney] =
     whileJourneyIsAmendable {
       getIndexOfMovementReferenceNumber(mrn) match {
-        case None        => Left("removeMovementReferenceNumberAndDisplayDeclaration.notFound")
-        case Some(0)     => Left("removeMovementReferenceNumberAndDisplayDeclaration.cannotRemoveLeadMRN")
-        case Some(index) =>
+        case None                                             => Left("removeMovementReferenceNumberAndDisplayDeclaration.notFound")
+        case Some(0)                                          => Left("removeMovementReferenceNumberAndDisplayDeclaration.cannotRemoveFirstMRN")
+        case Some(1) if countOfMovementReferenceNumbers === 2 =>
+          Left("removeMovementReferenceNumberAndDisplayDeclaration.cannotRemoveSecondMRN")
+        case Some(index)                                      =>
           Right(
             new RejectedGoodsMultipleJourney(
               answers.copy(
@@ -774,7 +776,8 @@ object RejectedGoodsMultipleJourney extends FluentImplicits[RejectedGoodsMultipl
   /** Validate if all required answers has been provided and the journey is ready to produce output. */
   val validator: Validate[RejectedGoodsMultipleJourney] =
     all(
-      check(_.answers.movementReferenceNumbers.exists(_.nonEmpty), MISSING_MOVEMENT_REFERENCE_NUMBER),
+      check(_.answers.movementReferenceNumbers.exists(_.nonEmpty), MISSING_FIRST_MOVEMENT_REFERENCE_NUMBER),
+      check(_.answers.movementReferenceNumbers.exists(_.size > 1), MISSING_FIRST_MOVEMENT_REFERENCE_NUMBER),
       check(_.answers.displayDeclarations.exists(_.nonEmpty), MISSING_DISPLAY_DECLARATION),
       checkIsDefined(_.answers.basisOfClaim, MISSING_BASIS_OF_CLAIM),
       checkIsDefined(_.answers.detailsOfRejectedGoods, MISSING_DETAILS_OF_REJECTED_GOODS),
@@ -917,7 +920,8 @@ object RejectedGoodsMultipleJourney extends FluentImplicits[RejectedGoodsMultipl
 
   object ValidationErrors {
     val JOURNEY_ALREADY_FINALIZED: String                                = "journeyAlreadyFinalized"
-    val MISSING_MOVEMENT_REFERENCE_NUMBER: String                        = "missingMovementReferenceNumber"
+    val MISSING_FIRST_MOVEMENT_REFERENCE_NUMBER: String                  = "missingFirstMovementReferenceNumber"
+    val MISSING_SECOND_MOVEMENT_REFERENCE_NUMBER: String                 = "missingSecondMovementReferenceNumber"
     val MISSING_DISPLAY_DECLARATION: String                              = "missingDisplayDeclaration"
     val MISSING_BASIS_OF_CLAIM: String                                   = "missingBasisOfClaim"
     val MISSING_DETAILS_OF_REJECTED_GOODS: String                        = "missingDetailsOfRejectedGoods"

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
@@ -76,8 +76,7 @@ final class RejectedGoodsSingleJourney private (
     answers.reimbursementClaims.exists(rc => rc.nonEmpty && rc.forall(_._2.isDefined))
 
   def hasCompleteSupportingEvidences: Boolean =
-    answers.checkYourAnswersChangeMode &&
-      answers.supportingEvidences.forall(_.documentType.isDefined)
+    answers.supportingEvidences.forall(_.documentType.isDefined)
 
   def getConsigneeEoriFromACC14: Option[Eori] =
     answers.displayDeclaration.flatMap(_.getConsigneeEori)
@@ -523,7 +522,12 @@ final class RejectedGoodsSingleJourney private (
 
   def submitCheckYourAnswersChangeMode(enabled: Boolean): RejectedGoodsSingleJourney =
     whileJourneyIsAmendable {
-      new RejectedGoodsSingleJourney(answers.copy(checkYourAnswersChangeMode = enabled))
+      RejectedGoodsSingleJourney.validator
+        .apply(this)
+        .fold(
+          _ => this,
+          _ => new RejectedGoodsSingleJourney(answers.copy(checkYourAnswersChangeMode = enabled))
+        )
     }
 
   def finalizeJourneyWith(caseNumber: String): Either[String, RejectedGoodsSingleJourney] =

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/CheckYourAnswersControllerSpec.scala
@@ -96,10 +96,13 @@ class CheckYourAnswersControllerSpec
     val summaryValues = doc.select(".govuk-summary-list__value").eachText()
     val summary       = summaryKeys.asScala.zip(summaryValues.asScala).toMap
 
-    headers            should not be empty
-    summaryKeys        should not be empty
-    summaryValues      should not be empty
-    summaryKeys.size shouldBe summaryValues.size
+    headers              should not be empty
+    summaryKeys          should not be empty
+    summaryValues        should not be empty
+    if (claim.supportingEvidences.isEmpty)
+      summaryKeys.size shouldBe (summaryValues.size - 1)
+    else
+      summaryKeys.size shouldBe summaryValues.size
 
     headers should contain allOf ("Movement Reference Numbers (MRNs)", "Declaration details", "Contact information for this claim", "Basis for claim", "Disposal method", "Details of rejected goods", "Claim total", "Details of inspection", "Repayment method", "Supporting documents", "Now send your application")
 
@@ -114,9 +117,8 @@ class CheckYourAnswersControllerSpec
       "Inspection date",
       "Inspection address type",
       "Inspection address",
-      "Method",
-      "Uploaded"
-    )): _*)
+      "Method"
+    ) ++ (if (claim.supportingEvidences.isEmpty) Seq.empty else Seq("Uploaded"))): _*)
 
     mrnKeys.zip(claim.movementReferenceNumbers).foreach { case (key, mrn) =>
       summary(key) shouldBe mrn.value

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckYourAnswersControllerSpec.scala
@@ -96,14 +96,20 @@ class CheckYourAnswersControllerSpec
     val summaryValues = doc.select(".govuk-summary-list__value").eachText()
     val summary       = summaryKeys.asScala.zip(summaryValues.asScala).toMap
 
-    headers            should not be empty
-    summaryKeys        should not be empty
-    summaryValues      should not be empty
-    summaryKeys.size shouldBe summaryValues.size
+    headers              should not be empty
+    summaryKeys          should not be empty
+    summaryValues        should not be empty
+    if (claim.supportingEvidences.isEmpty)
+      summaryKeys.size shouldBe (summaryValues.size - 1)
+    else
+      summaryKeys.size shouldBe summaryValues.size
 
     headers should contain allOf ("Movement Reference Number (MRN)", "Declaration details", "Contact information for this claim", "Basis for claim", "Disposal method", "Details of rejected goods", "Claim total", "Details of inspection", "Repayment method", "Supporting documents", "Now send your application")
 
-    summaryKeys should contain allOf ("MRN", "Contact details", "Contact address", "This is the basis behind the claim", "This is how the goods will be disposed of", "These are the details of the rejected goods", "Total", "Inspection date", "Inspection address type", "Inspection address", "Method", "Uploaded")
+    if (claim.supportingEvidences.isEmpty)
+      summaryKeys should contain allOf ("MRN", "Contact details", "Contact address", "This is the basis behind the claim", "This is how the goods will be disposed of", "These are the details of the rejected goods", "Total", "Inspection date", "Inspection address type", "Inspection address", "Method")
+    else
+      summaryKeys should contain allOf ("MRN", "Contact details", "Contact address", "This is the basis behind the claim", "This is how the goods will be disposed of", "These are the details of the rejected goods", "Total", "Inspection date", "Inspection address type", "Inspection address", "Method", "Uploaded")
 
     summary("MRN")                                         shouldBe claim.movementReferenceNumber.value
     summary("Contact details")                             shouldBe s"${claim.claimantInformation.summaryContact(" ")}"

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyTestData.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyTestData.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
 
+import cats.syntax.eq._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.Country
@@ -40,6 +41,20 @@ trait JourneyTestData {
             s"Journey construction in ${pos.fileName}:${pos.lineNumber} has failed because of $error"
           ),
         identity
+      )
+
+    def expectFailure(expectedError: String)(implicit pos: org.scalactic.source.Position): Unit =
+      either.fold(
+        error =>
+          if (error === expectedError) ()
+          else
+            throw new Exception(
+              s"Journey construction in ${pos.fileName}:${pos.lineNumber} has failed as expected, but error was different: $error"
+            ),
+        _ =>
+          throw new Exception(
+            s"Expected failure but journey construction succeeded in ${pos.fileName}:${pos.lineNumber}"
+          )
       )
   }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneyGenerators.scala
@@ -144,6 +144,7 @@ object RejectedGoodsMultipleJourneyGenerators extends JourneyGenerators with Rej
     submitBankAccountType: Boolean = true,
     reimbursementMethod: Option[ReimbursementMethodAnswer] = None,
     minNumberOfMRNs: Int = 2,
+    maxNumberOfMRNs: Int = 6,
     maxSize: Int = 5
   ): Gen[RejectedGoodsMultipleJourney] =
     buildJourneyGen(
@@ -158,6 +159,7 @@ object RejectedGoodsMultipleJourneyGenerators extends JourneyGenerators with Rej
       submitBankAccountType = submitBankAccountType,
       reimbursementMethod = reimbursementMethod,
       minNumberOfMRNs = minNumberOfMRNs,
+      maxNumberOfMRNs = maxNumberOfMRNs,
       maxSize = maxSize
     ).map(
       _.fold(
@@ -196,11 +198,12 @@ object RejectedGoodsMultipleJourneyGenerators extends JourneyGenerators with Rej
     submitBankAccountType: Boolean = true,
     reimbursementMethod: Option[ReimbursementMethodAnswer] = None,
     minNumberOfMRNs: Int = 2,
+    maxNumberOfMRNs: Int = 6,
     maxSize: Int = 5
   ): Gen[Either[String, RejectedGoodsMultipleJourney]] =
     for {
       userEoriNumber      <- IdGen.genEori
-      numberOfMRNs        <- Gen.choose(minNumberOfMRNs, 3 * minNumberOfMRNs)
+      numberOfMRNs        <- Gen.choose(minNumberOfMRNs, Math.max(minNumberOfMRNs, maxNumberOfMRNs))
       mrns                <- Gen.listOfN(numberOfMRNs, IdGen.genMRN)
       declarantEORI       <- if (acc14DeclarantMatchesUserEori) Gen.const(userEoriNumber) else IdGen.genEori
       consigneeEORI       <- if (acc14ConsigneeMatchesUserEori) Gen.const(userEoriNumber) else IdGen.genEori

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneyGenerators.scala
@@ -212,13 +212,13 @@ object RejectedGoodsMultipleJourneyGenerators extends JourneyGenerators with Rej
       methodOfDisposal    <- Gen.oneOf(MethodOfDisposal.values)
       reimbursementMethod <- reimbursementMethod.map(Gen.const).getOrElse(Gen.oneOf(ReimbursementMethodAnswer.values))
 
-      numberOfSupportingEvidences <- Gen.choose(1, maxSize)
+      numberOfSupportingEvidences <- Gen.choose(0, maxSize)
       numberOfDocumentTypes       <- Gen.choose(1, maxSize - 1)
       documentTypes               <- Gen.listOfN(numberOfDocumentTypes, Gen.oneOf(UploadDocumentType.rejectedGoodsMultipleTypes))
       supportingEvidences         <-
         Gen
           .sequence[Seq[(UploadDocumentType, Int)], (UploadDocumentType, Int)](
-            documentTypes.map(dt => Gen.choose(1, numberOfSupportingEvidences).map(n => (dt, n)))
+            documentTypes.map(dt => Gen.choose(0, numberOfSupportingEvidences).map(n => (dt, n)))
           )
           .map(_.toMap)
       bankAccountType             <- Gen.oneOf(BankAccountType.values)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneySpec.scala
@@ -247,12 +247,12 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
           .removeMovementReferenceNumberAndDisplayDeclaration(
             journey.getLeadMovementReferenceNumber.get
           )
-        modifiedJourneyEither shouldBe Left("removeMovementReferenceNumberAndDisplayDeclaration.cannotRemoveLeadMRN")
+        modifiedJourneyEither shouldBe Left("removeMovementReferenceNumberAndDisplayDeclaration.cannotRemoveFirstMRN")
       }
     }
 
     "accept removal of non-lead MRN" in {
-      forAll(completeJourneyGen) { journey =>
+      forAll(buildCompleteJourneyGen(minNumberOfMRNs = 3)) { journey =>
         journey.answers.movementReferenceNumbers.get.drop(1).foreach { mrn =>
           val modifiedJourney = journey
             .removeMovementReferenceNumberAndDisplayDeclaration(mrn)
@@ -261,6 +261,16 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
           modifiedJourney.hasCompleteAnswers             shouldBe true
           modifiedJourney.hasCompleteReimbursementClaims shouldBe true
           modifiedJourney.hasCompleteSupportingEvidences shouldBe true
+        }
+      }
+    }
+
+    "decline removal of second MRN if only two" in {
+      forAll(buildCompleteJourneyGen(minNumberOfMRNs = 2, maxNumberOfMRNs = 2)) { journey =>
+        journey.answers.movementReferenceNumbers.get.drop(1).foreach { mrn =>
+          journey
+            .removeMovementReferenceNumberAndDisplayDeclaration(mrn)
+            .expectFailure("removeMovementReferenceNumberAndDisplayDeclaration.cannotRemoveSecondMRN")
         }
       }
     }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneySpec.scala
@@ -67,7 +67,7 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
       emptyJourney.getTotalReimbursementAmount              shouldBe BigDecimal("0.00")
       emptyJourney.isAllSelectedDutiesAreCMAEligible        shouldBe false
       emptyJourney.hasCompleteReimbursementClaims           shouldBe false
-      emptyJourney.hasCompleteSupportingEvidences           shouldBe false
+      emptyJourney.hasCompleteSupportingEvidences           shouldBe true
       emptyJourney.hasCompleteAnswers                       shouldBe false
       emptyJourney.toOutput.isLeft                          shouldBe true
       emptyJourney.isFinalized                              shouldBe false
@@ -101,6 +101,19 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
       }
     }
 
+    "check incompleteness if less than two MRNs" in {
+      forAll(buildCompleteJourneyGen(minNumberOfMRNs = 1, maxNumberOfMRNs = 1)) { journey =>
+        RejectedGoodsMultipleJourney.validator.apply(journey) shouldBe Validated.Invalid(
+          List(MISSING_SECOND_MOVEMENT_REFERENCE_NUMBER)
+        )
+        journey.answers.checkYourAnswersChangeMode            shouldBe false
+        journey.hasCompleteReimbursementClaims                shouldBe true
+        journey.hasCompleteSupportingEvidences                shouldBe true
+        journey.hasCompleteAnswers                            shouldBe false
+        journey.isFinalized                                   shouldBe false
+      }
+    }
+
     "finalize journey with caseNumber" in {
       forAll(completeJourneyGen) { journey =>
         journey.hasCompleteReimbursementClaims shouldBe true
@@ -126,7 +139,7 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
         journey.getLeadDisplayDeclaration      shouldBe Some(displayDeclaration)
         journey.hasCompleteAnswers             shouldBe false
         journey.hasCompleteReimbursementClaims shouldBe false
-        journey.hasCompleteSupportingEvidences shouldBe false
+        journey.hasCompleteSupportingEvidences shouldBe true
         journey.isFinalized                    shouldBe false
       }
     }
@@ -157,7 +170,7 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
         journey.countOfMovementReferenceNumbers shouldBe 11
         journey.hasCompleteAnswers              shouldBe false
         journey.hasCompleteReimbursementClaims  shouldBe false
-        journey.hasCompleteSupportingEvidences  shouldBe false
+        journey.hasCompleteSupportingEvidences  shouldBe true
         journey.isFinalized                     shouldBe false
       }
     }
@@ -181,7 +194,7 @@ class RejectedGoodsMultipleJourneySpec extends AnyWordSpec with ScalaCheckProper
         modifiedJourney.getLeadDisplayDeclaration       shouldBe Some(displayDeclaration)
         modifiedJourney.hasCompleteAnswers              shouldBe false
         modifiedJourney.hasCompleteReimbursementClaims  shouldBe false
-        modifiedJourney.hasCompleteSupportingEvidences  shouldBe false
+        modifiedJourney.hasCompleteSupportingEvidences  shouldBe true
         modifiedJourney.answers.reimbursementClaims     shouldBe None
         modifiedJourney.answers.inspectionAddress       shouldBe None
         modifiedJourney.answers.inspectionDate          shouldBe None

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneyGenerators.scala
@@ -177,13 +177,13 @@ object RejectedGoodsSingleJourneyGenerators extends JourneyGenerators with Rejec
       methodOfDisposal            <- Gen.oneOf(MethodOfDisposal.values)
       reimbursementMethod         <- reimbursementMethod.map(Gen.const).getOrElse(Gen.oneOf(ReimbursementMethodAnswer.values))
       numberOfSelectedTaxCodes    <- Gen.choose(1, numberOfTaxCodes)
-      numberOfSupportingEvidences <- Gen.choose(1, 3)
+      numberOfSupportingEvidences <- Gen.choose(0, 3)
       numberOfDocumentTypes       <- Gen.choose(1, 2)
       documentTypes               <- Gen.listOfN(numberOfDocumentTypes, Gen.oneOf(UploadDocumentType.rejectedGoodsSingleTypes))
       supportingEvidences         <-
         Gen
           .sequence[Seq[(UploadDocumentType, Int)], (UploadDocumentType, Int)](
-            documentTypes.map(dt => Gen.choose(1, numberOfSupportingEvidences).map(n => (dt, n)))
+            documentTypes.map(dt => Gen.choose(0, numberOfSupportingEvidences).map(n => (dt, n)))
           )
           .map(_.toMap)
       bankAccountType             <- Gen.oneOf(BankAccountType.values)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneySpec.scala
@@ -63,7 +63,7 @@ class RejectedGoodsSingleJourneySpec extends AnyWordSpec with ScalaCheckProperty
       emptyJourney.getSelectedDuties                        shouldBe None
       emptyJourney.isAllSelectedDutiesAreCMAEligible        shouldBe false
       emptyJourney.hasCompleteReimbursementClaims           shouldBe false
-      emptyJourney.hasCompleteSupportingEvidences           shouldBe false
+      emptyJourney.hasCompleteSupportingEvidences           shouldBe true
       emptyJourney.hasCompleteAnswers                       shouldBe false
       emptyJourney.toOutput.isLeft                          shouldBe true
       emptyJourney.isFinalized                              shouldBe false
@@ -120,7 +120,7 @@ class RejectedGoodsSingleJourneySpec extends AnyWordSpec with ScalaCheckProperty
         journey.answers.movementReferenceNumber.contains(mrn) shouldBe true
         journey.hasCompleteAnswers                            shouldBe false
         journey.hasCompleteReimbursementClaims                shouldBe false
-        journey.hasCompleteSupportingEvidences                shouldBe false
+        journey.hasCompleteSupportingEvidences                shouldBe true
         journey.isFinalized                                   shouldBe false
       }
     }
@@ -143,7 +143,7 @@ class RejectedGoodsSingleJourneySpec extends AnyWordSpec with ScalaCheckProperty
         modifiedJourney.answers.displayDeclaration     shouldBe Some(decl2)
         modifiedJourney.hasCompleteAnswers             shouldBe false
         modifiedJourney.hasCompleteReimbursementClaims shouldBe false
-        modifiedJourney.hasCompleteSupportingEvidences shouldBe false
+        modifiedJourney.hasCompleteSupportingEvidences shouldBe true
       }
     }
 
@@ -175,7 +175,7 @@ class RejectedGoodsSingleJourneySpec extends AnyWordSpec with ScalaCheckProperty
         journey.answers.displayDeclaration.contains(acc14.withDeclarationId(exampleMrnAsString)) shouldBe true
         journey.hasCompleteAnswers                                                               shouldBe false
         journey.hasCompleteReimbursementClaims                                                   shouldBe false
-        journey.hasCompleteSupportingEvidences                                                   shouldBe false
+        journey.hasCompleteSupportingEvidences                                                   shouldBe true
       }
     }
 
@@ -193,7 +193,7 @@ class RejectedGoodsSingleJourneySpec extends AnyWordSpec with ScalaCheckProperty
         modifiedJourney.answers.reimbursementClaims     shouldBe None
         modifiedJourney.hasCompleteAnswers              shouldBe false
         modifiedJourney.hasCompleteReimbursementClaims  shouldBe false
-        modifiedJourney.hasCompleteSupportingEvidences  shouldBe false
+        modifiedJourney.hasCompleteSupportingEvidences  shouldBe true
       }
     }
 


### PR DESCRIPTION
This PR fixes few bugs in multiple and single journey data model:
- it must be not possible to remove second MRN from multiple journey if only two MRNs left,
- it must be not possible to complete multiple journey with less then two MRNs,
- checkYourAnswersChangeMode flag can be only set if journey is complete,
- should generate test journeys with no supporting evidence