### PR TITLE
[CDSR-1725] move C285 Scheduled controllers into the overpaymentsscheduled package

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyTypesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyTypesController.scala
@@ -29,7 +29,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.Authenticat
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.selectDutyTypesForm
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.{routes => overpaymentsScheduledRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
@@ -65,7 +66,7 @@ class SelectDutyTypesController @Inject() (
   def showDutyTypes(implicit journey: JourneyBindable): Action[AnyContent] = authenticatedActionWithSessionData.async {
     implicit request =>
       withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (_, answer) =>
-        val postAction: Call = claimRoutes.SelectDutyTypesController.submitDutyTypes(journey)
+        val postAction: Call = claimsRoutes.SelectDutyTypesController.submitDutyTypes(journey)
         Ok(
           selectDutyTypesPage(
             answer.map(_.value.keys.toList).fold(selectDutyTypesForm)(selectDutyTypesForm.fill),
@@ -78,7 +79,7 @@ class SelectDutyTypesController @Inject() (
   def submitDutyTypes(implicit journey: JourneyBindable): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
       withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (fillingOutClaim, maybeAnswer) =>
-        val postAction: Call = claimRoutes.SelectDutyTypesController.submitDutyTypes(journey)
+        val postAction: Call = claimsRoutes.SelectDutyTypesController.submitDutyTypes(journey)
         selectDutyTypesForm
           .bindFromRequest()
           .fold(
@@ -98,7 +99,7 @@ class SelectDutyTypesController @Inject() (
                 .leftMap(_ => Error("could not update session"))
                 .fold(
                   logAndDisplayError("could not get duty types selected"),
-                  _ => Redirect(claimRoutes.SelectDutyCodesController.iterate())
+                  _ => Redirect(overpaymentsScheduledRoutes.SelectDutyCodesController.iterate())
                 )
             }
           )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/CheckScheduledClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/CheckScheduledClaimController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled
 
 import cats.data.EitherT
 import cats.implicits.catsSyntaxOptionId
@@ -32,7 +32,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckScheduledClaimController.whetherDutiesCorrectForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckScheduledClaimController.whetherDutiesCorrectForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/EnterScheduledClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/EnterScheduledClaimController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled
 
 import cats.data.EitherT
 import cats.syntax.all._
@@ -70,12 +70,12 @@ class EnterScheduledClaimController @Inject() (
 
   def iterate(): Action[AnyContent] = authenticatedActionWithSessionData.async { implicit request =>
     def redirectToSummaryPage: Future[Result] =
-      Future.successful(Redirect(claimRoutes.CheckScheduledClaimController.showReimbursements()))
+      Future.successful(Redirect(routes.CheckScheduledClaimController.showReimbursements()))
 
     def start(dutyAndTaxCode: (DutyType, TaxCode)): Future[Result] =
       Future.successful(
         Redirect(
-          claimRoutes.EnterScheduledClaimController.enterClaim(
+          routes.EnterScheduledClaimController.enterClaim(
             dutyAndTaxCode._1,
             dutyAndTaxCode._2
           )
@@ -92,7 +92,7 @@ class EnterScheduledClaimController @Inject() (
   def enterClaim(dutyType: DutyType, dutyCode: TaxCode): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
       withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (_, maybeAnswer) =>
-        val postAction: Call = claimRoutes.EnterScheduledClaimController.submitClaim(dutyType, dutyCode)
+        val postAction: Call = routes.EnterScheduledClaimController.submitClaim(dutyType, dutyCode)
         Ok(
           enterScheduledClaimPage(
             dutyType,
@@ -110,7 +110,7 @@ class EnterScheduledClaimController @Inject() (
   def submitClaim(dutyType: DutyType, taxCode: TaxCode): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
       withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (fillingOutClaim, maybeAnswer) =>
-        val postAction: Call                                             = claimRoutes.EnterScheduledClaimController.submitClaim(dutyType, taxCode)
+        val postAction: Call                                             = routes.EnterScheduledClaimController.submitClaim(dutyType, taxCode)
         def updateClaim(answer: SelectedDutyTaxCodesReimbursementAnswer) =
           updateSession(sessionCache, request)(
             _.copy(journeyStatus =
@@ -137,13 +137,13 @@ class EnterScheduledClaimController @Inject() (
                   _.findUnclaimedReimbursement
                     .map { dutyAndTaxCode =>
                       Redirect(
-                        claimRoutes.EnterScheduledClaimController.enterClaim(
+                        routes.EnterScheduledClaimController.enterClaim(
                           dutyAndTaxCode._1,
                           dutyAndTaxCode._2
                         )
                       )
                     }
-                    .getOrElse(Redirect(claimRoutes.CheckScheduledClaimController.showReimbursements()))
+                    .getOrElse(Redirect(routes.CheckScheduledClaimController.showReimbursements()))
                 )
           )
       }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/SelectDutyCodesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/SelectDutyCodesController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled
 
 import cats.data.OptionT
 import cats.implicits.catsSyntaxOptionId
@@ -68,7 +68,7 @@ class SelectDutyCodesController @Inject() (
       Future.successful(Redirect(claimRoutes.SelectDutyTypesController.showDutyTypes(JourneyBindable.Scheduled)))
 
     def start(dutyType: DutyType): Future[Result] =
-      Future(Redirect(claimRoutes.SelectDutyCodesController.showDutyCodes(dutyType)))
+      Future(Redirect(routes.SelectDutyCodesController.showDutyCodes(dutyType)))
 
     withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (_, maybeAnswer) =>
       maybeAnswer.flatMap(_.value.headOption).fold(selectDuties) { selectedDutyTaxCodesReimbursement =>
@@ -81,7 +81,7 @@ class SelectDutyCodesController @Inject() (
     implicit request =>
       withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (_, maybeAnswer) =>
         val maybeSelectedTaxCodes = maybeAnswer.map(_.getTaxCodes(dutyType))
-        val postAction: Call      = claimRoutes.SelectDutyCodesController.submitDutyCodes(dutyType)
+        val postAction: Call      = routes.SelectDutyCodesController.submitDutyCodes(dutyType)
         Ok(
           selectDutyCodesPage(
             dutyType,
@@ -95,7 +95,7 @@ class SelectDutyCodesController @Inject() (
   def submitDutyCodes(currentDuty: DutyType): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
       withAnswers[SelectedDutyTaxCodesReimbursementAnswer] { (fillingOutClaim, maybeAnswer) =>
-        val postAction: Call = claimRoutes.SelectDutyCodesController.submitDutyCodes(currentDuty)
+        val postAction: Call = routes.SelectDutyCodesController.submitDutyCodes(currentDuty)
 
         def updateClaim(answer: SelectedDutyTaxCodesReimbursementAnswer) = {
           val claim = from(fillingOutClaim)(_.copy(selectedDutyTaxCodesReimbursementAnswer = answer.some))
@@ -116,8 +116,8 @@ class SelectDutyCodesController @Inject() (
                     _ =>
                       maybeAnswer
                         .flatMap(_.findNextSelectedDutyAfter(currentDuty))
-                        .fold(Redirect(claimRoutes.EnterScheduledClaimController.iterate()))(nextDuty =>
-                          Redirect(claimRoutes.SelectDutyCodesController.showDutyCodes(nextDuty))
+                        .fold(Redirect(routes.EnterScheduledClaimController.iterate()))(nextDuty =>
+                          Redirect(routes.SelectDutyCodesController.showDutyCodes(nextDuty))
                         )
                   )
                 )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_scheduled_claim_summary.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_scheduled_claim_summary.scala.html
@@ -19,7 +19,7 @@
 @import play.twirl.api.Html
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.{routes => overpaymentsScheduledRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.{SelectedDutyTaxCodesReimbursementAnswer, YesNo}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.DutyAndTaxCodeReimbursementSummary
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.TaxCodeReimbursementSummary
@@ -42,7 +42,7 @@
 @key = @{"check-claim-summary"}
 @title = @{messages(s"$key.scheduled.title")}
 
-@postAction = @{claimRoutes.CheckScheduledClaimController.submitReimbursements()}
+@postAction = @{overpaymentsScheduledRoutes.CheckScheduledClaimController.submitReimbursements()}
 
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
@@ -21,6 +21,7 @@
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.{routes => overpaymentsScheduledRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.OverpaymentsRoutes
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.fileupload.{routes => fileUploadRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
@@ -104,7 +105,7 @@
             claim.typeOfClaim.contains(TypeOfClaimAnswer.Individual) ||
             claim.typeOfClaim.contains(TypeOfClaimAnswer.Scheduled)) {
             @pageHeading(Html(messages(combine(s"$key.claim-calculation", subKey, "h2"))), "govuk-heading-m govuk-!-margin-top-9", "h2")
-            @summary(ClaimedReimbursementsAnswerSummary(reimbursement,s"$key.claim-calculation",subKey, if (journey == JourneyBindable.Scheduled) claimRoutes.CheckScheduledClaimController.showReimbursements() else claimRoutes.EnterSingleClaimController.checkClaimSummary()))
+            @summary(ClaimedReimbursementsAnswerSummary(reimbursement,s"$key.claim-calculation",subKey, if (journey == JourneyBindable.Scheduled) overpaymentsScheduledRoutes.CheckScheduledClaimController.showReimbursements() else claimRoutes.EnterSingleClaimController.checkClaimSummary()))
         }
     }
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/TaxCodeReimbursementSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/TaxCodeReimbursementSummary.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
 import play.api.i18n.Messages
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.{routes => overpaymentsScheduledRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.SelectedDutyTaxCodesReimbursementAnswer.SelectedTaxCodesReimbursementOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DutyType
@@ -60,7 +60,7 @@ object TaxCodeReimbursementSummary extends AnswerSummary[(DutyType, SortedMap[Ta
             Actions(
               items = Seq(
                 ActionItem(
-                  href = routes.EnterScheduledClaimController.enterClaim(duty, taxCode).url,
+                  href = overpaymentsScheduledRoutes.EnterScheduledClaimController.enterClaim(duty, taxCode).url,
                   content = Text(messages("cya.change")),
                   visuallyHiddenText = Some(messages(s"$key.duty-code.row.key", messages(s"tax-code.${taxCode.value}")))
                 )

--- a/conf/claims.routes
+++ b/conf/claims.routes
@@ -55,17 +55,6 @@ POST        /:journey/enter-additional-details                       uk.gov.hmrc
 GET         /:journey/select-duties/select-duty-types              uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyTypesController.showDutyTypes(journey: JourneyBindable)
 POST        /:journey/select-duties/select-duty-types              uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyTypesController.submitDutyTypes(journey: JourneyBindable)
 
-GET         /scheduled/select-duties/start                          uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyCodesController.iterate()
-GET         /scheduled/select-duties/:dutyType                      uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyCodesController.showDutyCodes(dutyType: DutyType)
-POST        /scheduled/select-duties/:dutyType                      uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyCodesController.submitDutyCodes(dutyType: DutyType)
-
-GET         /scheduled/select-duties/reimbursement-claim/start      uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterScheduledClaimController.iterate()
-GET         /scheduled/select-duties/:dutyType/:taxCode             uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterScheduledClaimController.enterClaim(dutyType: DutyType, taxCode: TaxCode)
-POST        /scheduled/select-duties/:dutyType/:taxCode             uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterScheduledClaimController.submitClaim(dutyType: DutyType, taxCode: TaxCode)
-
-GET         /scheduled/check-claim                                  uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckScheduledClaimController.showReimbursements()
-POST        /scheduled/check-claim                                  uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckScheduledClaimController.submitReimbursements()
-
 GET         /single/select-reimbursement-method                     uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.ReimbursementMethodController.showReimbursementMethod()
 POST        /single/select-reimbursement-method                     uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.ReimbursementMethodController.submitReimbursementMethod()
 

--- a/conf/overpayments_scheduled.routes
+++ b/conf/overpayments_scheduled.routes
@@ -1,11 +1,22 @@
 GET         /scheduled/enter-movement-reference-number                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.EnterMovementReferenceNumberController.enterJourneyMrn
 POST        /scheduled/enter-movement-reference-number                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.EnterMovementReferenceNumberController.enterMrnSubmit
 
+GET         /scheduled/select-duties/start                                      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.SelectDutyCodesController.iterate()
+GET         /scheduled/select-duties/:dutyType                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.SelectDutyCodesController.showDutyCodes(dutyType: DutyType)
+POST        /scheduled/select-duties/:dutyType                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.SelectDutyCodesController.submitDutyCodes(dutyType: DutyType)
+
+GET         /scheduled/select-duties/reimbursement-claim/start                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.EnterScheduledClaimController.iterate()
+GET         /scheduled/select-duties/:dutyType/:taxCode                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.EnterScheduledClaimController.enterClaim(dutyType: DutyType, taxCode: TaxCode)
+POST        /scheduled/select-duties/:dutyType/:taxCode                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.EnterScheduledClaimController.submitClaim(dutyType: DutyType, taxCode: TaxCode)
+
+GET         /scheduled/check-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckScheduledClaimController.showReimbursements()
+POST        /scheduled/check-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckScheduledClaimController.submitReimbursements()
+
 GET         /scheduled/supporting-evidence/select-supporting-evidence-type      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.ChooseFileTypeController.show
 POST        /scheduled/supporting-evidence/select-supporting-evidence-type      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.ChooseFileTypeController.submit
 
 GET         /scheduled/supporting-evidence/choose-files                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.UploadFilesController.show
-+nocsrf
++nocsrf            
 POST        /scheduled/supporting-evidence/choose-files                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.UploadFilesController.callback
 GET         /scheduled/supporting-evidence/summary                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.UploadFilesController.summary
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyTypesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/SelectDutyTypesControllerSpec.scala
@@ -32,6 +32,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.{routes => overpaymentsScheduledRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.SelectedDutyTaxCodesReimbursementAnswer
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DutyTypeGen._
@@ -125,7 +126,7 @@ class SelectDutyTypesControllerSpec
 
       checkIsRedirect(
         performAction(Seq("select-duty-types[0]" -> duty.repr)),
-        routes.SelectDutyCodesController.iterate()
+        overpaymentsScheduledRoutes.SelectDutyCodesController.iterate()
       )
     }
 
@@ -142,7 +143,7 @@ class SelectDutyTypesControllerSpec
 
       checkIsRedirect(
         performAction(Seq("select-duty-types[0]" -> duty.repr)),
-        routes.SelectDutyCodesController.iterate()
+        overpaymentsScheduledRoutes.SelectDutyCodesController.iterate()
       )
     }
 
@@ -166,7 +167,7 @@ class SelectDutyTypesControllerSpec
         performAction(
           Seq("select-duty-types[0]" -> duty.repr)
         ),
-        routes.SelectDutyCodesController.iterate()
+        overpaymentsScheduledRoutes.SelectDutyCodesController.iterate()
       )
     }
   }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/CheckScheduledClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/CheckScheduledClaimControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled
 
 import cats.implicits.catsSyntaxOptionId
 import play.api.i18n.Lang
@@ -27,7 +27,7 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.CheckScheduledClaimController.checkClaimSummaryKey
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.CheckScheduledClaimController.checkClaimSummaryKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
@@ -56,6 +56,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
 
 import scala.collection.immutable.SortedMap
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.OverpaymentsRoutes
 
 class CheckScheduledClaimControllerSpec extends ControllerSpec with AuthSupport with SessionSupport {
 
@@ -83,7 +84,7 @@ class CheckScheduledClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         checkIsRedirect(
           controller.showReimbursements()(FakeRequest()),
-          routes.SelectDutyTypesController.showDutyTypes(JourneyBindable.Scheduled)
+          claimsRoutes.SelectDutyTypesController.showDutyTypes(JourneyBindable.Scheduled)
         )
       }
 
@@ -97,7 +98,7 @@ class CheckScheduledClaimControllerSpec extends ControllerSpec with AuthSupport 
 
         checkIsRedirect(
           controller.submitReimbursements()(FakeRequest().withFormUrlEncodedBody(checkClaimSummaryKey -> "false")),
-          routes.SelectDutyTypesController.showDutyTypes(JourneyBindable.Scheduled)
+          claimsRoutes.SelectDutyTypesController.showDutyTypes(JourneyBindable.Scheduled)
         )
       }
     }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/EnterScheduledClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/EnterScheduledClaimControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled
 
 import cats.implicits.catsSyntaxOptionId
 import org.scalacheck.Gen
@@ -29,7 +29,7 @@ import play.api.inject.guice.GuiceableModule
 import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterScheduledClaimControllerSpec.formatter
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.EnterScheduledClaimControllerSpec.formatter
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/SelectDutyCodesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/SelectDutyCodesControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled
 
 import cats.implicits.catsSyntaxOptionId
 import org.scalacheck.Gen
@@ -29,11 +29,12 @@ import play.api.inject.guice.GuiceableModule
 import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyCodesControllerSpec.genDutyWithRandomlySelectedTaxCode
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.SelectDutyCodesControllerSpec.genDutyWithRandomlySelectedTaxCode
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.SelectedDutyTaxCodesReimbursementAnswer
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.SelectedDutyTaxCodesReimbursementAnswer.dutyTypesOrdering
@@ -87,7 +88,7 @@ class SelectDutyCodesControllerSpec
 
         checkIsRedirect(
           controller.iterate()(FakeRequest()),
-          routes.SelectDutyTypesController.showDutyTypes(JourneyBindable.Scheduled)
+          claimsRoutes.SelectDutyTypesController.showDutyTypes(JourneyBindable.Scheduled)
         )
       }
     }


### PR DESCRIPTION
This PR affects the following endpoints:
- /scheduled/select-duties/start
- /scheduled/select-duties/:DutyType
- /scheduled/select-duties/reimbursement-claim/start
- /scheduled/select-duties/:dutyType/:taxCode
- /scheduled/check-claim