### PR TITLE
CDSR-1604 creating seperate BARS service, connector and model rules

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/BankAccountReputationConnector.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/BankAccountReputationConnector.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
+
+import akka.actor.ActorSystem
+import cats.implicits._
+import cats.data.EitherT
+import com.google.inject.Inject
+import javax.inject.Singleton
+import play.api.libs.json.Writes
+import play.api.Configuration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpClient
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ConnectorFailure
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ServiceUnavailableError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.TechnicalServiceError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsBusinessAssessRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsPersonalAssessRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.BusinessCompleteResponse
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.PersonalCompleteResponse
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.HttpResponseOps.HttpResponseOps
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+@Singleton
+class BankAccountReputationConnector @Inject() (
+  http: HttpClient,
+  servicesConfig: ServicesConfig,
+  configuration: Configuration,
+  val actorSystem: ActorSystem
+)(implicit
+  ec: ExecutionContext
+) extends Retries
+    with Logging {
+
+  def getBusinessReputation(
+    data: BarsBusinessAssessRequest
+  )(implicit hc: HeaderCarrier): EitherT[Future, ConnectorError, BankAccountReputation] = {
+    val url = getUri("bank-account-reputation", "business")
+    for {
+      httpResponse     <- getReputation(data, url)
+      businessResponse <-
+        EitherT.fromEither[Future](
+          httpResponse
+            .parseJSON[BusinessCompleteResponse]()
+            .map(_.toCommonResponse())
+            .leftMap(ConnectorFailure(_): ConnectorError)
+        )
+    } yield businessResponse
+  }
+
+  def getPersonalReputation(
+    data: BarsPersonalAssessRequest
+  )(implicit hc: HeaderCarrier): EitherT[Future, ConnectorError, BankAccountReputation] = {
+    val url = getUri("bank-account-reputation", "personal")
+    for {
+      httpResponse     <- getReputation(data, url)
+      personalResponse <-
+        EitherT.fromEither[Future](
+          httpResponse
+            .parseJSON[PersonalCompleteResponse]()
+            .map(_.toCommonResponse())
+            .leftMap(ConnectorFailure(_): ConnectorError)
+        )
+    } yield personalResponse
+  }
+
+  private def getUri(serviceName: String, apiName: String): String =
+    servicesConfig.baseUrl(serviceName) + servicesConfig.getString(s"microservice.services.$serviceName.$apiName")
+
+  lazy val retryIntervals: Seq[FiniteDuration] =
+    Retries.getConfIntervals("bank-account-reputation", configuration).toList
+
+  private def errorMessage(url: String, response: HttpResponse): String =
+    s"Request to POST $url failed because of $response ${response.body}"
+
+  private def getReputation[T](data: T, url: String)(implicit hc: HeaderCarrier, wts: Writes[T]) =
+    EitherT {
+      retry(retryIntervals: _*)(shouldRetry, retryReason)(
+        http
+          .POST[T, HttpResponse](url, data)
+      )
+        .map(checkResponse(_, url))
+    }
+
+  private def checkResponse(response: HttpResponse, url: String): Either[ConnectorError, HttpResponse] =
+    response.status match {
+      case 200                         => Right(response)
+      case x if (x >= 400) & (x < 500) => Left(TechnicalServiceError(errorMessage(url, response)))
+      case x if (x >= 500) & (x < 600) => Left(ServiceUnavailableError(errorMessage(url, response)))
+      case _                           => Left(ConnectorFailure(errorMessage(url, response)))
+    }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/CDSReimbursementClaimConnector.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/CDSReimbursementClaimConnector.scala
@@ -36,10 +36,6 @@ import scala.concurrent.Future
 @ImplementedBy(classOf[DefaultCDSReimbursementClaimConnector])
 trait CDSReimbursementClaimConnector {
   def getDeclaration(mrn: MRN)(implicit hc: HeaderCarrier): EitherT[Future, Error, HttpResponse]
-
-  def getBusinessReputation(data: JsValue)(implicit hc: HeaderCarrier): EitherT[Future, Error, HttpResponse]
-  def getPersonalReputation(data: JsValue)(implicit hc: HeaderCarrier): EitherT[Future, Error, HttpResponse]
-
 }
 
 @Singleton
@@ -60,26 +56,4 @@ class DefaultCDSReimbursementClaimConnector @Inject() (http: HttpClient, service
         .recover { case e => Left(Error(e)) }
     )
   }
-
-  def getBusinessReputation(data: JsValue)(implicit hc: HeaderCarrier): EitherT[Future, Error, HttpResponse] = {
-    val url = getUri("bank-account-reputation", "business")
-    getReputation(data, url)
-  }
-
-  def getPersonalReputation(data: JsValue)(implicit hc: HeaderCarrier): EitherT[Future, Error, HttpResponse] = {
-    val url = getUri("bank-account-reputation", "personal")
-    getReputation(data, url)
-  }
-
-  def getUri(serviceName: String, apiName: String): String =
-    servicesConfig.baseUrl(serviceName) + servicesConfig.getString(s"microservice.services.$serviceName.$apiName")
-
-  def getReputation(data: JsValue, url: String)(implicit hc: HeaderCarrier): EitherT[Future, Error, HttpResponse] =
-    EitherT[Future, Error, HttpResponse](
-      http
-        .POST[JsValue, HttpResponse](url, data)
-        .map(Right(_))
-        .recover { case e => Left(Error(e)) }
-    )
-
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/ConnectorError.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/ConnectorError.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
+
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.CdsError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
+
+sealed trait ConnectorError {
+  def message: String
+  def throwable: Option[Throwable]
+}
+object ConnectorError {
+  implicit def cdsError: CdsError[ConnectorError] =
+    new CdsError[ConnectorError] {
+      def message(error: ConnectorError): String = error.message
+    }
+
+  final case class ConnectorFailure(message: String, throwable: Option[Throwable] = None) extends ConnectorError
+  final case class TechnicalServiceError(message: String, throwable: Option[Throwable] = None) extends ConnectorError
+  final case class ServiceUnavailableError(message: String, throwable: Option[Throwable] = None) extends ConnectorError
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountController.scala
@@ -18,38 +18,46 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
 
 import cats.data.EitherT
 import cats.implicits.catsSyntaxEq
+import cats.implicits._
 import com.google.inject.Inject
 import com.google.inject.Singleton
 import play.api.Configuration
+import play.api.i18n.Messages
 import play.api.mvc._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyExtractor.extractRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyExtractor.withAnswersAndRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DraftClaim
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.Yes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.Yes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.util.toFuture
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging.LoggerOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
 import uk.gov.hmrc.http.BadGatewayException
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -61,6 +69,7 @@ class BankAccountController @Inject() (
   cc: MessagesControllerComponents,
   val config: Configuration,
   val claimService: ClaimService,
+  val bankAccountReputationService: BankAccountReputationService,
   checkBankAccountDetailsPage: pages.check_bank_account_details,
   enterBankAccountDetailsPage: pages.enter_bank_account_details
 )(implicit viewConfig: ViewConfig, ec: ExecutionContext, errorHandler: ErrorHandler)
@@ -107,9 +116,81 @@ class BankAccountController @Inject() (
       }
     }
 
