### PR TITLE
[CDSR-1698] split /:journey/check-if-claim-was-sent, /:journey/claim-submitted, /:journey/check-answers-accept-send

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Router.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Router.scala
@@ -67,7 +67,9 @@ trait JourneyTypeRoutes extends Product with Serializable {
 
   object CheckAnswers {
     def when(flag: Boolean)(alternatively: => Call): Call =
-      if (flag) claimRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(journeyBindable) else alternatively
+      if (flag)
+        controllers.claims.OverpaymentsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(journeyBindable)
+      else alternatively
   }
 
   def nextPageForCheckDeclarationDetails(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartController.scala
@@ -34,7 +34,6 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.Email
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.Name
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.util.toFuture
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views
@@ -67,9 +66,7 @@ class StartController @Inject() (
         request.authenticatedRequest.journeyUserType,
         request.sessionData.journeyStatus
       ) match {
-        case (_, Some(journeyStatus)) =>
-          handleSessionJourneyStatus(journeyStatus)
-        case (retrievedUserType, _)   =>
+        case (retrievedUserType, _) =>
           handleRetrievedUserType(retrievedUserType)
       }
     }
@@ -118,32 +115,6 @@ class StartController @Inject() (
 
   val timedOut: Action[AnyContent] =
     Action(implicit request => Ok(timedOutPage()))
-
-  private def handleSessionJourneyStatus(
-    journeyStatus: JourneyStatus
-  ): Future[Result] =
-    journeyStatus match {
-
-      case NonGovernmentGatewayJourney =>
-        Redirect(routes.StartController.weOnlySupportGG())
-
-      case claim: FillingOutClaim =>
-        Redirect(
-          controllers.claims.routes.CheckYourAnswersAndSubmitController.checkAllAnswers(
-            JourneyExtractor.extractJourney(claim)
-          )
-        )
-
-      case claim: JustSubmittedClaim =>
-        Redirect(
-          controllers.claims.routes.CheckYourAnswersAndSubmitController.confirmationOfSubmission(claim.journey)
-        )
-
-      case claim: SubmitClaimFailed =>
-        Redirect(
-          controllers.claims.routes.CheckYourAnswersAndSubmitController.submissionError(claim.journey)
-        )
-    }
 
   private def handleRetrievedUserType(
     retrievedUserType: RetrievedUserType

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataAction.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataAction.scala
@@ -45,9 +45,9 @@ final case class RequestWithSessionData[A](
   override def messagesApi: MessagesApi = authenticatedRequest.request.messagesApi
 
   val signedInUserDetails: Option[SignedInUserDetails] = sessionData.flatMap(_.journeyStatus).collect {
-    case JourneyStatus.FillingOutClaim(_, signedInUserDetails, _)          => signedInUserDetails
-    case JourneyStatus.JustSubmittedClaim(_, signedInUserDetails, _, _, _) => signedInUserDetails
-    case JourneyStatus.SubmitClaimFailed(_, signedInUserDetails, _)        => signedInUserDetails
+    case JourneyStatus.FillingOutClaim(_, signedInUserDetails, _)       => signedInUserDetails
+    case JourneyStatus.JustSubmittedClaim(_, signedInUserDetails, _, _) => signedInUserDetails
+    case JourneyStatus.SubmitClaimFailed(_, signedInUserDetails)        => signedInUserDetails
   }
 
   def using(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMovementReferenceNumberController.scala
@@ -110,7 +110,7 @@ class EnterMovementReferenceNumberController @Inject() (
                 previousAnswer.exists(_.value === mrnNumber.value)
 
               if (isSameAsPrevious && fillingOutClaim.draftClaim.isComplete)
-                Redirect(routes.CheckYourAnswersAndSubmitController.checkAllAnswers(journey))
+                Redirect(OverpaymentsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(journey))
               else if (isSameAsPrevious && journey === JourneyBindable.Multiple)
                 Redirect(routes.CheckMovementReferenceNumbersController.showMrns())
               else {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/OverpaymentsRoutes.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/OverpaymentsRoutes.scala
@@ -41,4 +41,30 @@ object OverpaymentsRoutes {
     }
   }
 
+  object CheckYourAnswersAndSubmitController {
+    def checkAllAnswers(journey: JourneyBindable): Call = journey match {
+      case JourneyBindable.Single    => overpaymentsSingleRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers
+      case JourneyBindable.Multiple  => overpaymentsMultipleRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers
+      case JourneyBindable.Scheduled => overpaymentsScheduledRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers
+    }
+
+    def confirmationOfSubmission(journey: JourneyBindable): Call = journey match {
+      case JourneyBindable.Single    =>
+        overpaymentsSingleRoutes.CheckYourAnswersAndSubmitController.confirmationOfSubmission
+      case JourneyBindable.Multiple  =>
+        overpaymentsMultipleRoutes.CheckYourAnswersAndSubmitController.confirmationOfSubmission
+      case JourneyBindable.Scheduled =>
+        overpaymentsScheduledRoutes.CheckYourAnswersAndSubmitController.confirmationOfSubmission
+    }
+
+    def submissionError(journey: JourneyBindable): Call = journey match {
+      case JourneyBindable.Single    =>
+        overpaymentsSingleRoutes.CheckYourAnswersAndSubmitController.submissionError
+      case JourneyBindable.Multiple  =>
+        overpaymentsMultipleRoutes.CheckYourAnswersAndSubmitController.submissionError
+      case JourneyBindable.Scheduled =>
+        overpaymentsScheduledRoutes.CheckYourAnswersAndSubmitController.submissionError
+    }
+  }
+
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ReimbursementMethodController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ReimbursementMethodController.scala
@@ -84,7 +84,7 @@ class ReimbursementMethodController @Inject() (
                 _ =>
                   Redirect((answer, isAmend(fillingOutClaim)) match {
                     case (_, true)                                             =>
-                      claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single)
+                      OverpaymentsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single)
                     case (ReimbursementMethodAnswer.CurrentMonthAdjustment, _) =>
                       OverpaymentsRoutes.ChooseFileTypeController.show(JourneyBindable.Single)
                     case (ReimbursementMethodAnswer.BankAccountTransfer, _)    =>

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/CheckYourAnswersAndSubmitController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/CheckYourAnswersAndSubmitController.scala
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple
+
+import cats.data.EitherT
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.i18n.Lang
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import play.api.mvc.Result
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.C285ClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.C285Claim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DraftClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.util.toFuture
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResult
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResult.SubmitClaimError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResult.SubmitClaimSuccess
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
+
+@Singleton
+class CheckYourAnswersAndSubmitController @Inject() (
+  val authenticatedAction: AuthenticatedAction,
+  val sessionDataAction: SessionDataAction,
+  val sessionStore: SessionCache,
+  cc: MessagesControllerComponents,
+  claimService: ClaimService,
+  checkYourAnswersPage: pages.check_your_answers,
+  confirmationOfSubmissionPage: pages.confirmation_of_submission,
+  submitClaimFailedPage: pages.submit_claim_error
+)(implicit viewConfig: ViewConfig, ec: ExecutionContext, errorHandler: ErrorHandler)
+    extends FrontendController(cc)
+    with WithAuthAndSessionDataAction
+    with SessionDataExtractor
+    with SessionUpdates
+    with Logging {
+
+  val journey: JourneyBindable = JourneyBindable.Multiple
+
+  val checkAllAnswers: Action[AnyContent] =
+    authenticatedActionWithSessionData.async { implicit request =>
+      request.using { case fillingOutClaim: FillingOutClaim =>
+        implicit val router: ReimbursementRoutes = extractRoutes(fillingOutClaim.draftClaim, journey)
+        implicit val subKey: Option[String]      = router.subKey
+        Ok(
+          checkYourAnswersPage(
+            fillingOutClaim.draftClaim,
+            fillingOutClaim.signedInUserDetails.verifiedEmail,
+            fillingOutClaim.signedInUserDetails.eori,
+            journey,
+            routes.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit
+          )
+        )
+      }
+    }
+
+  val checkAllAnswersSubmit: Action[AnyContent] =
+    authenticatedActionWithSessionData.async { implicit request =>
+      withCompleteDraftClaim { (fillingOutClaim, completeClaim) =>
+        val result =
+          for {
+            response        <- EitherT.liftF(
+                                 submitClaim(
+                                   completeClaim,
+                                   fillingOutClaim,
+                                   fillingOutClaim.signedInUserDetails,
+                                   request.authenticatedRequest.request.messages.lang
+                                 )
+                               )
+            newJourneyStatus = response match {
+                                 case _: SubmitClaimError =>
+                                   SubmitClaimFailed(
+                                     fillingOutClaim.ggCredId,
+                                     fillingOutClaim.signedInUserDetails
+                                   )
+                                 case SubmitClaimSuccess(
+                                       submitClaimResponse
+                                     ) =>
+                                   JustSubmittedClaim(
+                                     fillingOutClaim.ggCredId,
+                                     fillingOutClaim.signedInUserDetails,
+                                     completeClaim,
+                                     submitClaimResponse
+                                   )
+                               }
+            _               <- EitherT(
+                                 updateSession(sessionStore, request)(
+                                   _.copy(journeyStatus = Some(newJourneyStatus))
+                                 )
+                               )
+          } yield response
+
+        result.fold(
+          logAndDisplayError("Error while trying to update session"),
+          {
+            case SubmitClaimError(e) =>
+              logger.warn(s"Could not submit return}", e)
+              Redirect(
+                routes.CheckYourAnswersAndSubmitController.submissionError
+              )
+
+            case SubmitClaimSuccess(_) =>
+              logger.info(
+                s"Successfully submitted claim with claim id :${completeClaim.id}"
+              )
+              Redirect(routes.CheckYourAnswersAndSubmitController.confirmationOfSubmission)
+          }
+        )
+      }
+
+    }
+
+  private def submitClaim(
+    claim: C285Claim,
+    fillingOutClaim: FillingOutClaim,
+    signedInUserDetails: SignedInUserDetails,
+    language: Lang
+  )(implicit
+    hc: HeaderCarrier
+  ): Future[SubmitClaimResult] =
+    claimService
+      .submitClaim(
+        C285ClaimRequest(
+          fillingOutClaim.draftClaim.id,
+          claim,
+          signedInUserDetails
+        ),
+        language
+      )
+      .bimap(
+        SubmitClaimError(_),
+        SubmitClaimSuccess(_)
+      )
+      .merge
+
+  val submissionError: Action[AnyContent] =
+    authenticatedActionWithSessionData.async { implicit request =>
+      withSubmitClaimFailed(_ => Ok(submitClaimFailedPage()))
+    }
+
+  val confirmationOfSubmission: Action[AnyContent] =
+    authenticatedActionWithSessionData.async { implicit request =>
+      withJustSubmittedClaim(claim =>
+        Ok(
+          confirmationOfSubmissionPage(claim.claim.totalReimbursementAmount, claim.submissionResponse.caseNumber, None)
+        )
+      )
+    }
+
+  private def withJustSubmittedClaim(
+    f: JustSubmittedClaim => Future[Result]
+  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+    request.sessionData.flatMap(_.journeyStatus) match {
+      case Some(j: JustSubmittedClaim) => f(j)
+      case _                           => Redirect(baseRoutes.StartController.start())
+    }
+
+  private def withSubmitClaimFailed(
+    f: Either[SubmitClaimFailed, RetrievedUserType] => Future[Result]
+  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+    request.sessionData.flatMap(_.journeyStatus) match {
+      case Some(s: SubmitClaimFailed)  => f(Left(s))
+      case Some(_: JustSubmittedClaim) =>
+        Redirect(routes.CheckYourAnswersAndSubmitController.confirmationOfSubmission)
+      case _                           => Redirect(baseRoutes.StartController.start())
+    }
+
+  private def withCompleteDraftClaim(
+    f: (FillingOutClaim, C285Claim) => Future[Result]
+  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+    request.using({ case fillingOutClaim @ FillingOutClaim(_, signedInUserDetails, draftClaim: DraftClaim) =>
+      C285Claim
+        .fromDraftClaim(draftClaim, signedInUserDetails.verifiedEmail, signedInUserDetails.eori)
+        .fold[Future[Result]](
+          error => logAndDisplayError("could not make a complete claim") apply error,
+          c285Claim => f(fillingOutClaim, c285Claim)
+        )
+    })
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/UploadFilesController.scala
@@ -28,13 +28,11 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.FileUploadConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.UploadDocumentsConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.UploadDocumentsConnector
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Nonce
@@ -88,7 +86,7 @@ class UploadFilesController @Inject() (
               selfUrl + routes.ChooseFileTypeController.show.url
 
             val continueAfterNoAnswerUrl =
-              selfUrl + claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Multiple).url
+              selfUrl + routes.CheckYourAnswersAndSubmitController.checkAllAnswers.url
 
             uploadDocumentsConnector
               .initialize(
@@ -98,8 +96,7 @@ class UploadFilesController @Inject() (
                       fillingOutClaim.draftClaim.nonce,
                       documentType,
                       continueAfterYesAnswerUrl,
-                      continueAfterNoAnswerUrl,
-                      JourneyBindable.Multiple
+                      continueAfterNoAnswerUrl
                     ),
                     fillingOutClaim.draftClaim.supportingEvidencesAnswer
                       .map(_.toList)
@@ -166,7 +163,7 @@ class UploadFilesController @Inject() (
               selfUrl + routes.ChooseFileTypeController.show.url
 
             val continueAfterNoAnswerUrl =
-              selfUrl + claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Multiple).url
+              selfUrl + routes.CheckYourAnswersAndSubmitController.checkAllAnswers.url
 
             uploadDocumentsConnector
               .initialize(
@@ -176,8 +173,7 @@ class UploadFilesController @Inject() (
                       fillingOutClaim.draftClaim.nonce,
                       documentType,
                       continueAfterYesAnswerUrl,
-                      continueAfterNoAnswerUrl,
-                      JourneyBindable.Multiple
+                      continueAfterNoAnswerUrl
                     ),
                     fillingOutClaim.draftClaim.supportingEvidencesAnswer
                       .map(_.toList)
@@ -216,8 +212,7 @@ class UploadFilesController @Inject() (
     nonce: Nonce,
     documentType: UploadDocumentType,
     continueAfterYesAnswerUrl: String,
-    continueAfterNoAnswerUrl: String,
-    journey: JourneyBindable
+    continueAfterNoAnswerUrl: String
   )(implicit
     request: Request[_],
     messages: Messages
@@ -226,7 +221,7 @@ class UploadFilesController @Inject() (
       nonce = nonce,
       continueUrl = continueAfterNoAnswerUrl,
       continueAfterYesAnswerUrl = Some(continueAfterYesAnswerUrl),
-      continueWhenFullUrl = selfUrl + claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(journey).url,
+      continueWhenFullUrl = selfUrl + routes.CheckYourAnswersAndSubmitController.checkAllAnswers.url,
       backlinkUrl = selfUrl + routes.ChooseFileTypeController.show.url,
       callbackUrl = uploadDocumentsConfig.callbackUrlPrefix + routes.UploadFilesController.callback.url,
       minimumNumberOfFiles = 0, // user can skip uploading the files

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadFilesController.scala
@@ -28,13 +28,11 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.FileUploadConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.UploadDocumentsConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.UploadDocumentsConnector
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Nonce
@@ -88,7 +86,7 @@ class UploadFilesController @Inject() (
               selfUrl + routes.ChooseFileTypeController.show.url
 
             val continueAfterNoAnswerUrl =
-              selfUrl + claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Scheduled).url
+              selfUrl + routes.CheckYourAnswersAndSubmitController.checkAllAnswers.url
 
             uploadDocumentsConnector
               .initialize(
@@ -98,8 +96,7 @@ class UploadFilesController @Inject() (
                       fillingOutClaim.draftClaim.nonce,
                       documentType,
                       continueAfterYesAnswerUrl,
-                      continueAfterNoAnswerUrl,
-                      JourneyBindable.Scheduled
+                      continueAfterNoAnswerUrl
                     ),
                     fillingOutClaim.draftClaim.supportingEvidencesAnswer
                       .map(_.toList)
@@ -166,7 +163,7 @@ class UploadFilesController @Inject() (
               selfUrl + routes.ChooseFileTypeController.show.url
 
             val continueAfterNoAnswerUrl =
-              selfUrl + claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Scheduled).url
+              selfUrl + routes.CheckYourAnswersAndSubmitController.checkAllAnswers.url
 
             uploadDocumentsConnector
               .initialize(
@@ -176,8 +173,7 @@ class UploadFilesController @Inject() (
                       fillingOutClaim.draftClaim.nonce,
                       documentType,
                       continueAfterYesAnswerUrl,
-                      continueAfterNoAnswerUrl,
-                      JourneyBindable.Scheduled
+                      continueAfterNoAnswerUrl
                     ),
                     fillingOutClaim.draftClaim.supportingEvidencesAnswer
                       .map(_.toList)
@@ -216,8 +212,7 @@ class UploadFilesController @Inject() (
     nonce: Nonce,
     documentType: UploadDocumentType,
     continueAfterYesAnswerUrl: String,
-    continueAfterNoAnswerUrl: String,
-    journey: JourneyBindable
+    continueAfterNoAnswerUrl: String
   )(implicit
     request: Request[_],
     messages: Messages
@@ -226,7 +221,7 @@ class UploadFilesController @Inject() (
       nonce = nonce,
       continueUrl = continueAfterNoAnswerUrl,
       continueAfterYesAnswerUrl = Some(continueAfterYesAnswerUrl),
-      continueWhenFullUrl = selfUrl + claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(journey).url,
+      continueWhenFullUrl = selfUrl + routes.CheckYourAnswersAndSubmitController.checkAllAnswers.url,
       backlinkUrl = selfUrl + routes.ChooseFileTypeController.show.url,
       callbackUrl = uploadDocumentsConfig.callbackUrlPrefix + routes.UploadFilesController.callback.url,
       minimumNumberOfFiles = 0, // user can skip uploading the files

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/CheckYourAnswersAndSubmitController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/CheckYourAnswersAndSubmitController.scala
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle
+
+import cats.data.EitherT
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.i18n.Lang
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import play.api.mvc.Result
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.C285ClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.C285Claim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DraftClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.RetrievedUserType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.util.toFuture
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResult
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResult.SubmitClaimError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResult.SubmitClaimSuccess
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
+
+@Singleton
+class CheckYourAnswersAndSubmitController @Inject() (
+  val authenticatedAction: AuthenticatedAction,
+  val sessionDataAction: SessionDataAction,
+  val sessionStore: SessionCache,
+  cc: MessagesControllerComponents,
+  claimService: ClaimService,
+  checkYourAnswersPage: pages.check_your_answers,
+  confirmationOfSubmissionPage: pages.confirmation_of_submission,
+  submitClaimFailedPage: pages.submit_claim_error
+)(implicit viewConfig: ViewConfig, ec: ExecutionContext, errorHandler: ErrorHandler)
+    extends FrontendController(cc)
+    with WithAuthAndSessionDataAction
+    with SessionDataExtractor
+    with SessionUpdates
+    with Logging {
+
+  val journey: JourneyBindable = JourneyBindable.Single
+
+  val checkAllAnswers: Action[AnyContent] =
+    authenticatedActionWithSessionData.async { implicit request =>
+      request.using { case fillingOutClaim: FillingOutClaim =>
+        implicit val router: ReimbursementRoutes = extractRoutes(fillingOutClaim.draftClaim, journey)
+        implicit val subKey: Option[String]      = router.subKey
+        Ok(
+          checkYourAnswersPage(
+            fillingOutClaim.draftClaim,
+            fillingOutClaim.signedInUserDetails.verifiedEmail,
+            fillingOutClaim.signedInUserDetails.eori,
+            journey,
+            routes.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit
+          )
+        )
+      }
+    }
+
+  val checkAllAnswersSubmit: Action[AnyContent] =
+    authenticatedActionWithSessionData.async { implicit request =>
+      withCompleteDraftClaim { (fillingOutClaim, completeClaim) =>
+        val result =
+          for {
+            response        <- EitherT.liftF(
+                                 submitClaim(
+                                   completeClaim,
+                                   fillingOutClaim,
+                                   fillingOutClaim.signedInUserDetails,
+                                   request.authenticatedRequest.request.messages.lang
+                                 )
+                               )
+            newJourneyStatus = response match {
+                                 case _: SubmitClaimError =>
+                                   SubmitClaimFailed(
+                                     fillingOutClaim.ggCredId,
+                                     fillingOutClaim.signedInUserDetails
+                                   )
+                                 case SubmitClaimSuccess(
+                                       submitClaimResponse
+                                     ) =>
+                                   JustSubmittedClaim(
+                                     fillingOutClaim.ggCredId,
+                                     fillingOutClaim.signedInUserDetails,
+                                     completeClaim,
+                                     submitClaimResponse
+                                   )
+                               }
+            _               <- EitherT(
+                                 updateSession(sessionStore, request)(
+                                   _.copy(journeyStatus = Some(newJourneyStatus))
+                                 )
+                               )
+          } yield response
+
+        result.fold(
+          logAndDisplayError("Error while trying to update session"),
+          {
+            case SubmitClaimError(e) =>
+              logger.warn(s"Could not submit return}", e)
+              Redirect(
+                routes.CheckYourAnswersAndSubmitController.submissionError
+              )
+
+            case SubmitClaimSuccess(_) =>
+              logger.info(
+                s"Successfully submitted claim with claim id :${completeClaim.id}"
+              )
+              Redirect(routes.CheckYourAnswersAndSubmitController.confirmationOfSubmission)
+          }
+        )
+      }
+
+    }
+
+  private def submitClaim(
+    claim: C285Claim,
+    fillingOutClaim: FillingOutClaim,
+    signedInUserDetails: SignedInUserDetails,
+    language: Lang
+  )(implicit
+    hc: HeaderCarrier
+  ): Future[SubmitClaimResult] =
+    claimService
+      .submitClaim(
+        C285ClaimRequest(
+          fillingOutClaim.draftClaim.id,
+          claim,
+          signedInUserDetails
+        ),
+        language
+      )
+      .bimap(
+        SubmitClaimError(_),
+        SubmitClaimSuccess(_)
+      )
+      .merge
+
+  val submissionError: Action[AnyContent] =
+    authenticatedActionWithSessionData.async { implicit request =>
+      withSubmitClaimFailed(_ => Ok(submitClaimFailedPage()))
+    }
+
+  val confirmationOfSubmission: Action[AnyContent] =
+    authenticatedActionWithSessionData.async { implicit request =>
+      withJustSubmittedClaim(claim =>
+        Ok(
+          confirmationOfSubmissionPage(claim.claim.totalReimbursementAmount, claim.submissionResponse.caseNumber, None)
+        )
+      )
+    }
+
+  private def withJustSubmittedClaim(
+    f: JustSubmittedClaim => Future[Result]
+  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+    request.sessionData.flatMap(_.journeyStatus) match {
+      case Some(j: JustSubmittedClaim) => f(j)
+      case _                           => Redirect(baseRoutes.StartController.start())
+    }
+
+  private def withSubmitClaimFailed(
+    f: Either[SubmitClaimFailed, RetrievedUserType] => Future[Result]
+  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+    request.sessionData.flatMap(_.journeyStatus) match {
+      case Some(s: SubmitClaimFailed)  => f(Left(s))
+      case Some(_: JustSubmittedClaim) =>
+        Redirect(routes.CheckYourAnswersAndSubmitController.confirmationOfSubmission)
+      case _                           => Redirect(baseRoutes.StartController.start())
+    }
+
+  private def withCompleteDraftClaim(
+    f: (FillingOutClaim, C285Claim) => Future[Result]
+  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+    request.using({ case fillingOutClaim @ FillingOutClaim(_, signedInUserDetails, draftClaim: DraftClaim) =>
+      C285Claim
+        .fromDraftClaim(draftClaim, signedInUserDetails.verifiedEmail, signedInUserDetails.eori)
+        .fold[Future[Result]](
+          error => logAndDisplayError("could not make a complete claim") apply error,
+          c285Claim => f(fillingOutClaim, c285Claim)
+        )
+    })
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/UploadFilesController.scala
@@ -28,13 +28,11 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.FileUploadConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.UploadDocumentsConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.UploadDocumentsConnector
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Nonce
@@ -88,7 +86,7 @@ class UploadFilesController @Inject() (
               selfUrl + routes.ChooseFileTypeController.show.url
 
             val continueAfterNoAnswerUrl =
-              selfUrl + claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single).url
+              selfUrl + routes.CheckYourAnswersAndSubmitController.checkAllAnswers.url
 
             uploadDocumentsConnector
               .initialize(
@@ -98,8 +96,7 @@ class UploadFilesController @Inject() (
                       fillingOutClaim.draftClaim.nonce,
                       documentType,
                       continueAfterYesAnswerUrl,
-                      continueAfterNoAnswerUrl,
-                      JourneyBindable.Single
+                      continueAfterNoAnswerUrl
                     ),
                     fillingOutClaim.draftClaim.supportingEvidencesAnswer
                       .map(_.toList)
@@ -166,7 +163,7 @@ class UploadFilesController @Inject() (
               selfUrl + routes.ChooseFileTypeController.show.url
 
             val continueAfterNoAnswerUrl =
-              selfUrl + claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single).url
+              selfUrl + routes.CheckYourAnswersAndSubmitController.checkAllAnswers.url
 
             uploadDocumentsConnector
               .initialize(
@@ -176,8 +173,7 @@ class UploadFilesController @Inject() (
                       fillingOutClaim.draftClaim.nonce,
                       documentType,
                       continueAfterYesAnswerUrl,
-                      continueAfterNoAnswerUrl,
-                      JourneyBindable.Single
+                      continueAfterNoAnswerUrl
                     ),
                     fillingOutClaim.draftClaim.supportingEvidencesAnswer
                       .map(_.toList)
@@ -216,8 +212,7 @@ class UploadFilesController @Inject() (
     nonce: Nonce,
     documentType: UploadDocumentType,
     continueAfterYesAnswerUrl: String,
-    continueAfterNoAnswerUrl: String,
-    journey: JourneyBindable
+    continueAfterNoAnswerUrl: String
   )(implicit
     request: Request[_],
     messages: Messages
@@ -226,7 +221,7 @@ class UploadFilesController @Inject() (
       nonce = nonce,
       continueUrl = continueAfterNoAnswerUrl,
       continueAfterYesAnswerUrl = Some(continueAfterYesAnswerUrl),
-      continueWhenFullUrl = selfUrl + claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(journey).url,
+      continueWhenFullUrl = selfUrl + routes.CheckYourAnswersAndSubmitController.checkAllAnswers.url,
       backlinkUrl = selfUrl + routes.ChooseFileTypeController.show.url,
       callbackUrl = uploadDocumentsConfig.callbackUrlPrefix + routes.UploadFilesController.callback.url,
       minimumNumberOfFiles = 0, // user can skip uploading the files

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/CheckDeclarationDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/CheckDeclarationDetailsController.scala
@@ -23,7 +23,6 @@ import play.api.mvc._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.MRNScheduledRoutes.subKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.YesOrNoQuestionForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/JourneyStatus.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/JourneyStatus.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.models
 import cats.Eq
 import julienrf.json.derived
 import play.api.libs.json.OFormat
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResponse
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
 
@@ -48,14 +47,12 @@ object JourneyStatus {
     ggCredId: GGCredId,
     signedInUserDetails: SignedInUserDetails,
     claim: C285Claim,
-    submissionResponse: SubmitClaimResponse,
-    journey: JourneyBindable
+    submissionResponse: SubmitClaimResponse
   ) extends JourneyStatus
 
   final case class SubmitClaimFailed(
     ggCredId: GGCredId,
-    signedInUserDetails: SignedInUserDetails,
-    journey: JourneyBindable
+    signedInUserDetails: SignedInUserDetails
   ) extends JourneyStatus
 
   final case object NonGovernmentGatewayJourney extends JourneyStatus

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/claim/SubmitClaimResult.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/claim/SubmitClaimResult.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim
+
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
+
+sealed trait SubmitClaimResult
+
+object SubmitClaimResult {
+  final case class SubmitClaimError(error: Error) extends SubmitClaimResult
+  final case class SubmitClaimSuccess(response: SubmitClaimResponse) extends SubmitClaimResult
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_declaration_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_declaration_details.scala.html
@@ -20,7 +20,6 @@
 @import play.api.mvc.Call
 @import play.api.mvc.Request
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkYourAnswersKey
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.HtmlUtil._
@@ -68,7 +67,7 @@
             )
         )
 
-        @summary(CdsDisplayDeclarationSummary(declaration,s"$checkYourAnswersKey.declaration-details", subKey))
+        @summary(CdsDisplayDeclarationSummary(declaration,s"check-your-answers.declaration-details", subKey))
 
         @radios(
             form = form,

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_movement_reference_numbers.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_movement_reference_numbers.scala.html
@@ -15,7 +15,6 @@
  *@
 
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkYourAnswersKey
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
@@ -26,6 +25,7 @@
 @import play.api.data.Form
 @import play.api.i18n.Messages
 @import play.twirl.api.Html
+@import play.api.mvc.Call
 @import play.twirl.api.TwirlFeatureImports.defining
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
 
@@ -58,7 +58,7 @@
 
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">@Html(messages(s"$checkYourAnswersKey.reference-number.multiple.label"))</dt>
+                <dt class="govuk-summary-list__key">@Html(messages("check-your-answers.reference-number.multiple.label"))</dt>
                 <dd class="govuk-summary-list__value">@references.head.value</dd>
                 <dd class="govuk-summary-list__actions">
                     <a class="govuk-link" href=@routes.EnterMovementReferenceNumberController.enterJourneyMrn(JourneyBindable.Multiple).url>@{
@@ -70,7 +70,7 @@
             @references.drop(1).zipWithIndex.map { mrnWithIndex =>
                 @defining(AssociatedMrnIndex.fromListIndex(mrnWithIndex._2)) { index =>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">@Html(messages(s"$checkYourAnswersKey.reference-number.associated-mrn-label", index.ordinalNumeral.capitalize))</dt>
+                        <dt class="govuk-summary-list__key">@Html(messages("check-your-answers.reference-number.associated-mrn-label", index.ordinalNumeral.capitalize))</dt>
                         <dd class="govuk-summary-list__value">@mrnWithIndex._1.value</dd>
                         <dd class="govuk-summary-list__actions">
                             <a class="govuk-link" href=@routes.EnterAssociatedMrnController.changeMrn(index).url>@{

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
@@ -16,6 +16,7 @@
 
 @import play.twirl.api.Html
 @import play.api.i18n.Messages
+@import play.api.mvc.Call
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
@@ -43,7 +44,7 @@
     formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 )
 
-@(claim: DraftClaim, verifiedEmail: Email, userEoriNumber: Eori)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig, subKey: Option[String], journey: JourneyBindable)
+@(claim: DraftClaim, verifiedEmail: Email, userEoriNumber: Eori, journey: JourneyBindable, postAction: Call)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig, subKey: Option[String])
 
 @key = @{"check-your-answers"}
 @title = @{messages(s"$key.title")}
@@ -131,7 +132,7 @@
     @pageHeading(Html(messages(s"$key.confirmation-statement.h2")), "govuk-heading-m govuk-!-margin-top-9", "h2")
     @paragraph(Html(messages(s"$key.confirmation-statement")), Some("govuk-body"))
 
-    @formWithCSRF(claimRoutes.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit(journey), 'novalidate -> "novalidate") {
+    @formWithCSRF(postAction, 'novalidate -> "novalidate") {
         @submitButton("button.accept-and-send")
     }
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/rejectedgoods/check_declaration_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/rejectedgoods/check_declaration_details.scala.html
@@ -20,7 +20,6 @@
 @import play.api.mvc.Call
 @import play.api.mvc.Request
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkYourAnswersKey
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.RejectedGoodsCdsDisplayDeclarationSummary
@@ -69,7 +68,7 @@
 
     @formWithCSRF(postAction, 'novalidate -> "novalidate") {
 
-        @summary(RejectedGoodsCdsDisplayDeclarationSummary(declaration,s"$checkYourAnswersKey.declaration-details", subKey))
+        @summary(RejectedGoodsCdsDisplayDeclarationSummary(declaration, "check-your-answers.declaration-details", subKey))
 
         @{if(subKey.contains("scheduled"))
             paragraph(Html(messages(s"$key$subKeyDetail.is-information-correct")), Some("govuk-body"))

--- a/conf/claims.routes
+++ b/conf/claims.routes
@@ -46,13 +46,6 @@ GET         /:journey/bank-account-unavailable                      uk.gov.hmrc.
 GET         /:journey/bank-account-type                             uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectBankAccountTypeController.selectBankAccountType(journey: JourneyBindable)
 POST        /:journey/bank-account-type                             uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectBankAccountTypeController.selectBankAccountTypeSubmit(journey: JourneyBindable)
 
-GET         /:journey/check-answers-accept-send                     uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkAllAnswers(journey: JourneyBindable)
-POST        /:journey/check-answers-accept-send                     uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit(journey: JourneyBindable)
-
-GET         /:journey/claim-submitted                               uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.confirmationOfSubmission(journey: JourneyBindable)
-
-GET         /:journey/check-if-claim-was-sent                       uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.submissionError(journey: JourneyBindable)
-
 GET         /single/select-duties                                   uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutiesController.selectDuties()
 POST        /single/select-duties                                   uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutiesController.selectDutiesSubmit()
 

--- a/conf/overpayments_multiple.routes
+++ b/conf/overpayments_multiple.routes
@@ -6,9 +6,9 @@ GET         /multiple/supporting-evidence/choose-files                         @
 POST        /multiple/supporting-evidence/choose-files                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.UploadFilesController.callback
 GET         /multiple/supporting-evidence/summary                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.UploadFilesController.summary
 
-GET         /single/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.checkAllAnswers
-POST        /single/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit
+GET         /multiple/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.checkAllAnswers
+POST        /multiple/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit
 
-GET         /single/claim-submitted                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.confirmationOfSubmission
-GET         /single/check-if-claim-was-sent                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.submissionError
+GET         /multiple/claim-submitted                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.confirmationOfSubmission
+GET         /multiple/check-if-claim-was-sent                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.submissionError
 

--- a/conf/overpayments_multiple.routes
+++ b/conf/overpayments_multiple.routes
@@ -5,3 +5,10 @@ GET         /multiple/supporting-evidence/choose-files                         @
 +nocsrf
 POST        /multiple/supporting-evidence/choose-files                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.UploadFilesController.callback
 GET         /multiple/supporting-evidence/summary                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.UploadFilesController.summary
+
+GET         /single/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.checkAllAnswers
+POST        /single/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit
+
+GET         /single/claim-submitted                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.confirmationOfSubmission
+GET         /single/check-if-claim-was-sent                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckYourAnswersAndSubmitController.submissionError
+

--- a/conf/overpayments_scheduled.routes
+++ b/conf/overpayments_scheduled.routes
@@ -5,3 +5,9 @@ GET         /scheduled/supporting-evidence/choose-files                         
 +nocsrf
 POST        /scheduled/supporting-evidence/choose-files                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.UploadFilesController.callback
 GET         /scheduled/supporting-evidence/summary                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.UploadFilesController.summary
+
+GET         /single/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.checkAllAnswers
+POST        /single/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit
+
+GET         /single/claim-submitted                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.confirmationOfSubmission
+GET         /single/check-if-claim-was-sent                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.submissionError

--- a/conf/overpayments_scheduled.routes
+++ b/conf/overpayments_scheduled.routes
@@ -6,8 +6,8 @@ GET         /scheduled/supporting-evidence/choose-files                         
 POST        /scheduled/supporting-evidence/choose-files                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.UploadFilesController.callback
 GET         /scheduled/supporting-evidence/summary                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.UploadFilesController.summary
 
-GET         /single/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.checkAllAnswers
-POST        /single/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit
+GET         /scheduled/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.checkAllAnswers
+POST        /scheduled/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit
 
-GET         /single/claim-submitted                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.confirmationOfSubmission
-GET         /single/check-if-claim-was-sent                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.submissionError
+GET         /scheduled/claim-submitted                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.confirmationOfSubmission
+GET         /scheduled/check-if-claim-was-sent                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckYourAnswersAndSubmitController.submissionError

--- a/conf/overpayments_single.routes
+++ b/conf/overpayments_single.routes
@@ -1,7 +1,13 @@
 GET         /single/supporting-evidence/select-supporting-evidence-type      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.ChooseFileTypeController.show
 POST        /single/supporting-evidence/select-supporting-evidence-type      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.ChooseFileTypeController.submit
 
-GET         /single/supporting-evidence/choose-files                       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.UploadFilesController.show
+GET         /single/supporting-evidence/choose-files                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.UploadFilesController.show
 +nocsrf
-POST        /single/supporting-evidence/choose-files                       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.UploadFilesController.callback
-GET         /single/supporting-evidence/summary                            @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.UploadFilesController.summary
+POST        /single/supporting-evidence/choose-files                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.UploadFilesController.callback
+GET         /single/supporting-evidence/summary                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.UploadFilesController.summary
+
+GET         /single/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.CheckYourAnswersAndSubmitController.checkAllAnswers
+POST        /single/check-answers-accept-send                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.CheckYourAnswersAndSubmitController.checkAllAnswersSubmit
+
+GET         /single/claim-submitted                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.CheckYourAnswersAndSubmitController.confirmationOfSubmission
+GET         /single/check-if-claim-was-sent                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.CheckYourAnswersAndSubmitController.submissionError

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/StartControllerSpec.scala
@@ -270,7 +270,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
 
       "there is a claim submission failure journey status" must {
 
-        "redirect the user to the submission error page" in {
+        "redirect the user to the start of the journey" in {
 
           val submitClaimFailed = sample[SubmitClaimFailed]
           val sessionData       = sample[SessionData].copy(journeyStatus = Some(submitClaimFailed))
@@ -278,13 +278,26 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           inSequence {
             mockAuthWithEoriEnrolmentRetrievals()
             mockGetSession(sessionData)
+            mockStoreSession(
+              sessionData.copy(
+                journeyStatus = Some(
+                  FillingOutClaim(
+                    GGCredId("gg-cred-id"),
+                    SignedInUserDetails(
+                      None,
+                      Eori("AB12345678901234Z"),
+                      Email(""),
+                      ContactName("John Smith")
+                    ),
+                    DraftClaim.blank
+                  )
+                )
+              )
+            )(Right(()))
           }
 
           val result = performAction()
-          checkIsRedirect(
-            result,
-            claims.routes.CheckYourAnswersAndSubmitController.submissionError(submitClaimFailed.journey)
-          )
+          checkIsRedirect(result, commonRoutes.CheckEoriDetailsController.show())
 
         }
 
@@ -292,7 +305,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
 
       "there is just submitted claim journey status" must {
 
-        "redirect the user to the main CYA page" in {
+        "redirect the user to the start of the journey" in {
 
           val justSubmittedClaim = sample[JustSubmittedClaim]
           val sessionData        = sample[SessionData].copy(journeyStatus = Some(justSubmittedClaim))
@@ -300,31 +313,59 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           inSequence {
             mockAuthWithEoriEnrolmentRetrievals()
             mockGetSession(sessionData)
+            mockStoreSession(
+              sessionData.copy(
+                journeyStatus = Some(
+                  FillingOutClaim(
+                    GGCredId("gg-cred-id"),
+                    SignedInUserDetails(
+                      None,
+                      Eori("AB12345678901234Z"),
+                      Email(""),
+                      ContactName("John Smith")
+                    ),
+                    DraftClaim.blank
+                  )
+                )
+              )
+            )(Right(()))
           }
 
           val result = performAction()
-          checkIsRedirect(
-            result,
-            claims.routes.CheckYourAnswersAndSubmitController.confirmationOfSubmission(justSubmittedClaim.journey)
-          )
+          checkIsRedirect(result, commonRoutes.CheckEoriDetailsController.show())
         }
 
       }
 
       "there is filling out claim journey status" must {
 
-        "redirect the user to the main CYA page" in {
+        "redirect the user to the start of the journey" in {
           val fillingOutClaim = sample[FillingOutClaim]
           val sessionData     = sample[SessionData].copy(journeyStatus = Some(fillingOutClaim))
 
           inSequence {
-            mockAuthWithEoriEnrolmentRetrievals()
+            mockAuthWithOrgWithEoriEnrolmentRetrievals()
             mockGetSession(sessionData)
+            mockStoreSession(
+              sessionData.copy(
+                journeyStatus = Some(
+                  FillingOutClaim(
+                    GGCredId("gg-cred-id"),
+                    SignedInUserDetails(
+                      None,
+                      Eori("AB12345678901234Z"),
+                      Email(""),
+                      ContactName("John Smith")
+                    ),
+                    DraftClaim.blank
+                  )
+                )
+              )
+            )(Right(()))
           }
 
-          val result  = performAction()
-          val journey = JourneyExtractor.extractJourney(fillingOutClaim)
-          checkIsRedirect(result, claims.routes.CheckYourAnswersAndSubmitController.checkAllAnswers(journey))
+          val result = performAction()
+          checkIsRedirect(result, commonRoutes.CheckEoriDetailsController.show())
         }
       }
 
@@ -335,7 +376,7 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
           val sessionData = sample[SessionData].copy(journeyStatus = Some(NonGovernmentGatewayJourney))
 
           inSequence {
-            mockAuthWithEoriEnrolmentRetrievals()
+            mockAuthWithNonGGUserRetrievals()
             mockGetSession(sessionData)
           }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckScheduledClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckScheduledClaimControllerSpec.scala
@@ -198,7 +198,7 @@ class CheckScheduledClaimControllerSpec extends ControllerSpec with AuthSupport 
 
       checkIsRedirect(
         controller.submitReimbursements()(FakeRequest().withFormUrlEncodedBody(checkClaimSummaryKey -> "true")),
-        claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Scheduled)
+        OverpaymentsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Scheduled)
       )
     }
   }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourAnswersSummarySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/CheckYourAnswersSummarySpec.scala
@@ -59,10 +59,7 @@ abstract class CheckYourAnswersSummarySpec
       bind[ClaimService].toInstance(mockClaimService)
     )
 
-  protected val controller: CheckYourAnswersAndSubmitController =
-    instanceOf[CheckYourAnswersAndSubmitController]
-
-  implicit lazy val messagesApi: MessagesApi = controller.messagesApi
+  implicit lazy val messagesApi: MessagesApi = instanceOf[MessagesApi]
   implicit lazy val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
 
   protected def genData(maybeTypeOfClaim: TypeOfClaimAnswer): (SessionData, DraftClaim) = {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAdditionalDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAdditionalDetailsControllerSpec.scala
@@ -260,7 +260,7 @@ class EnterAdditionalDetailsControllerSpec
               "enter-additional-details" -> claim.additionalDetailsAnswer.fold("")(_.value)
             )
           ),
-          routes.CheckYourAnswersAndSubmitController.checkAllAnswers(journey)
+          OverpaymentsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(journey)
         )
       }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterMovementReferenceNumberControllerSpec.scala
@@ -378,7 +378,7 @@ class EnterMovementReferenceNumberControllerSpec
       status(result) shouldBe 303
       redirectLocation(
         result
-      ).value        shouldBe routes.CheckYourAnswersAndSubmitController.checkAllAnswers(journeyBindable).url
+      ).value        shouldBe OverpaymentsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(journeyBindable).url
     }
 
     "start a new claim if a different MRN is submitted" in {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterSingleClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterSingleClaimControllerSpec.scala
@@ -537,7 +537,7 @@ class EnterSingleClaimControllerSpec
 
       checkIsRedirect(
         result,
-        routes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single)
+        OverpaymentsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single)
       )
     }
   }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ReimbursementMethodControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ReimbursementMethodControllerSpec.scala
@@ -191,7 +191,7 @@ class ReimbursementMethodControllerSpec
 
         checkIsRedirect(
           performAction(Seq(ReimbursementMethodController.reimbursementMethodKey -> "0")),
-          claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single)
+          OverpaymentsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single)
         )
       }
 
@@ -207,7 +207,7 @@ class ReimbursementMethodControllerSpec
 
         checkIsRedirect(
           performAction(Seq(ReimbursementMethodController.reimbursementMethodKey -> "1")),
-          claimsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single)
+          OverpaymentsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single)
         )
       }
     }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBasisForClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectBasisForClaimControllerSpec.scala
@@ -225,7 +225,7 @@ class SelectBasisForClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         checkIsRedirect(
           performAction(Seq(selectBasisForClaimKey -> idx.toString)),
-          routes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single)
+          OverpaymentsRoutes.CheckYourAnswersAndSubmitController.checkAllAnswers(JourneyBindable.Single)
         )
       }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/CheckYourMultipleJourneyAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/CheckYourMultipleJourneyAnswersSpec.scala
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple
 
 import org.jsoup.nodes
 import play.api.test.FakeRequest
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkYourAnswersKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectBasisForClaimController.selectBasisForClaimKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaims
@@ -32,8 +30,11 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.Claima
 
 import scala.collection.JavaConverters._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.OrdinalNumber
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersSummarySpec
 
 class CheckYourMultipleJourneyAnswersSpec extends CheckYourAnswersSummarySpec with SummaryMatchers {
+
+  val controller = instanceOf[CheckYourAnswersAndSubmitController]
 
   "The C285 Multiple journey CYA page" should {
 
@@ -45,11 +46,11 @@ class CheckYourMultipleJourneyAnswersSpec extends CheckYourAnswersSummarySpec wi
           mockGetSession(session)
         }
 
-        val result = controller.checkAllAnswers(JourneyBindable.Multiple)(FakeRequest())
+        val result = controller.checkAllAnswers(FakeRequest())
 
         checkPageIsDisplayed(
           result,
-          messageFromMessageKey(s"$checkYourAnswersKey.title"),
+          messageFromMessageKey("check-your-answers.title"),
           (doc: nodes.Document) => {
 
             val headers       = doc.select("h2.govuk-heading-m").eachText().asScala

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/CheckYourScheduledJourneyAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/CheckYourScheduledJourneyAnswersSpec.scala
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled
 
 import org.jsoup.nodes
 import play.api.test.FakeRequest
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkYourAnswersKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectBasisForClaimController.selectBasisForClaimKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaims
@@ -32,8 +30,11 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.Claima
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.DutyTypeSummary
 
 import scala.collection.JavaConverters._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersSummarySpec
 
 class CheckYourScheduledJourneyAnswersSpec extends CheckYourAnswersSummarySpec with SummaryMatchers {
+
+  val controller = instanceOf[CheckYourAnswersAndSubmitController]
 
   "The C285 Scheduled journey CYA page" should {
 
@@ -45,11 +46,11 @@ class CheckYourScheduledJourneyAnswersSpec extends CheckYourAnswersSummarySpec w
           mockGetSession(session)
         }
 
-        val result = controller.checkAllAnswers(JourneyBindable.Scheduled)(FakeRequest())
+        val result = controller.checkAllAnswers(FakeRequest())
 
         checkPageIsDisplayed(
           result,
-          messageFromMessageKey(s"$checkYourAnswersKey.title"),
+          messageFromMessageKey("check-your-answers.title"),
           (doc: nodes.Document) => {
 
             val headers       = doc.select("h2.govuk-heading-m").eachText().asScala

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/CheckYourSingleJourneyAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/CheckYourSingleJourneyAnswersSpec.scala
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle
 
 import org.jsoup.nodes
 import play.api.test.FakeRequest
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.checkYourAnswersKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectBasisForClaimController.selectBasisForClaimKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaims
@@ -34,7 +32,11 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.support.SummaryMatchers
 import scala.collection.JavaConverters._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.DutyTypeSummary
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.ClaimantInformationSummary
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersSummarySpec
+
 class CheckYourSingleJourneyAnswersSpec extends CheckYourAnswersSummarySpec with SummaryMatchers {
+
+  val controller = instanceOf[CheckYourAnswersAndSubmitController]
 
   "The C285 Single journey CYA page" should {
 
@@ -46,14 +48,14 @@ class CheckYourSingleJourneyAnswersSpec extends CheckYourAnswersSummarySpec with
           mockGetSession(session)
         }
 
-        val result = controller.checkAllAnswers(JourneyBindable.Single)(FakeRequest())
+        val result = controller.checkAllAnswers(FakeRequest())
 
         val bankDetailsExpected = claim.findNonEmptyBankAccountDetails.isDefined &&
           !claim.reimbursementMethodAnswer.contains(CurrentMonthAdjustment)
 
         checkPageIsDisplayed(
           result,
-          messageFromMessageKey(s"$checkYourAnswersKey.title"),
+          messageFromMessageKey("check-your-answers.title"),
           (doc: nodes.Document) => {
 
             val headers       = doc.select("h2.govuk-heading-m").eachText().asScala
@@ -121,9 +123,9 @@ class CheckYourSingleJourneyAnswersSpec extends CheckYourAnswersSummarySpec with
                   .expectedWhen(bankDetailsExpected),
                 ("Account number"                                  -> claim.bankAccountDetailsAnswer.map(_.accountNumber.masked))
                   .expectedWhen(bankDetailsExpected),
-                ("Method"                                          -> messages(s"$checkYourAnswersKey.reimbursement-method.cma"))
+                ("Method"                                          -> messages("check-your-answers.reimbursement-method.cma"))
                   .expectedWhen(claim.reimbursementMethodAnswer.contains(CurrentMonthAdjustment)),
-                ("Method"                                          -> messages(s"$checkYourAnswersKey.reimbursement-method.bt"))
+                ("Method"                                          -> messages("check-your-answers.reimbursement-method.bt"))
                   .expectedWhen(claim.reimbursementMethodAnswer.contains(BankAccountTransfer)),
                 ("Contact details"                                 -> claim
                   .getClaimantInformation(user.eori)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/JourneyStatusGen.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/JourneyStatusGen.scala
@@ -30,7 +30,6 @@ trait JourneyStatusLowerPriorityGen {
 
   import IdGen._
   import SignedInUserDetailsGen._
-  import JourneyBindableGen._
   import DraftClaimGen._
   import C285ClaimGen._
   import SubmissionResponseGen._

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/SubmissionResponseGen.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/SubmissionResponseGen.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators
 
 import org.scalacheck.magnolia._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckYourAnswersAndSubmitController.SubmitClaimResult.SubmitClaimError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResult.SubmitClaimError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.C285ClaimRequest
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.claim.SubmitClaimResponse
 


### PR DESCRIPTION
This PR splits overpayments (a.k.a C285) CYA routes. In addition, it also steps into the garden of CDSR-1433 and fixes the behaviour of a StartController, i.e. now we always start with an empty C285 claim instead of going straight to the CYA. This is not yet achieving CDSR-1433 solution,  but aligns overpayments with rejectedgoods.