### PR TITLE
[CDSR-1724] move multiple-only controllers into the overpaymentsmultiple package

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Router.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Router.scala
@@ -86,7 +86,7 @@ trait JourneyTypeRoutes extends Product with Serializable {
             if (hasAssociatedMrns)
               overpaymentsMultipleRoutes.CheckMovementReferenceNumbersController.showMrns
             else
-              claimRoutes.EnterAssociatedMrnController.enterMrn(AssociatedMrnIndex.fromListIndex(0))
+              overpaymentsMultipleRoutes.EnterAssociatedMrnController.enterMrn(AssociatedMrnIndex.fromListIndex(0))
           case _                         =>
             claimRoutes.CheckContactDetailsMrnController.show(journeyBindable)
         }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAdditionalDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAdditionalDetailsController.scala
@@ -31,6 +31,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAdditionalDetailsController.additionalDetailsForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
@@ -93,7 +94,7 @@ class EnterAdditionalDetailsController @Inject() (
                         case JourneyBindable.Scheduled =>
                           claimRoutes.SelectDutyTypesController.showDutyTypes(JourneyBindable.Scheduled)
                         case JourneyBindable.Multiple  =>
-                          claimRoutes.SelectMultipleDutiesController.selectDuties(index = 1)
+                          overpaymentsMultipleRoutes.SelectMultipleDutiesController.selectDuties(index = 1)
                         case _                         =>
                           claimRoutes.SelectDutiesController.selectDuties()
                       })

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/CheckMovementReferenceNumbersController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/CheckMovementReferenceNumbersController.scala
@@ -102,7 +102,7 @@ class CheckMovementReferenceNumbersController @Inject() (
           {
             case Yes =>
               Redirect(
-                claimsRoutes.EnterAssociatedMrnController
+                routes.EnterAssociatedMrnController
                   .enterMrn(AssociatedMrnIndex.fromListIndex(journey.draftClaim.associatedMRNsAnswer.length))
               )
             case No  =>

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterAssociatedMrnController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterAssociatedMrnController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple
 
 import cats.data.EitherT
 import cats.implicits.catsSyntaxEq
@@ -37,7 +37,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAssociatedMrnController.enterAssociatedMrnKey
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterAssociatedMrnController.enterAssociatedMrnKey
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.AssociatedMrn
@@ -50,7 +51,6 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.util.toFuture
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterMultipleClaimsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterMultipleClaimsController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple
 
 import cats.data.EitherT
 import cats.data.NonEmptyList
@@ -28,9 +28,9 @@ import play.api.mvc._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable.Multiple
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.YesOrNoQuestionForm
@@ -38,6 +38,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.Authenticat
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.OverpaymentsRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ClaimedReimbursement
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Duty
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
@@ -199,7 +201,7 @@ class EnterMultipleClaimsController @Inject() (
                           case Yes =>
                             Redirect(
                               router.CheckAnswers.when(fillingOutClaim.draftClaim.isComplete)(alternatively =
-                                routes.BankAccountController.checkBankAccountDetails(Multiple)
+                                claimsRoutes.BankAccountController.checkBankAccountDetails(Multiple)
                               )
                             )
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/SelectMultipleDutiesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/SelectMultipleDutiesController.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple
 
 import cats.data.EitherT
+import cats.data.NonEmptyList
 import cats.implicits.catsSyntaxEq
 import cats.instances.future.catsStdInstancesForFuture
 import com.google.inject.Inject
@@ -29,21 +30,22 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectMultipleDutiesController._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer.IncorrectExciseValue
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.SelectMultipleDutiesController._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ClaimedReimbursement
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Duty
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCodes
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer.IncorrectExciseValue
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.AssociatedMrnIndex
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.util.toFuture
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging._
@@ -52,8 +54,6 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import cats.data.NonEmptyList
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ClaimedReimbursement
 
 @Singleton
 class SelectMultipleDutiesController @Inject() (

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_movement_reference_numbers.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_movement_reference_numbers.scala.html
@@ -72,7 +72,7 @@
                         <dt class="govuk-summary-list__key">@Html(messages("check-your-answers.reference-number.associated-mrn-label", index.ordinalNumeral.capitalize))</dt>
                         <dd class="govuk-summary-list__value">@mrnWithIndex._1.value</dd>
                         <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link" href=@routes.EnterAssociatedMrnController.changeMrn(index).url>@{
+                            <a class="govuk-link" href=@overpaymentsMultipleRoutes.EnterAssociatedMrnController.changeMrn(index).url>@{
                                 messages(s"cya.change")
                             }</a>
                         </dd>

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
@@ -20,6 +20,7 @@
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.OverpaymentsRoutes
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.fileupload.{routes => fileUploadRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
@@ -109,7 +110,7 @@
 
     @if(claim.typeOfClaim.contains(TypeOfClaimAnswer.Multiple)) {
         @pageHeading(Html(messages(s"$key.multiple-claim-totals.label")), "govuk-heading-m govuk-!-margin-top-9", "h2")
-        @summary(MultipleClaimsAnswerSummary(claim.multipleClaimsAnswer,s"$key.claim-calculation",subKey,claimRoutes.EnterMultipleClaimsController.checkClaimSummary.setChangeFlag))
+        @summary(MultipleClaimsAnswerSummary(claim.multipleClaimsAnswer,s"$key.claim-calculation",subKey, overpaymentsMultipleRoutes.EnterMultipleClaimsController.checkClaimSummary.setChangeFlag))
     }
 
     @claim.reimbursementMethodAnswer.map { rma =>

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_associated_mrn.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_associated_mrn.scala.html
@@ -19,7 +19,7 @@
 @import play.twirl.api.Html
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes=>overpaymentsMultipleRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.AssociatedMrn
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.AssociatedMrnIndex
 
@@ -41,8 +41,8 @@
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
 @submitUrl = @{
-    if(editing) routes.EnterAssociatedMrnController.submitChangedMrn(index)
-    else routes.EnterAssociatedMrnController.submitEnteredMrn(index)
+    if(editing) overpaymentsMultipleRoutes.EnterAssociatedMrnController.submitChangedMrn(index)
+    else overpaymentsMultipleRoutes.EnterAssociatedMrnController.submitEnteredMrn(index)
 }
 
 @layout(pageTitle = Some(title), hasErrors = hasErrors) {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_multiple_claims.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_multiple_claims.scala.html
@@ -22,7 +22,7 @@
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ClaimedReimbursement
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterMultipleClaimsController.CorrectedAmount
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterMultipleClaimsController.CorrectedAmount
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.input.PrefixOrSuffix
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_multiple_duties.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_multiple_duties.scala.html
@@ -18,7 +18,7 @@
 @import play.twirl.api.Html
 @import play.api.i18n.Messages
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes=>overpaymentsMultipleRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.DutiesSelectedAnswer
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Duty
@@ -44,7 +44,7 @@
   @key = @{"select-duties"}
   @title = @{messages(s"multiple-$key.title",  OrdinalNumeral(mrnIndex))}
 
-  @postAction = @{routes.SelectMultipleDutiesController.selectDutiesSubmit(mrnIndex)}
+  @postAction = @{overpaymentsMultipleRoutes.SelectMultipleDutiesController.selectDutiesSubmit(mrnIndex)}
     @options = @{dutiesToDisplay.map { duty =>
 
         CheckboxItem(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/MovementReferenceNumbersSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/MovementReferenceNumbersSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.AssociatedMrn
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.LeadMrn
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.AssociatedMrnIndex
@@ -58,7 +58,7 @@ object MovementReferenceNumbersSummary extends AnswerSummary[List[MRN]] {
           Actions(items =
             Seq(
               ActionItem(
-                href = s"${routes.EnterAssociatedMrnController.changeMrn(mrnIndex).url}",
+                href = s"${overpaymentsMultipleRoutes.EnterAssociatedMrnController.changeMrn(mrnIndex).url}",
                 content = Text(messages("cya.change"))
               )
             )

--- a/conf/claims.routes
+++ b/conf/claims.routes
@@ -52,21 +52,6 @@ POST        /single/check-claim                                     uk.gov.hmrc.
 GET         /:journey/enter-additional-details                       uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAdditionalDetailsController.enterAdditionalDetails(journey: JourneyBindable)
 POST        /:journey/enter-additional-details                       uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAdditionalDetailsController.enterAdditionalDetailsSubmit(journey: JourneyBindable)
 
-GET         /multiple/enter-movement-reference-number/:index        uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAssociatedMrnController.enterMrn(index: AssociatedMrnIndex)
-POST        /multiple/enter-movement-reference-number/:index        uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAssociatedMrnController.submitEnteredMrn(index: AssociatedMrnIndex)
-
-GET         /multiple/change-movement-reference-number/:index       uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAssociatedMrnController.changeMrn(index: AssociatedMrnIndex)
-POST        /multiple/change-movement-reference-number/:index       uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAssociatedMrnController.submitChangedMrn(index: AssociatedMrnIndex)
-
-GET         /multiple/select-duties/:index                          uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectMultipleDutiesController.selectDuties(index: Int)
-POST        /multiple/select-duties/:index                          uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectMultipleDutiesController.selectDutiesSubmit(index: Int)
-
-GET         /multiple/select-duties/:index/:taxCode                 uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterMultipleClaimsController.enterClaim(index: Int, taxCode: TaxCode)
-POST        /multiple/select-duties/:index/:taxCode                 uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterMultipleClaimsController.enterClaimSubmit(index: Int, taxCode: TaxCode)
-
-GET         /multiple/check-claim                                   uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterMultipleClaimsController.checkClaimSummary
-POST        /multiple/check-claim                                   uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterMultipleClaimsController.checkClaimSummarySubmit
-
 GET         /:journey/select-duties/select-duty-types              uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyTypesController.showDutyTypes(journey: JourneyBindable)
 POST        /:journey/select-duties/select-duty-types              uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyTypesController.submitDutyTypes(journey: JourneyBindable)
 

--- a/conf/overpayments_multiple.routes
+++ b/conf/overpayments_multiple.routes
@@ -5,6 +5,21 @@ GET         /multiple/check-movement-reference-numbers                         @
 POST        /multiple/check-movement-reference-numbers                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckMovementReferenceNumbersController.submitMrns
 GET         /multiple/delete-movement-reference-number/:index                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.CheckMovementReferenceNumbersController.deleteMrn(index: AssociatedMrnIndex)
 
+GET         /multiple/enter-movement-reference-number/:index                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterAssociatedMrnController.enterMrn(index: AssociatedMrnIndex)
+POST        /multiple/enter-movement-reference-number/:index                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterAssociatedMrnController.submitEnteredMrn(index: AssociatedMrnIndex)
+
+GET         /multiple/change-movement-reference-number/:index                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterAssociatedMrnController.changeMrn(index: AssociatedMrnIndex)
+POST        /multiple/change-movement-reference-number/:index                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterAssociatedMrnController.submitChangedMrn(index: AssociatedMrnIndex)
+
+GET         /multiple/select-duties/:index                                     @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.SelectMultipleDutiesController.selectDuties(index: Int)
+POST        /multiple/select-duties/:index                                     @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.SelectMultipleDutiesController.selectDutiesSubmit(index: Int)
+
+GET         /multiple/select-duties/:index/:taxCode                            @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterMultipleClaimsController.enterClaim(index: Int, taxCode: TaxCode)
+POST        /multiple/select-duties/:index/:taxCode                            @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterMultipleClaimsController.enterClaimSubmit(index: Int, taxCode: TaxCode)
+
+GET         /multiple/check-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterMultipleClaimsController.checkClaimSummary
+POST        /multiple/check-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterMultipleClaimsController.checkClaimSummarySubmit
+
 GET         /multiple/supporting-evidence/select-supporting-evidence-type      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.ChooseFileTypeController.show
 POST        /multiple/supporting-evidence/select-supporting-evidence-type      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.ChooseFileTypeController.submit
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAdditionalDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/EnterAdditionalDetailsControllerSpec.scala
@@ -33,6 +33,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DraftClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
@@ -231,7 +232,7 @@ class EnterAdditionalDetailsControllerSpec
           if (journeyBindable === JourneyBindable.Scheduled) {
             routes.SelectDutyTypesController.showDutyTypes(JourneyBindable.Scheduled)
           } else if (journeyBindable === JourneyBindable.Multiple) {
-            routes.SelectMultipleDutiesController.selectDuties(1)
+            overpaymentsMultipleRoutes.SelectMultipleDutiesController.selectDuties(1)
           } else {
             routes.SelectDutiesController.selectDuties()
           }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/CheckMovementReferenceNumbersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/CheckMovementReferenceNumbersControllerSpec.scala
@@ -267,7 +267,7 @@ class CheckMovementReferenceNumbersControllerSpec
 
           checkIsRedirect(
             performActionWithData(Seq(checkMovementReferenceNumbersKey -> true.toString)),
-            claimsRoutes.EnterAssociatedMrnController.enterMrn(AssociatedMrnIndex.fromListIndex(mrnForwardIndex))
+            routes.EnterAssociatedMrnController.enterMrn(AssociatedMrnIndex.fromListIndex(mrnForwardIndex))
           )
         }
       }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterAssociatedMrnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterAssociatedMrnControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple
 
 import cats.Functor
 import cats.Id
@@ -39,8 +39,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.EnterAssociatedMrnController.enterAssociatedMrnKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAssociatedMrnController.enterAssociatedMrnKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.TypeOfClaimAnswer

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterMultipleClaimsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterMultipleClaimsControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple
 
 import cats.Functor
 import cats.Id
@@ -24,6 +24,7 @@ import org.scalacheck.Gen
 import org.scalactic.source.Position
 import org.scalatest.Assertion
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.http.Status
 import play.api.i18n.Lang
 import play.api.i18n.Messages
 import play.api.i18n.MessagesApi
@@ -36,13 +37,16 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.OverpaymentsRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer.IncorrectExciseValue
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer.IncorrectExciseValue
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.NdrcDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Acc14Gen._
@@ -52,12 +56,9 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.SignedInUserDetailsGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.GGCredId
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 
 import scala.concurrent.Future
 import scala.util.Random
-import play.api.http.Status
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 
 class EnterMultipleClaimsControllerSpec
     extends ControllerSpec

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/SelectMultipleDutiesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/SelectMultipleDutiesControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple
 
 import cats.Functor
 import cats.Id
@@ -23,6 +23,7 @@ import org.jsoup.nodes.Document
 import org.scalacheck.Gen
 import org.scalactic.source.Position
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.http.Status
 import play.api.i18n.Lang
 import play.api.i18n.Messages
 import play.api.i18n.MessagesApi
@@ -37,11 +38,11 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer.IncorrectExciseValue
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer.IncorrectExciseValue
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.NdrcDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Acc14Gen._
@@ -54,7 +55,6 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 
 import scala.concurrent.Future
 import scala.util.Random
-import play.api.http.Status
 
 class SelectMultipleDutiesControllerSpec
     extends ControllerSpec


### PR DESCRIPTION
This PR moves the following endpoints:
- /multiple/enter-movement-reference-number/:index
- /multiple/change-movement-reference-number/:index
- /multiple/select-duties/:index
- /multiple/select-duties/:index/:taxCode
- /multiple/check-claim