### PR TITLE
[CDSR-1729] move /scheduled/scheduled-document-upload/choose-files and /scheduled/scheduled-document-upload/continue

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Router.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Router.scala
@@ -20,6 +20,7 @@ import play.api.mvc.Call
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.{routes => overpaymentsScheduledRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.common.{routes => commonRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnJourney.MrnImporter
@@ -81,7 +82,7 @@ trait JourneyTypeRoutes extends Product with Serializable {
       case Yes =>
         journeyBindable match {
           case JourneyBindable.Scheduled =>
-            claimRoutes.UploadMrnListController.show()
+            overpaymentsScheduledRoutes.UploadMrnListController.show
           case JourneyBindable.Multiple  =>
             if (hasAssociatedMrns)
               overpaymentsMultipleRoutes.CheckMovementReferenceNumbersController.showMrns

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadMrnListController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadMrnListController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled
 
 import cats.data.EitherT
 import cats.implicits.catsSyntaxOptionId
@@ -34,6 +34,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Nonce
@@ -72,7 +73,7 @@ class UploadMrnListController @Inject() (
   final val pageKey: String = "schedule-document"
 
   final val selfUrl: String     = servicesConfig.getString("self.url")
-  final val continueUrl: String = selfUrl + routes.UploadMrnListController.continue().url
+  final val continueUrl: String = selfUrl + routes.UploadMrnListController.continue.url
 
   final val show: Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
@@ -146,7 +147,7 @@ class UploadMrnListController @Inject() (
         request
           .routeToCheckAnswers(JourneyBindable.Scheduled)
           .whenComplete(journey.draftClaim)(alternatively =
-            routes.CheckContactDetailsMrnController.show(JourneyBindable.Scheduled)
+            claimsRoutes.CheckContactDetailsMrnController.show(JourneyBindable.Scheduled)
           )
       }
     }
@@ -162,8 +163,8 @@ class UploadMrnListController @Inject() (
       nonce = nonce,
       continueUrl = continueUrl,
       continueWhenFullUrl = continueUrl,
-      backlinkUrl = selfUrl + routes.CheckDeclarationDetailsController.show(JourneyBindable.Scheduled).url,
-      callbackUrl = uploadDocumentsConfig.callbackUrlPrefix + routes.UploadMrnListController.callback().url,
+      backlinkUrl = selfUrl + claimsRoutes.CheckDeclarationDetailsController.show(JourneyBindable.Scheduled).url,
+      callbackUrl = uploadDocumentsConfig.callbackUrlPrefix + routes.UploadMrnListController.callback.url,
       minimumNumberOfFiles = 1,
       maximumNumberOfFiles = 1,
       initialNumberOfEmptyRows = 1,

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
@@ -72,7 +72,7 @@
 
     @claim.scheduledDocumentAnswer.map { scheduledDocument =>
         @pageHeading(Html(messages(s"$key.scheduled-document.h2")), "govuk-heading-m govuk-!-margin-top-9", "h2")
-        @summary(ScheduledDocumentSummary(scheduledDocument,s"$key.scheduled-document",subKey, claimRoutes.UploadMrnListController.show()))
+        @summary(ScheduledDocumentSummary(scheduledDocument,s"$key.scheduled-document",subKey, overpaymentsScheduledRoutes.UploadMrnListController.show))
     }
 
     @claim.displayDeclaration.map { displayDeclaration =>

--- a/conf/claims.routes
+++ b/conf/claims.routes
@@ -57,8 +57,3 @@ POST        /:journey/select-duties/select-duty-types              uk.gov.hmrc.c
 
 GET         /single/select-reimbursement-method                     uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.ReimbursementMethodController.showReimbursementMethod()
 POST        /single/select-reimbursement-method                     uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.ReimbursementMethodController.submitReimbursementMethod()
-
-GET         /scheduled/scheduled-document-upload/choose-files       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.UploadMrnListController.show()
-+nocsrf
-POST        /scheduled/scheduled-document-upload/choose-files       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.UploadMrnListController.callback()
-GET         /scheduled/scheduled-document-upload/continue           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.UploadMrnListController.continue()

--- a/conf/overpayments_scheduled.routes
+++ b/conf/overpayments_scheduled.routes
@@ -1,6 +1,11 @@
 GET         /scheduled/enter-movement-reference-number                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.EnterMovementReferenceNumberController.enterJourneyMrn
 POST        /scheduled/enter-movement-reference-number                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.EnterMovementReferenceNumberController.enterMrnSubmit
 
+GET         /scheduled/scheduled-document-upload/choose-files                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.UploadMrnListController.show
++nocsrf
+POST        /scheduled/scheduled-document-upload/choose-files                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.UploadMrnListController.callback
+GET         /scheduled/scheduled-document-upload/continue                       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.UploadMrnListController.continue
+
 GET         /scheduled/select-duties/start                                      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.SelectDutyCodesController.iterate()
 GET         /scheduled/select-duties/:dutyType                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.SelectDutyCodesController.showDutyCodes(dutyType: DutyType)
 POST        /scheduled/select-duties/:dutyType                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.SelectDutyCodesController.submitDutyCodes(dutyType: DutyType)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/RouterSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/RouterSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.{routes => overpaymentsScheduledRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnJourney.MrnImporter
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnJourney.ThirdPartyImporter
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.No
@@ -65,7 +66,7 @@ class RouterSpec extends AnyWordSpec with Matchers with TableDrivenPropertyCheck
         whetherDeclarationDetailsCorrect = Yes,
         hasAssociatedMrns = false
       ) should be(
-        claimRoutes.UploadMrnListController.show()
+        overpaymentsScheduledRoutes.UploadMrnListController.show
       )
     }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadMrnListControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadMrnListControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled
 
 import play.api.inject.bind
 import play.api.inject.guice.GuiceableModule
@@ -29,6 +29,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.UploadDocumentsConne
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.PropertyBasedControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
@@ -193,7 +194,7 @@ class UploadMrnListControllerSpec extends PropertyBasedControllerSpec with AuthS
         }
         checkIsRedirect(
           performAction(),
-          routes.CheckContactDetailsMrnController.show(JourneyBindable.Scheduled)
+          claimsRoutes.CheckContactDetailsMrnController.show(JourneyBindable.Scheduled)
         )
       }
     }


### PR DESCRIPTION
This PR moves controllers serving the following endpoints:
- /scheduled/scheduled-document-upload/choose-files 
- /scheduled/scheduled-document-upload/continue