### PR TITLE
CDSR-1349: Bug fix for subsequent movement in multiple MRN journey

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/EnterMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/EnterMovementReferenceNumberController.scala
@@ -47,7 +47,7 @@ class EnterMovementReferenceNumberController @Inject() (
 
   val subKey: Some[String] = Some("multiple")
 
-  def showFirst(): Action[AnyContent] = show(1) // For lead MRN
+  def showFirst(): Action[AnyContent] = show(1)
 
   def show(pageIndex: Int): Action[AnyContent] = actionReadJourney { implicit request => journey =>
     (if (pageIndex <= 0 || pageIndex > journey.countOfMovementReferenceNumbers + 1)
@@ -133,13 +133,12 @@ class EnterMovementReferenceNumberController @Inject() (
     )
 
   private def redirectLocation(journey: RejectedGoodsMultipleJourney, pageIndex: Int): Result =
-    if (journey.needsDeclarantAndConsigneeEoriSubmission) {
+    if (journey.needsDeclarantAndConsigneeEoriMultipleSubmission(pageIndex)) {
       Redirect(routes.EnterImporterEoriNumberController.show())
     } else {
       Redirect(
         if (pageIndex === 1) routes.CheckDeclarationDetailsController.show()
-        else
-          routes.CheckMovementReferenceNumbersController.show()
+        else routes.CheckMovementReferenceNumbersController.show()
       )
     }
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
@@ -53,7 +53,7 @@ import java.time.LocalDate
   * The journey uses two nested case classes:
   *
   *  - [[RejectedGoodsMultipleJourney.Answers]] - keeps record of user answers and acquired documents
-  *  - [[RejectedGoodsMultipleJourney.Outcome]] - final outcome of the journey to be sent to backend processing
+  *  - [[RejectedGoodsMultipleJourney.Output]] - final outcome of the journey to be sent to backend processing
   */
 final class RejectedGoodsMultipleJourney private (
   val answers: RejectedGoodsMultipleJourney.Answers,
@@ -119,6 +119,9 @@ final class RejectedGoodsMultipleJourney private (
   def needsBanksAccountDetailsSubmission: Boolean =
     true
 
+  def needsDeclarantAndConsigneeEoriMultipleSubmission(pageIndex: Int): Boolean =
+    if (pageIndex === 1) needsDeclarantAndConsigneeEoriSubmission else false
+
   def getNdrcDetailsFor(mrn: MRN): Option[List[NdrcDetails]] =
     getDisplayDeclarationFor(mrn).flatMap(_.getNdrcDetailsList)
 
@@ -129,7 +132,7 @@ final class RejectedGoodsMultipleJourney private (
     * or None if either MRN or tax code not found.
     */
   def getAmountPaidFor(mrn: MRN, taxCode: TaxCode): Option[BigDecimal] =
-    getNdrcDetailsFor(mrn, taxCode).map(_.amount).map(BigDecimal.apply(_))
+    getNdrcDetailsFor(mrn, taxCode).map(_.amount).map(BigDecimal.apply)
 
   /** If the user has selected the tax code for repayment
     * then returns the amount paid for the given MRN and tax code as returned by ACC14,
@@ -187,7 +190,7 @@ final class RejectedGoodsMultipleJourney private (
     getReimbursementClaimsFor(mrn).map(_.map(_._2.getOrElse(ZERO)).sum)
 
   def getTotalReimbursementAmount: BigDecimal =
-    getReimbursementClaims.values.flatMap(_.map(_._2)).sum
+    getReimbursementClaims.values.flatMap(_.values).sum
 
   def withDutiesChangeMode(enabled: Boolean): RejectedGoodsMultipleJourney =
     new RejectedGoodsMultipleJourney(answers.copy(dutiesChangeMode = enabled))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/DisplayDeclaration.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/DisplayDeclaration.scala
@@ -77,7 +77,7 @@ final case class DisplayDeclaration(
 
   def hasSameEoriAs(other: DisplayDeclaration): Boolean =
     this.getDeclarantEori === other.getDeclarantEori ||
-      this.getConsigneeEori.map(eori => other.getConsigneeEori.contains(eori)).getOrElse(false)
+      this.getConsigneeEori.exists(eori => other.getConsigneeEori.contains(eori))
 
 }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyTestData.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyTestData.scala
@@ -67,6 +67,7 @@ trait JourneyTestData {
   val exampleEoriAsString: String = exampleEori.value
 
   val exampleMrn: MRN            = IdGen.genMRN.sample.get
+  val anotherExampleMrn: MRN     = IdGen.genMRN.sample.get
   val exampleMrnAsString: String = exampleMrn.value
 
   val uploadDocument = buildUploadDocument("foo")


### PR DESCRIPTION
Lead MRN EORIs should match EORIs from ACC14 for the subsequent MRNs. 

The scenario is already handled [here](https://github.com/hmrc/cds-reimbursement-claim-frontend/blob/5c12062838b257aebd7a98a2d94413939bfe9d82/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala#L227) so this fix is just to redirect to `/check-movement-reference-numbers` instead of `/enter-importer-eori` for the non-lead MRNs