+  private def getBankAccountReputation(
+    bankAccountType: BankAccountType,
+    bankAccountDetails: BankAccountDetails,
+    fillingOutClaim: FillingOutClaim
+  )(implicit hc: HeaderCarrier): EitherT[Future, ConnectorError, BankAccountReputation] =
+    if (bankAccountType === BankAccountType.Business) {
+      bankAccountReputationService.getBusinessAccountReputation(bankAccountDetails)
+    } else {
+      val postCode = fillingOutClaim.draftClaim
+        .extractEstablishmentAddress(fillingOutClaim.signedInUserDetails)
+        .flatMap(_.postalCode)
+      bankAccountReputationService.getPersonalAccountReputation(bankAccountDetails, postCode)
+    }
+
+  private def processCdsError[T : CdsError](
+    error: T
+  )(implicit request: RequestWithSessionData[AnyContent], journeyBindable: JourneyBindable): Result =
+    error match {
+      case e @ ServiceUnavailableError(_, _) =>
+        logger.warn(s"could not contact bank account service: $e")
+        Redirect(routes.ServiceUnavailableController.unavailable(journeyBindable))
+      case e                                 =>
+        logAndDisplayError("could not process bank account details: ", e)
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  private def addBankAccount(
+    bankAccountReputation: BankAccountReputation,
+    request: RequestWithSessionData[AnyContent],
+    updatedJourney: FillingOutClaim
+  )(implicit hc: HeaderCarrier): EitherT[Future, Error, Unit] =
+    if (bankAccountReputation.accountExists.contains(Yes)) {
+      EitherT[Future, Error, Unit](
+        updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney)))
+      ).leftMap(_ => Error("could not update session"))
+    } else {
+      EitherT.rightT[Future, Error](Unit)
+    }
+
+  private def processBankAccountReputation(
+    bankAccountReputation: BankAccountReputation,
+    bankAccountDetails: BankAccountDetails,
+    router: ReimbursementRoutes
+  )(implicit journeyBindable: JourneyBindable, request: Request[_], mesaages: Messages) =
+    if (bankAccountReputation.otherError.isDefined) {
+      val errorKey = bankAccountReputation.otherError.map(_.code).getOrElse("account-does-not-exist")
+      val form     = enterBankDetailsForm
+        .fill(bankAccountDetails)
+        .withError("enter-bank-details", s"error.$errorKey")
+      BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
+    } else if (bankAccountReputation.accountNumberWithSortCodeIsValid === ReputationResponse.No) {
+      val form = enterBankDetailsForm
+        .withError("enter-bank-details", "error.moc-check-no")
+      BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
+    } else if (bankAccountReputation.accountNumberWithSortCodeIsValid =!= ReputationResponse.Yes) {
+      val form = enterBankDetailsForm
+        .withError("enter-bank-details", "error.moc-check-failed")
+      BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
+    } else if (bankAccountReputation.accountExists === Some(ReputationResponse.Error)) {
+      val form = enterBankDetailsForm
+        .fill(bankAccountDetails)
+        .withError("enter-bank-details", s"error.account-exists-error")
+      BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
+    } else if (bankAccountReputation.accountExists =!= Some(ReputationResponse.Yes)) {
+      val form = enterBankDetailsForm
+        .withError("enter-bank-details", s"error.account-does-not-exist")
+      BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
+    } else {
+      Redirect(claimRoutes.BankAccountController.checkBankAccountDetails(journeyBindable))
+    }
+
   def enterBankAccountDetailsSubmit(implicit journeyBindable: JourneyBindable): Action[AnyContent] =
