### PR TITLE
CDSR-1344 C&E1179 Scheduled | /enter-importer-eori

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterImporterEoriNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterImporterEoriNumberController.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled
+
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.eoriNumberForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class EnterImporterEoriNumberController @Inject() (
+  val jcc: JourneyControllerComponents,
+  enterImporterEoriNumber: pages.enter_importer_eori_number
+)(implicit val ec: ExecutionContext, viewConfig: ViewConfig)
+    extends RejectedGoodsScheduledJourneyBaseController
+    with Logging {
+
+  val eoriNumberFormKey: String = "enter-importer-eori-number"
+
+  def show(): Action[AnyContent] = actionReadJourney { implicit request => journey =>
+    Ok(
+      enterImporterEoriNumber(
+        eoriNumberForm(eoriNumberFormKey).withDefault(journey.answers.consigneeEoriNumber),
+        routes.EnterImporterEoriNumberController.submit()
+      )
+    ).asFuture
+  }
+
+  def submit(): Action[AnyContent] = actionReadWriteJourney { implicit request => journey =>
+    eoriNumberForm(eoriNumberFormKey)
+      .bindFromRequest()
+      .fold(
+        formWithErrors =>
+          (
+            journey,
+            BadRequest(
+              enterImporterEoriNumber(
+                formWithErrors.fill(Eori("")),
+                routes.EnterImporterEoriNumberController.submit()
+              )
+            )
+          ).asFuture,
+        eori =>
+          journey
+            .submitConsigneeEoriNumber(eori)
+            .fold(
+              errors => {
+                logger.error(s"Unable to record $eori - $errors")
+                (journey, Redirect(baseRoutes.IneligibleController.ineligible()))
+              },
+              updatedJourney =>
+                (
+                  updatedJourney,
+                  Redirect("routes.EnterDeclarantEoriNumberController.show()")
+                )
+            )
+            .asFuture
+      )
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterMovementReferenceNumberController.scala
@@ -115,7 +115,7 @@ class EnterMovementReferenceNumberController @Inject() (
   private def redirectLocation(updatedJourney: RejectedGoodsScheduledJourney): Result                         =
     Redirect(
       if (updatedJourney.needsDeclarantAndConsigneeEoriSubmission) {
-        routes.WorkInProgressController.show() //TODO: Should be routes.EnterImporterEoriNumberController.show()
+        routes.EnterImporterEoriNumberController.show()
       } else {
         routes.WorkInProgressController.show() //TODO: Should be routes.CheckDeclarationDetailsController.show()
       }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/RejectedGoodsSingleJourneyRouter.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/RejectedGoodsSingleJourneyRouter.scala
@@ -40,8 +40,8 @@ trait RejectedGoodsScheduledJourneyRouter {
       case TOTAL_REIMBURSEMENT_AMOUNT_MUST_BE_GREATER_THAN_ZERO     => undefined
       case DECLARANT_EORI_NUMBER_MUST_BE_PROVIDED                   => undefined
       case DECLARANT_EORI_NUMBER_MUST_BE_EQUAL_TO_THAT_OF_ACC14     => undefined
-      case CONSIGNEE_EORI_NUMBER_MUST_BE_PROVIDED                   => undefined
-      case CONSIGNEE_EORI_NUMBER_MUST_BE_EQUAL_TO_THAT_OF_ACC14     => undefined
+      case CONSIGNEE_EORI_NUMBER_MUST_BE_PROVIDED                   => routes.EnterImporterEoriNumberController.show()
+      case CONSIGNEE_EORI_NUMBER_MUST_BE_EQUAL_TO_THAT_OF_ACC14     => routes.EnterImporterEoriNumberController.show()
       case DECLARANT_EORI_NUMBER_DOES_NOT_HAVE_TO_BE_PROVIDED       => undefined
       case CONSIGNEE_EORI_NUMBER_DOES_NOT_HAVE_TO_BE_PROVIDED       => undefined
       case BANK_ACCOUNT_DETAILS_MUST_BE_DEFINED                     => undefined

--- a/conf/rejected_goods_scheduled.routes
+++ b/conf/rejected_goods_scheduled.routes
@@ -1,8 +1,8 @@
 GET          /rejected-goods/scheduled/enter-movement-reference-number               @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled.EnterMovementReferenceNumberController.show()
 POST         /rejected-goods/scheduled/enter-movement-reference-number               @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled.EnterMovementReferenceNumberController.submit()
 
-GET          /rejected-goods/scheduled/enter-importer-eori                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled.WorkInProgressController.show()
-POST         /rejected-goods/scheduled/enter-importer-eori                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled.WorkInProgressController.submit()
+GET          /rejected-goods/scheduled/enter-importer-eori                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled.EnterImporterEoriNumberController.show()
+POST         /rejected-goods/scheduled/enter-importer-eori                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled.EnterImporterEoriNumberController.submit()
 
 GET          /rejected-goods/scheduled/enter-declarant-eori                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled.WorkInProgressController.show()
 POST         /rejected-goods/scheduled/enter-declarant-eori                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled.WorkInProgressController.submit()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterImporterEoriNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterImporterEoriNumberControllerSpec.scala
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled
+
+import cats.implicits._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.i18n.Lang
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
+import play.api.inject.bind
+import play.api.inject.guice.GuiceableModule
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.JourneyTestData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduledJourneyGenerators.buildCompleteJourneyGen
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.ConsigneeDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DisplayDeclarationGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DisplayResponseDetailGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+
+import scala.concurrent.Future
+
+class EnterImporterEoriNumberControllerSpec
+    extends ControllerSpec
+    with AuthSupport
+    with SessionSupport
+    with BeforeAndAfterEach
+    with ScalaCheckPropertyChecks
+    with JourneyTestData {
+
+  override val overrideBindings: List[GuiceableModule] =
+    List[GuiceableModule](
+      bind[AuthConnector].toInstance(mockAuthConnector),
+      bind[SessionCache].toInstance(mockSessionCache)
+    )
+
+  val controller: EnterImporterEoriNumberController = instanceOf[EnterImporterEoriNumberController]
+
+  implicit val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
+
+  private lazy val featureSwitch = instanceOf[FeatureSwitchService]
+
+  override def beforeEach(): Unit =
+    featureSwitch.enable(Feature.RejectedGoods)
+
+  private val session = SessionData.empty.copy(
+    rejectedGoodsScheduledJourney = Some(RejectedGoodsScheduledJourney.empty(exampleEori))
+  )
+
+  "Importer Eori Number Controller" when {
+    "Enter Importer Eori page" must {
+
+      def performAction(): Future[Result] =
+        controller.show()(FakeRequest())
+
+      "do not find the page if rejected goods feature is disabled" in {
+        featureSwitch.disable(Feature.RejectedGoods)
+
+        status(performAction()) shouldBe NOT_FOUND
+      }
+
+      "display the page on a new journey" in {
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+        }
+
+        checkPageIsDisplayed(
+          performAction(),
+          messageFromMessageKey("enter-importer-eori-number.title"),
+          doc => {
+            doc
+              .select("form div#enter-importer-eori-number-hint")
+              .text()                                         shouldBe messageFromMessageKey("enter-importer-eori-number.help-text")
+            doc.select("#enter-importer-eori-number").`val`() shouldBe ""
+            doc.select("form").attr("action")                 shouldBe routes.EnterImporterEoriNumberController.submit().url
+          }
+        )
+      }
+
+      "display the page on a pre-existing journey" in {
+        val journey        = buildCompleteJourneyGen(
+          acc14DeclarantMatchesUserEori = false,
+          acc14ConsigneeMatchesUserEori = false,
+          hasConsigneeDetailsInACC14 = true
+        ).sample.getOrElse(
+          fail("Unable to generate complete journey")
+        )
+        val eori           = journey.answers.consigneeEoriNumber.getOrElse(fail("No consignee eori found"))
+        val sessionToAmend = session.copy(rejectedGoodsScheduledJourney = Some(journey))
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(sessionToAmend)
+        }
+
+        checkPageIsDisplayed(
+          performAction(),
+          messageFromMessageKey("enter-importer-eori-number.title"),
+          doc => {
+            doc
+              .select("form div#enter-importer-eori-number-hint")
+              .text()                                         shouldBe messageFromMessageKey("enter-importer-eori-number.help-text")
+            doc.select("#enter-importer-eori-number").`val`() shouldBe eori.value
+          }
+        )
+      }
+    }
+
+    "Submit Importer Eori  page" must {
+
+      def performAction(data: (String, String)*): Future[Result] =
+        controller.submit()(FakeRequest().withFormUrlEncodedBody(data: _*))
+
+      "do not find the page if rejected goods feature is disabled" in {
+        featureSwitch.disable(Feature.RejectedGoods)
+
+        status(performAction()) shouldBe NOT_FOUND
+      }
+
+      "reject an empty Eori" in {
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+        }
+
+        checkPageIsDisplayed(
+          performAction(controller.eoriNumberFormKey -> ""),
+          messageFromMessageKey("enter-importer-eori-number.title"),
+          doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-importer-eori-number.error.required"),
+          expectedStatus = BAD_REQUEST
+        )
+      }
+
+      "reject an invalid Eori" in {
+        val invalidEori = Eori("INVALID_MOVEMENT_REFERENCE_NUMBER")
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+        }
+
+        checkPageIsDisplayed(
+          performAction(controller.eoriNumberFormKey -> invalidEori.value),
+          messageFromMessageKey("enter-importer-eori-number.title"),
+          doc => {
+            getErrorSummary(doc)                              shouldBe messageFromMessageKey("enter-importer-eori-number.invalid.number")
+            doc.select("#enter-importer-eori-number").`val`() shouldBe ""
+          },
+          expectedStatus = BAD_REQUEST
+        )
+      }
+
+      "submit a valid Eori which is the Consignee Eori" in forAll {
+        (
+          mrn: MRN,
+          eori: Eori,
+          initialDisplayDeclaration: DisplayDeclaration,
+          initialConsigneeDetails: ConsigneeDetails
+        ) =>
+          val initialJourney                = session.rejectedGoodsScheduledJourney.getOrElse(fail("No rejected goods journey"))
+          val displayDeclaration            = initialDisplayDeclaration.withDeclarationId(mrn.value)
+          val consigneeDetails              = initialConsigneeDetails.copy(consigneeEORI = eori.value)
+          val updatedDisplayResponseDetails =
+            displayDeclaration.displayResponseDetail.copy(consigneeDetails = Some(consigneeDetails))
+          val updatedDisplayDeclaration     = displayDeclaration.copy(displayResponseDetail = updatedDisplayResponseDetails)
+          val journey                       =
+            initialJourney
+              .submitMovementReferenceNumberAndDeclaration(mrn, updatedDisplayDeclaration)
+              .getOrFail
+
+          val requiredSession = session.copy(rejectedGoodsScheduledJourney = Some(journey))
+          val updatedJourney  = journey.submitConsigneeEoriNumber(eori).getOrElse(fail("Unable to update eori"))
+          val updatedSession  = session.copy(rejectedGoodsScheduledJourney = Some(updatedJourney))
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(requiredSession)
+            mockStoreSession(updatedSession)(Right(()))
+          }
+
+          checkIsRedirect(
+            performAction(controller.eoriNumberFormKey -> eori.value),
+            "routes.EnterDeclarantEoriNumberController.show()" // todo CDS-1346
+          )
+      }
+
+      "submit a valid Eori which is not the consignee" in forAll {
+        (
+          mrn: MRN,
+          enteredConsigneeEori: Eori,
+          wantedConsignee: Eori,
+          initialDisplayDeclaration: DisplayDeclaration
+        ) =>
+          whenever(enteredConsigneeEori =!= wantedConsignee) {
+            val initialJourney                = session.rejectedGoodsScheduledJourney.getOrElse(fail("No rejected goods journey"))
+            val displayDeclaration            = initialDisplayDeclaration.withDeclarationId(mrn.value)
+            val updatedConsigneDetails        =
+              displayDeclaration.getConsigneeDetails.map(_.copy(consigneeEORI = wantedConsignee.value))
+            val updatedDisplayResponseDetails =
+              displayDeclaration.displayResponseDetail.copy(consigneeDetails = updatedConsigneDetails)
+            val updatedDisplayDeclaration     =
+              displayDeclaration.copy(displayResponseDetail = updatedDisplayResponseDetails)
+            val journey                       =
+              initialJourney
+                .submitMovementReferenceNumberAndDeclaration(mrn, updatedDisplayDeclaration)
+                .getOrFail
+            val requiredSession               = session.copy(rejectedGoodsScheduledJourney = Some(journey))
+
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(requiredSession)
+            }
+
+            checkIsRedirect(
+              performAction(controller.eoriNumberFormKey -> enteredConsigneeEori.value),
+              baseRoutes.IneligibleController.ineligible()
+            )
+          }
+      }
+    }
+  }
+}


### PR DESCRIPTION
As a trader on a C&E1179 Scheduled journey

I want to enter the importer eori, if I fail the initial eori check

So that I get a second chance to validate my EORIs against the EORIs brought back by ACC14.