### PR TITLE
change to use new internal route prefix in upload-documents-frontend

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/config/UploadDocumentsConfig.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/config/UploadDocumentsConfig.scala
@@ -41,7 +41,7 @@ class UploadDocumentsConfig @Inject() (servicesConfig: ServicesConfig, configura
   lazy val retryIntervals: Seq[FiniteDuration] =
     Retries.getConfIntervals("upload-documents-frontend", configuration)
 
-  lazy val initializationUrl: String = s"$baseUrl$contextPath/initialize"
+  lazy val initializationUrl: String = s"$baseUrl/internal/initialize"
 
-  lazy val wipeOutUrl: String = s"$baseUrl$contextPath/wipe-out"
+  lazy val wipeOutUrl: String = s"$baseUrl/internal/wipe-out"
 }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/UploadDocumentsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/UploadDocumentsConnectorSpec.scala
@@ -81,8 +81,8 @@ class UploadDocumentsConnectorSpec
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
-  val expectedInitializationUrl = "http://host3:124/foo-upload/initialize"
-  val expectedWipeOutUrl        = "http://host3:124/foo-upload/wipe-out"
+  val expectedInitializationUrl = "http://host3:124/internal/initialize"
+  val expectedWipeOutUrl        = "http://host3:124/internal/wipe-out"
 
   val uploadDocumentsParameters: UploadDocumentsSessionConfig =
     UploadDocumentsSessionConfig(


### PR DESCRIPTION
This PR accompanies the change made in https://github.com/hmrc/upload-documents-frontend/pull/14