-    authenticatedActionWithSessionData.async { implicit request =>
-      withAnswersAndRoutes[BankAccountDetails] { (fillingOutClaim, _, router) =>
+    authenticatedActionWithSessionData.async { implicit request: RequestWithSessionData[AnyContent] =>
+      withAnswersAndRoutes[BankAccountDetails] { (fillingOutClaim: FillingOutClaim, _, router) =>
+        val x: ReimbursementRoutes = router
         fillingOutClaim.draftClaim.bankAccountTypeAnswer match {
           case None =>
             Redirect(claimRoutes.SelectBankAccountTypeController.selectBankAccountType(journeyBindable))
@@ -123,67 +204,20 @@ class BankAccountController @Inject() (
                     enterBankAccountDetailsPage(requestFormWithErrors, router.submitUrlForEnterBankAccountDetails())
                   ),
                 bankAccountDetails => {
-                  val updatedJourney =
+                  val updatedJourney: FillingOutClaim =
                     FillingOutClaim.from(fillingOutClaim)(_.copy(bankAccountDetailsAnswer = Some(bankAccountDetails)))
 
-                  (for {
-                    reputationResponse <- {
-                      if (bankAccount === BankAccountType.Business) {
-                        claimService.getBusinessAccountReputation(bankAccountDetails)
-                      } else {
-                        val postCode = fillingOutClaim.draftClaim
-                          .extractEstablishmentAddress(fillingOutClaim.signedInUserDetails)
-                          .flatMap(_.postalCode)
-                        claimService.getPersonalAccountReputation(bankAccountDetails, postCode)
+                  getBankAccountReputation(bankAccount, bankAccountDetails, fillingOutClaim).value.map {
+                    case Left(error)                  =>
+                      Future.successful(processCdsError(error))
+                    case Right(bankAccountReputation) =>
+                      addBankAccount(bankAccountReputation, request, updatedJourney).value.map {
+                        case Left(error) =>
+                          processCdsError(error)
+                        case Right(_)    =>
+                          processBankAccountReputation(bankAccountReputation, bankAccountDetails, router)
                       }
-                    }
-                    _                  <- {
-                      if (reputationResponse.accountExists.contains(Yes)) {
-                        EitherT
-                          .liftF(
-                            updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney)))
-                          )
-                          .leftMap((_: Unit) => Error("could not update session"))
-                      } else {
-                        EitherT.rightT[Future, Error](Right(()))
-                      }
-                    }
-                  } yield reputationResponse).fold(
-                    {
-                      case e @ Error(_, Some(_: BadGatewayException), _) =>
-                        logger warn ("could not contact bank account service: ", e)
-                        Redirect(routes.ServiceUnavailableController.unavailable(journeyBindable))
-                      case e                                             =>
-                        logAndDisplayError("could not process bank account details: ")(errorHandler, request)(e)
-                    },
-                    reputationResponse =>
-                      if (reputationResponse.otherError.isDefined) {
-                        val errorKey = reputationResponse.otherError.map(_.code).getOrElse("account-does-not-exist")
-                        val form     = enterBankDetailsForm
-                          .fill(bankAccountDetails)
-                          .withError("enter-bank-details", s"error.$errorKey")
-                        BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
-                      } else if (reputationResponse.accountNumberWithSortCodeIsValid === ReputationResponse.No) {
-                        val form = enterBankDetailsForm
-                          .withError("enter-bank-details", "error.moc-check-no")
-                        BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
-                      } else if (reputationResponse.accountNumberWithSortCodeIsValid =!= ReputationResponse.Yes) {
-                        val form = enterBankDetailsForm
-                          .withError("enter-bank-details", "error.moc-check-failed")
-                        BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
-                      } else if (reputationResponse.accountExists === Some(ReputationResponse.Error)) {
-                        val form = enterBankDetailsForm
-                          .fill(bankAccountDetails)
-                          .withError("enter-bank-details", s"error.account-exists-error")
-                        BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
-                      } else if (reputationResponse.accountExists =!= Some(ReputationResponse.Yes)) {
-                        val form = enterBankDetailsForm
-                          .withError("enter-bank-details", s"error.account-does-not-exist")
-                        BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
-                      } else {
-                        Redirect(claimRoutes.BankAccountController.checkBankAccountDetails(journeyBindable))
-                      }
-                  )
+                  }.flatten
                 }
               )
         }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/EnterBankAccountDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/EnterBankAccountDetailsController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsmultiple
 
-import cats.data.EitherT
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.Call
@@ -24,18 +23,19 @@ import play.api.mvc.Request
 import play.api.mvc.Result
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ServiceUnavailableError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoods.{routes => rejectedGoodsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsMultipleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.CdsError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.{Error => ReputationResponseError, _}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
-import uk.gov.hmrc.http.BadRequestException
 
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -46,6 +46,7 @@ import scala.concurrent.Future
 class EnterBankAccountDetailsController @Inject() (
   val jcc: JourneyControllerComponents,
   val claimService: ClaimService,
+  val bankAccountReputationService: BankAccountReputationService,
   enterBankAccountDetailsPage: pages.enter_bank_account_details
 )(implicit val ec: ExecutionContext, viewConfig: ViewConfig, errorHandler: ErrorHandler)
     extends RejectedGoodsMultipleJourneyBaseController {
@@ -120,16 +121,13 @@ class EnterBankAccountDetailsController @Inject() (
         )
     }
 
-  def checkBankAccountReputation(
-    bankAccountType: BankAccountType,
-    bankAccountDetails: BankAccountDetails,
-    postCode: Option[String]
-  )(implicit request: Request[_]): EitherT[Future, Error, BankAccountReputation] =
-    bankAccountType match {
-      case BankAccountType.Personal =>
-        claimService.getPersonalAccountReputation(bankAccountDetails, postCode)
-      case BankAccountType.Business =>
-        claimService.getBusinessAccountReputation(bankAccountDetails)
+  private def processCdsError[T : CdsError](error: T)(implicit request: Request[_]): Result =
+    error match {
+      case e @ ServiceUnavailableError(_, _) =>
+        logger.warn(s"could not contact bank account service: $e")
+        Redirect(rejectedGoodsRoutes.ServiceUnavailableController.show())
+      case e                                 =>
+        logAndDisplayError("could not process bank account details: ", e)
     }
 
   def validateBankAccountDetails(
@@ -139,15 +137,10 @@ class EnterBankAccountDetailsController @Inject() (
   )(implicit request: Request[_]): Future[(RejectedGoodsMultipleJourney, Result)] =
     journey.answers.bankAccountType.fold((journey, Redirect(routes.ChooseBankAccountTypeController.show())).asFuture) {
       bankAccountType =>
-        checkBankAccountReputation(bankAccountType, bankAccountDetails, postCode)
+        bankAccountReputationService
+          .checkBankAccountReputation(bankAccountType, bankAccountDetails, postCode)
           .fold(
-            {
-              case Error(_, Some(t: BadRequestException), _) =>
-                logger.warn("Could not contact bank account service: ", t)
-                (journey, Redirect(rejectedGoodsRoutes.ServiceUnavailableController.show()))
-              case error                                     =>
-                (journey, logAndDisplayError("Could not process bank account details: ")(errorHandler, request)(error))
-            },
+            e => (journey, processCdsError(e)),
             {
               case BankAccountReputation(Yes, Some(Yes), None) =>
                 journey

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterBankAccountDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterBankAccountDetailsController.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle
 
 import cats.data.EitherT
+
 import javax.inject.Inject
 import javax.inject.Singleton
 import cats.implicits._
@@ -27,6 +28,7 @@ import play.api.mvc.Request
 import play.api.mvc.Result
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ServiceUnavailableError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoods.{routes => rejectedGoodsRoutes}
@@ -34,13 +36,12 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRout
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.CdsError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
-import uk.gov.hmrc.http.BadRequestException
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -48,7 +49,7 @@ import scala.concurrent.Future
 @Singleton
 class EnterBankAccountDetailsController @Inject() (
   val jcc: JourneyControllerComponents,
-  val claimService: ClaimService,
+  val bankAccountReputationService: BankAccountReputationService,
   enterBankAccountDetailsPage: pages.enter_bank_account_details
 )(implicit val ec: ExecutionContext, viewConfig: ViewConfig, errorHandler: ErrorHandler)
     extends RejectedGoodsSingleJourneyBaseController {
@@ -63,18 +64,21 @@ class EnterBankAccountDetailsController @Inject() (
     }
   }
 
-  def handleBankAccountReputation(
+  private def processCdsError[T : CdsError](error: T)(implicit request: Request[_]): Result =
+    error match {
+      case e @ ServiceUnavailableError(_, _) =>
+        logger.warn(s"could not contact bank account service: $e")
+        Redirect(rejectedGoodsRoutes.ServiceUnavailableController.show())
+      case e                                 =>
+        logAndDisplayError("could not process bank account details: ", e)
+    }
+
+  def handleBankAccountReputation[Error : CdsError](
     bankAccountDetails: BankAccountDetails,
     reputation: EitherT[Future, Error, BankAccountReputation]
   )(implicit request: Request[_], journey: RejectedGoodsSingleJourney): Future[(RejectedGoodsSingleJourney, Result)] =
     reputation.fold(
-      {
-        case Error(_, Some(t: BadRequestException), _) =>
-          logger.warn("Could not contact bank account service: ", t)
-          (journey, Redirect(rejectedGoodsRoutes.ServiceUnavailableController.show()))
-        case error                                     =>
-          (journey, logAndDisplayError("Could not process bank account details: ")(errorHandler, request)(error))
-      },
+      e => (journey, processCdsError(e)),
       {
         case BankAccountReputation(Yes, Some(Yes), None)                                  =>
           journey
@@ -123,12 +127,12 @@ class EnterBankAccountDetailsController @Inject() (
       case Some(BankAccountType.Personal) =>
         handleBankAccountReputation(
           bankAccountDetails,
-          claimService.getPersonalAccountReputation(bankAccountDetails, postCode)
+          bankAccountReputationService.getPersonalAccountReputation(bankAccountDetails, postCode)
         )
       case Some(BankAccountType.Business) =>
         handleBankAccountReputation(
           bankAccountDetails,
-          claimService.getBusinessAccountReputation(bankAccountDetails)
+          bankAccountReputationService.getBusinessAccountReputation(bankAccountDetails)
         )
       case _                              =>
         (journey, Redirect(routes.ChooseBankAccountTypeController.show())).asFuture

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/Error.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/Error.scala
@@ -37,5 +37,14 @@ object Error {
 
   def apply(error: Throwable, identifiers: (IdKey, IdValue)*): Error =
     Error(error.getMessage, Some(error), identifiers.toMap)
+}
 
+trait CdsError[A] {
+  def message(error: A): String
+}
+object CdsError {
+  implicit val cdsError: CdsError[Error] =
+    new CdsError[Error] {
+      def message(error: Error): String = error.message
+    }
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/BankAccountReputationService.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/BankAccountReputationService.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.services
+
+import cats.implicits._
+import cats.data.EitherT
+import com.google.inject.ImplementedBy
+import com.google.inject.Inject
+import play.api.mvc.Request
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.BankAccountReputationConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsAccount
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsAddress
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsBusinessAssessRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsPersonalAssessRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsSubject
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+@ImplementedBy(classOf[DefaultBankAccountReputationService])
+trait BankAccountReputationService {
+  def checkBankAccountReputation(
+    bankAccountType: BankAccountType,
+    bankAccountDetails: BankAccountDetails,
+    postCode: Option[String]
+  )(implicit hc: HeaderCarrier): EitherT[Future, ConnectorError, BankAccountReputation]
+
+  def getBusinessAccountReputation(
+    bankAccountDetails: BankAccountDetails
+  )(implicit hc: HeaderCarrier): EitherT[Future, ConnectorError, BankAccountReputation]
+
+  def getPersonalAccountReputation(
+    bankAccountDetails: BankAccountDetails,
+    postCode: Option[String]
+  )(implicit hc: HeaderCarrier): EitherT[Future, ConnectorError, BankAccountReputation]
+}
+
+@Singleton
+class DefaultBankAccountReputationService @Inject() (bankAccountReputationConnector: BankAccountReputationConnector)(
+  implicit ec: ExecutionContext
+) extends BankAccountReputationService
+    with Logging {
+
+  def checkBankAccountReputation(
+    bankAccountType: BankAccountType,
+    bankAccountDetails: BankAccountDetails,
+    postCode: Option[String]
+  )(implicit hc: HeaderCarrier): EitherT[Future, ConnectorError, BankAccountReputation] =
+    bankAccountType match {
+      case BankAccountType.Personal =>
+        getPersonalAccountReputation(bankAccountDetails, postCode)
+      case BankAccountType.Business =>
+        getBusinessAccountReputation(bankAccountDetails)
+    }
+
+  def getBusinessAccountReputation(
+    bankAccountDetails: BankAccountDetails
+  )(implicit hc: HeaderCarrier): EitherT[Future, ConnectorError, BankAccountReputation] = {
+    val barsAccount: BarsAccount               =
+      BarsAccount(bankAccountDetails.sortCode.value, bankAccountDetails.accountNumber.value)
+    val barsRequest: BarsBusinessAssessRequest = BarsBusinessAssessRequest(barsAccount, None)
+    bankAccountReputationConnector.getBusinessReputation(barsRequest)
+  }
+
+  def getPersonalAccountReputation(
+    bankAccountDetails: BankAccountDetails,
+    postCode: Option[String]
+  )(implicit hc: HeaderCarrier): EitherT[Future, ConnectorError, BankAccountReputation] = {
+    val barsAccount                            = BarsAccount(bankAccountDetails.sortCode.value, bankAccountDetails.accountNumber.value)
+    val address                                = BarsAddress(Nil, None, postCode)
+    val accountName                            = Some(bankAccountDetails.accountName.value)
+    val subject                                = BarsSubject(None, accountName, None, None, None, address)
+    val barsRequest: BarsPersonalAssessRequest = BarsPersonalAssessRequest(barsAccount, subject)
+    bankAccountReputationConnector.getPersonalReputation(barsRequest)
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/utils/Logging.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/utils/Logging.scala
@@ -20,7 +20,9 @@ import play.api.Logger
 import play.api.mvc.Request
 import play.api.mvc.Result
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.CdsError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging._
 
 trait Logging {
@@ -35,6 +37,15 @@ trait Logging {
       logger warn (description, error)
       errorResult()
     }
+  }
+
+  def logAndDisplayError[T : CdsError](
+    description: String,
+    error: T
+  )(implicit errorHandler: ErrorHandler, request: Request[_], cdsError: CdsError[T]): Result = {
+    import errorHandler._
+    logger.warn(s"$description: ${cdsError.message(error)}")
+    errorResult()
   }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -166,6 +166,7 @@ microservice {
       port = 7502
       business = "/business/v2/assess"
       personal = "/personal/v3/assess"
+      retryIntervals = [1s, 2s]
     }
 
     customs-data-store {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/BankAccountReputationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/BankAccountReputationConnectorSpec.scala
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
+
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalamock.handlers.CallHandler
+import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.Configuration
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ConnectorFailure
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ServiceUnavailableError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.TechnicalServiceError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsBusinessAssessRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsPersonalAssessRequest
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.BusinessCompleteResponse
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.PersonalCompleteResponse
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.BankAccountReputationGen
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.BankAccountReputationGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class BankAccountReputationConnectorSpec
+    extends AnyWordSpec
+    with ScalaCheckDrivenPropertyChecks
+    with Matchers
+    with MockFactory
+    with HttpSupport
+    with ConnectorSpec
+    with BeforeAndAfterAll
+    with TypeCheckedTripleEquals {
+
+  val config                     = Configuration(ConfigFactory.load)
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  val actorSystem = ActorSystem("test-BankAccountReputationConnector")
+
+  override protected def afterAll(): Unit =
+    actorSystem.terminate()
+
+  val connector = new BankAccountReputationConnector(mockHttp, new ServicesConfig(config), config, actorSystem)
+
+  val businessRequest: BarsBusinessAssessRequest     = sample[BarsBusinessAssessRequest]
+  val personalRequest: BarsPersonalAssessRequest     = sample[BarsPersonalAssessRequest]
+  val businessResponseBody: BusinessCompleteResponse = sample(
+    BankAccountReputationGen.arbitraryBusinessCompleteResponse.arbitrary
+  )
+  val personalResponseBody: PersonalCompleteResponse = sample(
+    BankAccountReputationGen.arbitraryPersonalCompleteResponse.arbitrary
+  )
+  val businessUrl                                    = "http://localhost:7502/business/v2/assess"
+  val personalUrl                                    = "http://localhost:7502/personal/v3/assess"
+
+  def givenServiceReturns[T](
+    expectedUrl: String,
+    request: T
+  ): Option[HttpResponse] => CallHandler[Future[HttpResponse]] =
+    mockPost(expectedUrl, Seq.empty[(String, String)], request)
+
+  "BankAccountReputationConnector" should {
+    "have retries defined" in {
+      connector.retryIntervals should ===(Seq(1.second, 2.seconds))
+    }
+
+    "return bank account reputation information from a successful business request call" in
+      forAll { (request: BarsBusinessAssessRequest, response: BusinessCompleteResponse) =>
+        givenServiceReturns(businessUrl, request)(Some(HttpResponse(200, Json.toJson(response).toString()))).once()
+        await(connector.getBusinessReputation(request).value) shouldBe a[Right[_, BankAccountReputation]]
+      }
+
+    "return bank account reputation information from a successful personal request call" in {
+      forAll { (request: BarsPersonalAssessRequest, response: PersonalCompleteResponse) =>
+        givenServiceReturns(personalUrl, request)(Some(HttpResponse(200, Json.toJson(response).toString()))).once()
+        await(connector.getPersonalReputation(request).value) shouldBe a[Right[_, BankAccountReputation]]
+      }
+    }
+
+    "return an error when business response is 200 but payload is empty" in {
+      givenServiceReturns(businessUrl, businessRequest)(Some(HttpResponse(200, ""))).once()
+      await(connector.getBusinessReputation(businessRequest).value) should ===(
+        Left(
+          ConnectorFailure(
+            "could not read http response as JSON: No content to map due to end-of-input\n at [Source: (String)\"\"; line: 1, column: 0]"
+          )
+        )
+      )
+    }
+
+    "return an error when personal response is 200 but payload is empty" in {
+      givenServiceReturns(personalUrl, personalRequest)(Some(HttpResponse(200, ""))).once()
+      await(connector.getPersonalReputation(personalRequest).value) should ===(
+        Left(
+          ConnectorFailure(
+            "could not read http response as JSON: No content to map due to end-of-input\n at [Source: (String)\"\"; line: 1, column: 0]"
+          )
+        )
+      )
+    }
+
+    "return an error when business response is 200 but payload is invalid" in {
+      givenServiceReturns(businessUrl, businessRequest)(Some(HttpResponse(200, """{"foo":"bar"}"""))).once()
+      await(connector.getBusinessReputation(businessRequest).value) should ===(
+        Left(
+          ConnectorFailure(
+            "could not parse http response JSON: /accountNumberWithSortCodeIsValid: [error.path.missing]; /sortCodeIsPresentOnEISCD: [error.path.missing]"
+          )
+        )
+      )
+    }
+
+    "return an error when personal response is 200 but payload is invalid" in {
+      givenServiceReturns(personalUrl, personalRequest)(Some(HttpResponse(200, """{"foo":"bar"}"""))).once()
+      await(connector.getPersonalReputation(personalRequest).value) should ===(
+        Left(
+          ConnectorFailure(
+            "could not parse http response JSON: /accountNumberWithSortCodeIsValid: [error.path.missing]; /sortCodeIsPresentOnEISCD: [error.path.missing]"
+          )
+        )
+      )
+    }
+
+    "return an error when business request returns invalid success response status" in {
+      val response = Json.toJson(businessResponseBody).toString()
+      givenServiceReturns(businessUrl, businessRequest)(Some(HttpResponse(201, Json.toJson(response).toString())))
+        .once()
+      await(connector.getBusinessReputation(businessRequest).value) should ===(
+        Left(
+          ConnectorFailure(
+            s"""Request to POST http://localhost:7502/business/v2/assess failed because of HttpResponse status=201 "${response
+              .replace("\"", "\\\"")}""""
+          )
+        )
+      )
+    }
+
+    "return an error when personal request returns invalid success response status" in {
+      val response = Json.toJson(personalResponseBody).toString()
+      givenServiceReturns(personalUrl, personalRequest)(Some(HttpResponse(201, Json.toJson(response).toString())))
+        .once()
+      await(connector.getPersonalReputation(personalRequest).value) should ===(
+        Left(
+          ConnectorFailure(
+            s"""Request to POST http://localhost:7502/personal/v3/assess failed because of HttpResponse status=201 "${response
+              .replace("\"", "\\\"")}""""
+          )
+        )
+      )
+    }
+
+    "return an error when business request returns 4xx response status" in {
+      givenServiceReturns(businessUrl, businessRequest)(Some(HttpResponse(404, "not found"))).once()
+      await(connector.getBusinessReputation(businessRequest).value) should ===(
+        Left(
+          TechnicalServiceError(
+            s"Request to POST http://localhost:7502/business/v2/assess failed because of HttpResponse status=404 not found"
+          )
+        )
+      )
+    }
+
+    "return an error when personal request returns 4xx response status" in {
+      givenServiceReturns(personalUrl, personalRequest)(Some(HttpResponse(404, "not found"))).once()
+      await(connector.getPersonalReputation(personalRequest).value) shouldBe (
+        Left(
+          TechnicalServiceError(
+            s"Request to POST http://localhost:7502/personal/v3/assess failed because of HttpResponse status=404 not found"
+          )
+        )
+      )
+    }
+
+    "return an error when 5xx response status from a business request in the third attempt" in {
+      givenServiceReturns(businessUrl, businessRequest)(Some(HttpResponse(500, ""))).repeat(3)
+      givenServiceReturns(businessUrl, businessRequest)(
+        Some(HttpResponse(200, Json.toJson(businessResponseBody).toString()))
+      ).never()
+      await(connector.getBusinessReputation(businessRequest).value) should ===(
+        Left(
+          ServiceUnavailableError(
+            "Request to POST http://localhost:7502/business/v2/assess failed because of HttpResponse status=500 "
+          )
+        )
+      )
+    }
+
+    "return an error when 5xx response status from a personal request in the third attempt" in {
+      givenServiceReturns(personalUrl, personalRequest)(Some(HttpResponse(500, ""))).repeat(3)
+      givenServiceReturns(personalUrl, personalRequest)(
+        Some(HttpResponse(200, Json.toJson(personalResponseBody).toString()))
+      ).never()
+      await(connector.getPersonalReputation(personalRequest).value) should ===(
+        Left(
+          ServiceUnavailableError(
+            "Request to POST http://localhost:7502/personal/v3/assess failed because of HttpResponse status=500 "
+          )
+        )
+      )
+    }
+
+    "accept valid response from a business request on a second attempt" in {
+      givenServiceReturns(businessUrl, businessRequest)(Some(HttpResponse(500, ""))).once()
+      givenServiceReturns(businessUrl, businessRequest)(
+        Some(HttpResponse(200, Json.toJson(businessResponseBody).toString()))
+      ).once()
+      await(connector.getBusinessReputation(businessRequest).value) shouldBe a[Right[_, BankAccountReputation]]
+    }
+
+    "accept valid response from a personal request on a second attempt" in {
+      givenServiceReturns(personalUrl, personalRequest)(Some(HttpResponse(500, ""))).once()
+      givenServiceReturns(personalUrl, personalRequest)(
+        Some(HttpResponse(200, Json.toJson(personalResponseBody).toString()))
+      ).once()
+      await(connector.getPersonalReputation(personalRequest).value) shouldBe a[Right[_, BankAccountReputation]]
+    }
+
+    "accept valid response from a business request on a third attempt" in {
+      givenServiceReturns(businessUrl, businessRequest)(Some(HttpResponse(500, ""))).repeat(2)
+      givenServiceReturns(businessUrl, businessRequest)(
+        Some(HttpResponse(200, Json.toJson(businessResponseBody).toString()))
+      ).once()
+      await(connector.getBusinessReputation(businessRequest).value) shouldBe a[Right[_, BankAccountReputation]]
+    }
+
+    "accept valid response from a personal request on a third attempt" in {
+      givenServiceReturns(personalUrl, personalRequest)(Some(HttpResponse(500, ""))).repeat(2)
+      givenServiceReturns(personalUrl, personalRequest)(
+        Some(HttpResponse(200, Json.toJson(personalResponseBody).toString()))
+      ).once()
+      await(connector.getPersonalReputation(personalRequest).value) shouldBe a[Right[_, BankAccountReputation]]
+    }
+  }
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/CDSReimbursementClaimConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/CDSReimbursementClaimConnectorSpec.scala
@@ -51,14 +51,6 @@ class CDSReimbursementClaimConnectorSpec
         |        host     = localhost
         |        port     = 7501
         |      }
-        |      bank-account-reputation {
-        |        protocol = http
-        |        host = localhost
-        |        port = 9871
-        |        business = /business/v2/assess
-        |        personal = /personal/v3/assess
-        |     }
-        |
         |   }
         |}
         |""".stripMargin
@@ -77,26 +69,6 @@ class CDSReimbursementClaimConnectorSpec
       behave like connectorBehaviour(
         mockGet(url)(_),
         () => connector.getDeclaration(mrn)
-      )
-    }
-
-    "handling requests to verify a business bank account" must {
-      val url     = "http://localhost:9871/business/v2/assess"
-      val jsValue = sample[JsValue]
-
-      behave like connectorBehaviour(
-        mockPost(url, Seq.empty, *)(_),
-        () => connector.getBusinessReputation(jsValue)
-      )
-    }
-
-    "handling requests to verify a personal bank account" must {
-      val url     = "http://localhost:9871/personal/v3/assess"
-      val jsValue = sample[JsValue]
-
-      behave like connectorBehaviour(
-        mockPost(url, Seq.empty, *)(_),
-        () => connector.getPersonalReputation(jsValue)
       )
     }
   }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsScheduledClaimConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/RejectedGoodsScheduledClaimConnectorSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
+import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
@@ -35,6 +36,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 import scala.util.Failure
 import org.scalamock.handlers.CallHandler
+
 import scala.concurrent.Future
 
 class RejectedGoodsScheduledClaimConnectorSpec
@@ -77,7 +79,7 @@ class RejectedGoodsScheduledClaimConnectorSpec
 
   val expectedUrl = "http://host-2:312/foo-claim-scheduled/claims/rejected-goods-scheduled"
 
-  val requestGen = for {
+  val requestGen: Gen[RejectedGoodsScheduledClaimConnector.Request] = for {
     journey <- RejectedGoodsScheduledJourneyGenerators.completeJourneyGen
   } yield RejectedGoodsScheduledClaimConnector.Request(
     journey.toOutput.getOrElse(fail("Could not generate journey output!"))

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/MockBankAccountReputationService.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/MockBankAccountReputationService.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers
+
+import cats.data.EitherT
+import cats.implicits._
+import org.scalamock.scalatest.MockFactory
+import org.scalamock.handlers.CallHandler2
+import org.scalamock.handlers.CallHandler3
+import org.scalamock.handlers.CallHandler4
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.AccountName
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.AccountNumber
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SortCode
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+trait MockBankAccountReputationService {
+  this: MockFactory =>
+
+  lazy val mockBankAccountReputationService: BankAccountReputationService = mock[BankAccountReputationService]
+
+  def mockBusinessReputation(
+    bankAccountDetails: BankAccountDetails = BankAccountDetails(AccountName(""), SortCode(""), AccountNumber("")),
+    response: Either[ConnectorError, BankAccountReputation]
+  )(implicit
+    ec: ExecutionContext
+  ): CallHandler2[BankAccountDetails, HeaderCarrier, EitherT[Future, ConnectorError, BankAccountReputation]] =
+    (mockBankAccountReputationService
+      .getBusinessAccountReputation(_: BankAccountDetails)(_: HeaderCarrier))
+      .expects(bankAccountDetails, *)
+      .returning(EitherT.fromEither[Future](response))
+      .once()
+
+  def mockPersonalReputation(
+    bankAccountDetails: BankAccountDetails,
+    postCode: Option[String],
+    response: Either[ConnectorError, BankAccountReputation]
+  )(implicit
+    ec: ExecutionContext
+  ): CallHandler3[BankAccountDetails, Option[String], HeaderCarrier, EitherT[
+    Future,
+    ConnectorError,
+    BankAccountReputation
+  ]] =
+    (mockBankAccountReputationService
+      .getPersonalAccountReputation(_: BankAccountDetails, _: Option[String])(_: HeaderCarrier))
+      .expects(bankAccountDetails, postCode, *)
+      .returning(EitherT.fromEither[Future](response))
+      .once()
+
+  def mockBankAccountReputation(
+    bankAccountType: BankAccountType,
+    bankAccountDetails: BankAccountDetails,
+    postCode: Option[String],
+    response: Either[ConnectorError, BankAccountReputation]
+  )(implicit
+    ec: ExecutionContext
+  ): CallHandler4[BankAccountType, BankAccountDetails, Option[String], HeaderCarrier, EitherT[
+    Future,
+    ConnectorError,
+    BankAccountReputation
+  ]] =
+    (mockBankAccountReputationService
+      .checkBankAccountReputation(_: BankAccountType, _: BankAccountDetails, _: Option[String])(_: HeaderCarrier))
+      .expects(bankAccountType, bankAccountDetails, postCode, *)
+      .returning(EitherT.fromEither[Future](response))
+      .once()
+
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterBankAccountDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterBankAccountDetailsControllerSpec.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled
 
-import cats.data.EitherT
-import cats.implicits._
 import org.jsoup.nodes.Document
 import org.scalacheck.Gen
 import org.scalatest.BeforeAndAfterEach
@@ -33,20 +31,19 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ServiceUnavailableError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.MockBankAccountReputationService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.PropertyBasedControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoods.{routes => rejectedGoodsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduledJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduledJourneyGenerators._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.BankAccountReputationGen.arbitraryBankAccountReputation
@@ -55,10 +52,9 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.ContactAddres
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DisplayResponseDetailGen.genBankAccountDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.alphaNumGen
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.numStringGen
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 import uk.gov.hmrc.http.BadRequestException
-import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -67,30 +63,8 @@ class EnterBankAccountDetailsControllerSpec
     extends PropertyBasedControllerSpec
     with AuthSupport
     with SessionSupport
-    with BeforeAndAfterEach {
-
-  val mockClaimService = mock[ClaimService]
-
-  def mockBusinessReputation(
-    bankAccountDetails: BankAccountDetails,
-    response: Either[Error, BankAccountReputation]
-  ) =
-    (mockClaimService
-      .getBusinessAccountReputation(_: BankAccountDetails)(_: HeaderCarrier))
-      .expects(bankAccountDetails, *)
-      .returning(EitherT.fromEither[Future](response))
-      .once()
-
-  def mockPersonalReputation(
-    bankAccountDetails: BankAccountDetails,
-    postCode: Option[String],
-    response: Either[Error, BankAccountReputation]
-  ) =
-    (mockClaimService
-      .getPersonalAccountReputation(_: BankAccountDetails, _: Option[String])(_: HeaderCarrier))
-      .expects(bankAccountDetails, postCode, *)
-      .returning(EitherT.fromEither[Future](response))
-      .once()
+    with BeforeAndAfterEach
+    with MockBankAccountReputationService {
 
   private def getInputBoxValue(doc: Document, inputBoxSubKey: String): Option[String] =
     selectedInputBox(doc, s"enter-bank-details.$inputBoxSubKey")
@@ -99,7 +73,7 @@ class EnterBankAccountDetailsControllerSpec
     List[GuiceableModule](
       bind[AuthConnector].toInstance(mockAuthConnector),
       bind[SessionCache].toInstance(mockSessionCache),
-      bind[ClaimService].toInstance(mockClaimService)
+      bind[BankAccountReputationService].toInstance(mockBankAccountReputationService)
     )
 
   val controller: EnterBankAccountDetailsController = instanceOf[EnterBankAccountDetailsController]
@@ -198,7 +172,7 @@ class EnterBankAccountDetailsControllerSpec
             )
 
           inSequence(
-            mockPersonalReputation(bankDetails, postCode, Right(personalResponse))
+            mockBankAccountReputation(BankAccountType.Personal, bankDetails, postCode, Right(personalResponse))
           )
 
           checkIsRedirect(
@@ -217,7 +191,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockPersonalReputation(bankAccountDetails, postCode, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Personal, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -240,7 +214,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockPersonalReputation(bankAccountDetails, postCode, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Personal, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -263,7 +237,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockPersonalReputation(bankAccountDetails, postCode, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Personal, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -285,7 +259,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockPersonalReputation(bankAccountDetails, postCode, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Personal, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -313,7 +287,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockPersonalReputation(bankAccountDetails, postCode, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Personal, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -342,7 +316,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockPersonalReputation(bankAccountDetails, postCode, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Personal, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -370,7 +344,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockPersonalReputation(bankAccountDetails, postCode, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Personal, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -398,7 +372,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockPersonalReputation(bankAccountDetails, postCode, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Personal, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -422,7 +396,7 @@ class EnterBankAccountDetailsControllerSpec
           genBankAccountDetails,
           Gen.option(genPostcode)
         ) { (bankDetails, postCode) =>
-          val personalResponse =
+          val expectedResponse =
             bankaccountreputation.BankAccountReputation(
               accountNumberWithSortCodeIsValid = Yes,
               accountExists = Some(Yes),
@@ -430,7 +404,7 @@ class EnterBankAccountDetailsControllerSpec
             )
 
           inSequence(
-            mockBusinessReputation(bankDetails, Right(personalResponse))
+            mockBankAccountReputation(BankAccountType.Business, bankDetails, postCode, Right(expectedResponse))
           )
 
           checkIsRedirect(
@@ -449,7 +423,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockBusinessReputation(bankAccountDetails, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Business, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -472,7 +446,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockBusinessReputation(bankAccountDetails, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Business, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -495,7 +469,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockBusinessReputation(bankAccountDetails, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Business, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -523,7 +497,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockBusinessReputation(bankAccountDetails, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Business, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -551,7 +525,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockBusinessReputation(bankAccountDetails, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Business, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -580,7 +554,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockBusinessReputation(bankAccountDetails, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Business, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -608,7 +582,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockBusinessReputation(bankAccountDetails, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Business, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -636,7 +610,7 @@ class EnterBankAccountDetailsControllerSpec
           )
 
           inSequence(
-            mockBusinessReputation(bankAccountDetails, Right(expectedResponse))
+            mockBankAccountReputation(BankAccountType.Business, bankAccountDetails, postCode, Right(expectedResponse))
           )
 
           checkPageIsDisplayed(
@@ -670,7 +644,7 @@ class EnterBankAccountDetailsControllerSpec
         inSequence {
           mockAuthWithNoRetrievals()
           mockGetSession(requiredSession)
-          mockPersonalReputation(bankDetails, None, Right(expectedSuccessfulResponse))
+          mockBankAccountReputation(BankAccountType.Personal, bankDetails, None, Right(expectedSuccessfulResponse))
           mockStoreSession(updatedSession)(Right(()))
         }
 
@@ -711,10 +685,17 @@ class EnterBankAccountDetailsControllerSpec
           RejectedGoodsScheduledJourney.empty(exampleEori).submitBankAccountType(BankAccountType.Personal).getOrFail
         val requiredSession = session.copy(rejectedGoodsScheduledJourney = Some(initialJourney))
 
+        val boom = new BadRequestException("Boom!")
+
         inSequence {
           mockAuthWithNoRetrievals()
           mockGetSession(requiredSession)
-          mockPersonalReputation(bankDetails, None, Left(Error(new BadRequestException("Boom!"))))
+          mockBankAccountReputation(
+            BankAccountType.Personal,
+            bankDetails,
+            None,
+            Left(ServiceUnavailableError(boom.message, Some(boom)))
+          )
         }
 
         checkIsRedirect(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/BankAccountReputationGen.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/BankAccountReputationGen.scala
@@ -18,6 +18,8 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators
 
 import org.scalacheck.Gen
 import org.scalacheck.magnolia._
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.request.BarsBusinessAssessRequest
@@ -27,6 +29,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.re
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.PersonalCompleteResponse
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationErrorResponse
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
 
 object BankAccountReputationGen {
 


### PR DESCRIPTION
CDSR-1604 add MockBankAccountReputationService
CDSR-1604 fix updated bank account number issue with failing BankAccountControllerSpec
CDSR-1604 eod work on BankAccountReputationConnectorSpec BankAccountReputationService
CDSR-1604 add retries to BankAccountReputationConnector
CDSR-1604 generated business request 200 test passing
CDSR-1604 generated personal request 200 test passing
CDSR-1604 error when 5xx response status in the third attempt passing
CDSR-1604 all 5xx response tests passing
CDSR-1604 200 response witjh invalid payloads passing
CDSR-1604 201 tests passing
CDSR-1604 404 tests passing, tidy up
CDSR-1604 formatting
CDSR-1604 add ConnectorError and merge BankAccountReputationConnector
CDSR-1604 merge BankAccountReputationService
CDSR-1604 merge claims/BankAccountController
CDSR-1604 merge the three 1179 EnterBankAccountDetailsController(s)
CDSR-1604 make tests compile
CDSR-1604 update error types in BankAccountReputationConnectorSpec