### PR TITLE
[CDSR-1726] move single only controller into the overpaymentssingle package

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/CDSReimbursementClaimConnector.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/CDSReimbursementClaimConnector.scala
@@ -22,14 +22,13 @@ import com.google.inject.Inject
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
-import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpClient
+import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
-import javax.inject.Singleton
-import play.api.libs.json.JsValue
 
+import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/ConnectorError.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/ConnectorError.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
 
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.CdsError
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
 
 sealed trait ConnectorError {
   def message: String

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/BankAccountController.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
 
 import cats.data.EitherT
-import cats.implicits.catsSyntaxEq
 import cats.implicits._
+import cats.implicits.catsSyntaxEq
 import com.google.inject.Inject
 import com.google.inject.Singleton
 import play.api.Configuration
@@ -29,32 +29,31 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyExtractor.extractRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyExtractor.withAnswersAndRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ReimbursementRoutes.ReimbursementRoutes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DraftClaim
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.Yes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.util.toFuture
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
-import uk.gov.hmrc.http.BadGatewayException
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterAdditionalDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterAdditionalDetailsController.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.OverpaymentsRoutes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.{routes => overpaymentsSingleRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/EnterSingleClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/EnterSingleClaimController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle
 
 import cats.data.EitherT
 import cats.implicits.catsSyntaxEq
@@ -33,11 +33,12 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.Authenticat
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterSingleClaimController._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.EnterSingleClaimController._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.YesOrNoQuestionForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.No
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.Yes
@@ -85,10 +86,10 @@ class EnterSingleClaimController @Inject() (
         generateReimbursementsFromDuties(fillingOutClaim.draftClaim).map(ClaimedReimbursementsAnswer(_)) match {
           case Left(error)         =>
             logger.warn("Error generating claims: ", error)
-            Redirect(routes.SelectDutiesController.selectDuties())
+            Redirect(routes.SelectDutiesController.selectDuties)
           case Right(None)         =>
             logger.warn("No duties found to create claims ")
-            Redirect(routes.SelectDutiesController.selectDuties())
+            Redirect(routes.SelectDutiesController.selectDuties)
           case Right(Some(claims)) =>
             val nextPage = calculateNextPage(claims)
             updateClaimedReimbursementsAnswer(claims, fillingOutClaim, nextPage)
@@ -115,11 +116,11 @@ class EnterSingleClaimController @Inject() (
       withAnswers[ClaimedReimbursementsAnswer] { (fillingOutClaim, answers) =>
         answers match {
           case None                 =>
-            Redirect(routes.EnterSingleClaimController.startClaim())
+            Redirect(routes.EnterSingleClaimController.startClaim)
           case Some(reimbursements) =>
             reimbursements.find(_.id === id) match {
               case None                =>
-                Redirect(routes.EnterSingleClaimController.startClaim())
+                Redirect(routes.EnterSingleClaimController.startClaim)
               case Some(reimbursement) =>
                 mrnClaimAmountForm(reimbursement.paidAmount)
                   .bindFromRequest()
@@ -149,10 +150,10 @@ class EnterSingleClaimController @Inject() (
                 Ok(checkSingleClaimSummaryPage(mrn, claims, whetherClaimCorrect))
 
               case None =>
-                Redirect(routes.EnterSingleClaimController.startClaim())
+                Redirect(routes.EnterSingleClaimController.startClaim)
             }
           case None      =>
-            Redirect(OverpaymentsRoutes.EnterMovementReferenceNumberController.enterJourneyMrn(Single))
+            Redirect(routes.EnterMovementReferenceNumberController.enterJourneyMrn)
         }
       }
     }
@@ -177,16 +178,16 @@ class EnterSingleClaimController @Inject() (
                       .routeToCheckAnswers(Single)
                       .whenComplete(journey.draftClaim)(alternatively = journey.draftClaim match {
                         case claim: DraftClaim if isCmaEligible(claim) =>
-                          routes.ReimbursementMethodController.showReimbursementMethod()
+                          claimsRoutes.ReimbursementMethodController.showReimbursementMethod()
                         case _                                         =>
-                          routes.BankAccountController.checkBankAccountDetails(Single)
+                          claimsRoutes.BankAccountController.checkBankAccountDetails(Single)
                       })
-                  case No  => Redirect(routes.SelectDutiesController.selectDuties())
+                  case No  => Redirect(routes.SelectDutiesController.selectDuties)
                 }
               )
 
           case None =>
-            Redirect(OverpaymentsRoutes.EnterMovementReferenceNumberController.enterJourneyMrn(Single))
+            Redirect(routes.EnterMovementReferenceNumberController.enterJourneyMrn)
         }
       }
     }
@@ -196,7 +197,7 @@ class EnterSingleClaimController @Inject() (
       case Some(claim) =>
         Redirect(routes.EnterSingleClaimController.enterClaim(claim.id))
       case None        =>
-        Redirect(routes.EnterSingleClaimController.checkClaimSummary())
+        Redirect(routes.EnterSingleClaimController.checkClaimSummary)
     }
 
   protected def updateClaimedReimbursementsAnswer(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/EnterSingleClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/EnterSingleClaimController.scala
@@ -105,7 +105,9 @@ class EnterSingleClaimController @Inject() (
           .map { claim =>
             val emptyForm = mrnClaimAmountForm(claim.paidAmount)
             val form      = Either.cond(claim.isFilled, emptyForm.fill(ClaimAmount(claim.correctedAmount)), emptyForm).merge
-            Future.successful(Ok(enterSingleClaimPage(id, form, claim)))
+            Future.successful(
+              Ok(enterSingleClaimPage(form, claim, routes.EnterSingleClaimController.enterClaimSubmit(id)))
+            )
           }
           .getOrElse(Future.successful(Redirect(baseRoutes.IneligibleController.ineligible())))
       }
@@ -127,7 +129,13 @@ class EnterSingleClaimController @Inject() (
                   .fold(
                     formWithErrors => {
                       val updatedErrors = formWithErrors.errors.map(d => d.copy(key = "enter-claim"))
-                      BadRequest(enterSingleClaimPage(id, formWithErrors.copy(errors = updatedErrors), reimbursement))
+                      BadRequest(
+                        enterSingleClaimPage(
+                          formWithErrors.copy(errors = updatedErrors),
+                          reimbursement,
+                          routes.EnterSingleClaimController.enterClaimSubmit(id)
+                        )
+                      )
                     },
                     formOk => {
                       val newClaim =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/SelectDutiesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/SelectDutiesController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle
 
 import cats.data.EitherT
 import cats.implicits.catsSyntaxEq
@@ -30,7 +30,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.selectDutiesF
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.AuthenticatedAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthAndSessionDataAction
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutiesController._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.SelectDutiesController._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
@@ -111,7 +111,7 @@ class SelectDutiesController @Inject() (
                     .leftMap(_ => Error("could not update session"))
                     .fold(
                       logAndDisplayError("could not get duties selected "),
-                      _ => Redirect(routes.EnterSingleClaimController.startClaim())
+                      _ => Redirect(routes.EnterSingleClaimController.startClaim)
                     )
                 }
               )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/SelectDutiesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/SelectDutiesController.scala
@@ -80,7 +80,14 @@ class SelectDutiesController @Inject() (
           dutiesAvailable => {
             val emptyForm  = selectDutiesForm(dutiesAvailable)
             val filledForm = previousAnswer.fold(emptyForm)(emptyForm.fill)
-            Ok(selectDutiesPage(filledForm, dutiesAvailable, cmaEligibleDutiesMap.isCmaEligible))
+            Ok(
+              selectDutiesPage(
+                filledForm,
+                dutiesAvailable,
+                cmaEligibleDutiesMap.isCmaEligible,
+                routes.SelectDutiesController.selectDutiesSubmit
+              )
+            )
           }
         )
       }
@@ -101,7 +108,14 @@ class SelectDutiesController @Inject() (
               .bindFromRequest()
               .fold(
                 formWithErrors =>
-                  BadRequest(selectDutiesPage(formWithErrors, dutiesAvailable, cmaEligibleDutiesMap.isCmaEligible)),
+                  BadRequest(
+                    selectDutiesPage(
+                      formWithErrors,
+                      dutiesAvailable,
+                      cmaEligibleDutiesMap.isCmaEligible,
+                      routes.SelectDutiesController.selectDutiesSubmit
+                    )
+                  ),
                 dutiesSelected => {
                   val newDraftClaim  =
                     fillingOutClaim.draftClaim.copy(dutiesSelectedAnswer = Some(dutiesSelected))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_single_claim_summary.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_single_claim_summary.scala.html
@@ -22,7 +22,7 @@
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ClaimedReimbursement
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.{routes => overpaymentsSingleRoutes}
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 @import cats.data.NonEmptyList
 @import uk.gov.hmrc.govukfrontend.views.Aliases.RadioItem
@@ -58,7 +58,7 @@
     @pageHeading(Html(messages(s"$key.duty.label",mrn.value)), "govuk-heading-m", "h2")
     @summary(SummaryList(claimSummaryHelper.makeClaimSummary(claims)))
 
-    @formWithCSRF(routes.EnterSingleClaimController.checkClaimSummarySubmit, 'novalidate -> "novalidate") {
+    @formWithCSRF(overpaymentsSingleRoutes.EnterSingleClaimController.checkClaimSummarySubmit, 'novalidate -> "novalidate") {
         @radios(
             form = form,
             name = key,

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/check_your_answers.scala.html
@@ -22,6 +22,7 @@
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled.{routes => overpaymentsScheduledRoutes}
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.{routes => overpaymentsSingleRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.OverpaymentsRoutes
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.fileupload.{routes => fileUploadRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
@@ -105,7 +106,7 @@
             claim.typeOfClaim.contains(TypeOfClaimAnswer.Individual) ||
             claim.typeOfClaim.contains(TypeOfClaimAnswer.Scheduled)) {
             @pageHeading(Html(messages(combine(s"$key.claim-calculation", subKey, "h2"))), "govuk-heading-m govuk-!-margin-top-9", "h2")
-            @summary(ClaimedReimbursementsAnswerSummary(reimbursement,s"$key.claim-calculation",subKey, if (journey == JourneyBindable.Scheduled) overpaymentsScheduledRoutes.CheckScheduledClaimController.showReimbursements() else claimRoutes.EnterSingleClaimController.checkClaimSummary()))
+            @summary(ClaimedReimbursementsAnswerSummary(reimbursement,s"$key.claim-calculation",subKey, if (journey == JourneyBindable.Scheduled) overpaymentsScheduledRoutes.CheckScheduledClaimController.showReimbursements() else overpaymentsSingleRoutes.EnterSingleClaimController.checkClaimSummary))
         }
     }
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_single_claim.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_single_claim.scala.html
@@ -17,6 +17,7 @@
 @import play.api.data.Form
 @import play.twirl.api.Html
 @import play.api.i18n.Messages
+@import play.api.mvc.Call
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
@@ -38,7 +39,7 @@
     paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block
 )
 
-@(id: UUID, form: Form[ClaimAmount], reimbursement: ClaimedReimbursement)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(form: Form[ClaimAmount], reimbursement: ClaimedReimbursement, postAction: Call)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
 
 @key = @{"enter-claim"}
 @title = @{messages(s"$key.title", reimbursement.taxCode, messages(s"select-duties.duty.${reimbursement.taxCode}"))}
@@ -55,7 +56,7 @@
 
     @paragraph(Html(messages(s"$key.inset-text")), Some("govuk-inset-text govuk-!-margin-bottom-8"))
 
-    @formWithCSRF(overpaymentsSingleRoutes.EnterSingleClaimController.enterClaimSubmit(id), 'novalidate -> "novalidate") {
+    @formWithCSRF(postAction, 'novalidate -> "novalidate") {
 
         @paragraph(Html(messages(s"$key.paid-amount-label", reimbursement.paidAmount.toPoundSterlingString)), Some("govuk-body-l govuk-!-font-weight-bold"))
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_single_claim.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/enter_single_claim.scala.html
@@ -22,7 +22,8 @@
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ClaimedReimbursement
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
-@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterSingleClaimController.ClaimAmount
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.EnterSingleClaimController.ClaimAmount
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.{routes=>overpaymentsSingleRoutes}
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.input.PrefixOrSuffix
 @import java.util.UUID
@@ -54,7 +55,7 @@
 
     @paragraph(Html(messages(s"$key.inset-text")), Some("govuk-inset-text govuk-!-margin-bottom-8"))
 
-    @formWithCSRF(routes.EnterSingleClaimController.enterClaimSubmit(id), 'novalidate -> "novalidate") {
+    @formWithCSRF(overpaymentsSingleRoutes.EnterSingleClaimController.enterClaimSubmit(id), 'novalidate -> "novalidate") {
 
         @paragraph(Html(messages(s"$key.paid-amount-label", reimbursement.paidAmount.toPoundSterlingString)), Some("govuk-body-l govuk-!-font-weight-bold"))
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_duties.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_duties.scala.html
@@ -18,6 +18,7 @@
 @import play.api.i18n.Messages
 @import play.api.mvc.Request
 @import play.twirl.api.Html
+@import play.api.mvc.Call
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.{routes=>overpaymentsSingleRoutes}
@@ -38,12 +39,11 @@
  checkboxes: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.input_checkboxes
 )
 
-@(form : Form[DutiesSelectedAnswer], dutiesToDisplay : NonEmptyList[Duty], cmaEligibleList: Seq[Boolean])(implicit  request: Request[_], messages:Messages, viewConfig: ViewConfig)
+@(form : Form[DutiesSelectedAnswer], dutiesToDisplay : NonEmptyList[Duty], cmaEligibleList: Seq[Boolean], postAction: Call)(implicit  request: Request[_], messages:Messages, viewConfig: ViewConfig)
 
   @key = @{"select-duties"}
   @title = @{messages(s"$key.title")}
 
-  @postAction = @{overpaymentsSingleRoutes.SelectDutiesController.selectDutiesSubmit}
   @options = @{dutiesToDisplay.zipWithIndex.map { case (duty: Duty, index: Int) =>
 
         val isCmaEligible: Boolean = cmaEligibleList.nonEmpty && cmaEligibleList(index)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_duties.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/claims/select_duties.scala.html
@@ -20,6 +20,7 @@
 @import play.twirl.api.Html
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.{routes=>overpaymentsSingleRoutes}
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.DutiesSelectedAnswer
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.checkboxes.CheckboxItem
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
@@ -42,7 +43,7 @@
   @key = @{"select-duties"}
   @title = @{messages(s"$key.title")}
 
-  @postAction = @{routes.SelectDutiesController.selectDutiesSubmit}
+  @postAction = @{overpaymentsSingleRoutes.SelectDutiesController.selectDutiesSubmit}
   @options = @{dutiesToDisplay.zipWithIndex.map { case (duty: Duty, index: Int) =>
 
         val isCmaEligible: Boolean = cmaEligibleList.nonEmpty && cmaEligibleList(index)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/utils/ClaimSummaryHelper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/utils/ClaimSummaryHelper.scala
@@ -20,7 +20,7 @@ import cats.data.NonEmptyList
 import play.api.i18n.Lang
 import play.api.i18n.Langs
 import play.api.i18n.MessagesApi
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.routes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.{routes => overpaymentsSingleRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ClaimedReimbursement
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
@@ -50,7 +50,7 @@ class ClaimSummaryHelper @Inject() (implicit langs: Langs, messages: MessagesApi
           Actions(
             items = Seq(
               ActionItem(
-                href = s"${routes.EnterSingleClaimController.enterClaim(claim.id).url}",
+                href = s"${overpaymentsSingleRoutes.EnterSingleClaimController.enterClaim(claim.id).url}",
                 content = Text(messages("cya.change")(lang)),
                 visuallyHiddenText = Some(messages(s"select-duties.duty.${claim.taxCode}")(lang))
               )

--- a/conf/claims.routes
+++ b/conf/claims.routes
@@ -40,14 +40,8 @@ GET         /:journey/bank-account-unavailable                      uk.gov.hmrc.
 GET         /:journey/bank-account-type                             uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectBankAccountTypeController.selectBankAccountType(journey: JourneyBindable)
 POST        /:journey/bank-account-type                             uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectBankAccountTypeController.selectBankAccountTypeSubmit(journey: JourneyBindable)
 
-GET         /single/select-duties                                   uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutiesController.selectDuties()
-POST        /single/select-duties                                   uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutiesController.selectDutiesSubmit()
-
-GET         /single/start-claim                                     uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterSingleClaimController.startClaim()
-GET         /single/enter-claim/:id                                 uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterSingleClaimController.enterClaim(id: UUID)
-POST        /single/enter-claim/:id                                 uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterSingleClaimController.enterClaimSubmit(id: UUID)
-GET         /single/check-claim                                     uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterSingleClaimController.checkClaimSummary()
-POST        /single/check-claim                                     uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterSingleClaimController.checkClaimSummarySubmit()
+GET         /:journey/enter-additional-details                       uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAdditionalDetailsController.enterAdditionalDetails(journey: JourneyBindable)
+POST        /:journey/enter-additional-details                       uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAdditionalDetailsController.enterAdditionalDetailsSubmit(journey: JourneyBindable)
 
 GET         /:journey/select-duties/select-duty-types              uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyTypesController.showDutyTypes(journey: JourneyBindable)
 POST        /:journey/select-duties/select-duty-types              uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyTypesController.submitDutyTypes(journey: JourneyBindable)

--- a/conf/claims.routes
+++ b/conf/claims.routes
@@ -40,9 +40,6 @@ GET         /:journey/bank-account-unavailable                      uk.gov.hmrc.
 GET         /:journey/bank-account-type                             uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectBankAccountTypeController.selectBankAccountType(journey: JourneyBindable)
 POST        /:journey/bank-account-type                             uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectBankAccountTypeController.selectBankAccountTypeSubmit(journey: JourneyBindable)
 
-GET         /:journey/enter-additional-details                       uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAdditionalDetailsController.enterAdditionalDetails(journey: JourneyBindable)
-POST        /:journey/enter-additional-details                       uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.EnterAdditionalDetailsController.enterAdditionalDetailsSubmit(journey: JourneyBindable)
-
 GET         /:journey/select-duties/select-duty-types              uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyTypesController.showDutyTypes(journey: JourneyBindable)
 POST        /:journey/select-duties/select-duty-types              uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutyTypesController.submitDutyTypes(journey: JourneyBindable)
 

--- a/conf/overpayments_single.routes
+++ b/conf/overpayments_single.routes
@@ -7,6 +7,16 @@ POST        /single/enter-duplicate-movement-reference-number                @uk
 GET         /single/enter-additional-details                                 @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.EnterAdditionalDetailsController.show
 POST        /single/enter-additional-details                                 @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.EnterAdditionalDetailsController.submit
 
+GET         /single/select-duties                                            @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.SelectDutiesController.selectDuties
+POST        /single/select-duties                                            @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.SelectDutiesController.selectDutiesSubmit
+
+GET         /single/start-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.EnterSingleClaimController.startClaim
+GET         /single/enter-claim/:id                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.EnterSingleClaimController.enterClaim(id: UUID)
+POST        /single/enter-claim/:id                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.EnterSingleClaimController.enterClaimSubmit(id: UUID)
+
+GET         /single/check-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.EnterSingleClaimController.checkClaimSummary
+POST        /single/check-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.EnterSingleClaimController.checkClaimSummarySubmit
+
 GET         /single/supporting-evidence/select-supporting-evidence-type      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.ChooseFileTypeController.show
 POST        /single/supporting-evidence/select-supporting-evidence-type      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.ChooseFileTypeController.submit
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterAdditionalDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/EnterAdditionalDetailsControllerSpec.scala
@@ -36,6 +36,12 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.{routes => overpaymentsSingleRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DraftClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SignedInUserDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.AdditionalDetailsAnswer
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.BasisOfClaimAnswer

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/EnterSingleClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/EnterSingleClaimControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle
 
 import cats.Functor
 import cats.Id
@@ -36,6 +36,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBindable
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.{routes => claimsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.JourneyStatus.FillingOutClaim
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.ClaimedReimbursementsAnswer
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.DutiesSelectedAnswer
@@ -64,6 +65,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Acc14Gen.genN
 
 import scala.concurrent.Future
 import scala.util.Random
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.OverpaymentsRoutes
 
 class EnterSingleClaimControllerSpec
     extends ControllerSpec
@@ -164,7 +166,7 @@ class EnterSingleClaimControllerSpec
 
       checkIsRedirect(
         performAction(),
-        routes.SelectDutiesController.selectDuties()
+        routes.SelectDutiesController.selectDuties
       )
     }
 
@@ -185,7 +187,7 @@ class EnterSingleClaimControllerSpec
 
       checkIsRedirect(
         performAction(),
-        routes.EnterSingleClaimController.checkClaimSummary()
+        routes.EnterSingleClaimController.checkClaimSummary
       )
 
     }
@@ -354,7 +356,7 @@ class EnterSingleClaimControllerSpec
             "enter-claim" -> "5.00"
           )
         ),
-        routes.EnterSingleClaimController.checkClaimSummary()
+        routes.EnterSingleClaimController.checkClaimSummary
       )
     }
 
@@ -460,7 +462,7 @@ class EnterSingleClaimControllerSpec
       val result = performAction(Seq(EnterSingleClaimController.checkClaimSummaryKey -> "true"))
       checkIsRedirect(
         result,
-        routes.ReimbursementMethodController.showReimbursementMethod()
+        claimsRoutes.ReimbursementMethodController.showReimbursementMethod
       )
     }
 
@@ -486,7 +488,7 @@ class EnterSingleClaimControllerSpec
       val result = performAction(Seq(EnterSingleClaimController.checkClaimSummaryKey -> "true"))
       checkIsRedirect(
         result,
-        routes.BankAccountController.checkBankAccountDetails(JourneyBindable.Single)
+        claimsRoutes.BankAccountController.checkBankAccountDetails(JourneyBindable.Single)
       )
     }
 
@@ -513,7 +515,7 @@ class EnterSingleClaimControllerSpec
       val result = performAction(Seq(EnterSingleClaimController.checkClaimSummaryKey -> "false"))
       checkIsRedirect(
         result,
-        routes.SelectDutiesController.selectDuties()
+        routes.SelectDutiesController.selectDuties
       )
     }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/SelectDutiesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/SelectDutiesControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle
 
 import cats.Functor
 import cats.Id
@@ -30,7 +30,7 @@ import play.api.mvc.Result
 import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutiesController.CmaEligibleAndDuties
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.SelectDutiesController.CmaEligibleAndDuties
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/SelectTaxCodesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/SelectTaxCodesControllerSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.claims.SelectDutiesController.selectDutiesKey
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle.SelectDutiesController.selectDutiesKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodssingle.SelectTaxCodesController.selectTaxCodesKey
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourneyGenerators._


### PR DESCRIPTION
This PR moves the controllers representing the following endpoints:
- /select-duties
- /single/start-claim
- /single/enter-claim/:id
- /single/check-claim