### PR TITLE
[CDSR-1792] display check-your-answers page for securities

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Forms.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Forms.scala
@@ -376,7 +376,7 @@ object Forms {
           .transform[BasisOfClaimAnswer](BasisOfClaims.all(_), BasisOfClaims.indexOf)
       )(identity)(Some(_))
     )
-  
+
   val reasonForSecurityForm: Form[ReasonForSecurity] =
     Form(
       mapping(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/common/ChooseClaimTypeController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/common/ChooseClaimTypeController.scala
@@ -87,7 +87,7 @@ class ChooseClaimTypeController @Inject() (
                 .fold[Future[Result]](Future.failed(new Exception("User is missing EORI number"))) { eori =>
                   sessionStore
                     .store(SessionData(SecuritiesJourney.empty(eori, Nonce.random)))
-                    .map(_ => Redirect(securitiesRoutes.EnterMovementReferenceNumberController.enterMrn()))
+                    .map(_ => Redirect(securitiesRoutes.EnterMovementReferenceNumberController.show()))
                 }
           }
         )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/WorkInProgressMixin.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/WorkInProgressMixin.scala
@@ -31,6 +31,9 @@ trait WorkInProgressMixin[Journey] {
       Ok(s"Work in progress ...\n\nJourney state:\n\n${prettyPrint(journey)}")
     }
 
+  def show(a: Any): Action[AnyContent]         = show
+  def show(a: Any, b: Any): Action[AnyContent] = show
+
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   val submit: Action[AnyContent] =
     actionReadWriteJourney { implicit request => journey =>
@@ -42,9 +45,11 @@ trait WorkInProgressMixin[Journey] {
       ).asFuture
     }
 
+  def submit(a: Any): Action[AnyContent]         = submit
+  def submit(a: Any, b: Any): Action[AnyContent] = submit
+
   val redirectToALF: Action[AnyContent]                                   = show
   def retrieveAddressFromALF(id: Option[UUID] = None): Action[AnyContent] = show
-  def showAmend(taxCode: TaxCode): Action[AnyContent]                     = show
   val reset: Action[AnyContent]                                           = show
   val summary: Action[AnyContent]                                         = show
   val showConfirmation: Action[AnyContent]                                = show

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterMovementReferenceNumberController.scala
@@ -43,7 +43,7 @@ class EnterMovementReferenceNumberController @Inject() (
     extends SecuritiesJourneyBaseController
     with SessionDataExtractor {
 
-  def enterMrn: Action[AnyContent] = actionReadJourney { implicit request => journey =>
+  val show: Action[AnyContent] = actionReadJourney { implicit request => journey =>
     Future.successful {
       Ok(
         enterMovementReferenceNumberPage(
@@ -54,7 +54,7 @@ class EnterMovementReferenceNumberController @Inject() (
     }
   }
 
-  def submit: Action[AnyContent] = actionReadWriteJourney { implicit request => journey =>
+  val submit: Action[AnyContent] = actionReadWriteJourney { implicit request => journey =>
     movementReferenceNumberForm
       .bindFromRequest()
       .fold(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SecuritiesJourneyRouter.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SecuritiesJourneyRouter.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities
+
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.JourneyValidationErrors._
+
+trait SecuritiesJourneyRouter {
+
+  private val undefined: Call = routes.EnterMovementReferenceNumberController.show()
+
+  def routeForValidationError(error: String): Call =
+    error match {
+      case JOURNEY_ALREADY_FINALIZED                                         => routes.CheckYourAnswersController.showConfirmation()
+      case MISSING_FIRST_MOVEMENT_REFERENCE_NUMBER                           => routes.EnterMovementReferenceNumberController.show()
+      case MISSING_REASON_FOR_SECURITY                                       => routes.ChooseReasonForSecurityController.show()
+      case MISSING_DISPLAY_DECLARATION                                       => routes.ChooseReasonForSecurityController.show()
+      case MISSING_CLAIM_DUPLICATE_CHECK_STATUS_WITH_TPI04                   => routes.ChooseReasonForSecurityController.show()
+      case CHOOSEN_REASON_FOR_SECURITY_REQUIRES_GOODS_TO_BE_ALREADY_EXPORTED =>
+        routes.ChooseReasonForSecurityController.show()
+      case SIMILAR_CLAIM_EXISTS_ALREADY_IN_CDFPAY                            => routes.EnterMovementReferenceNumberController.show()
+      case INCOMPLETE_SECURITIES_RECLAIMS                                    => routes.CheckClaimDetailsController.show()
+      case INCOMPLETE_SUPPORTING_EVIDENCES                                   => routes.ChooseFileTypeController.show()
+      case MISSING_CONTACT_DETAILS                                           => routes.EnterContactDetailsController.show()
+      case MISSING_CONTACT_ADDRESS                                           => routes.CheckClaimantDetailsController.redirectToALF()
+      case TOTAL_REIMBURSEMENT_AMOUNT_MUST_BE_GREATER_THAN_ZERO              => routes.CheckClaimDetailsController.show()
+      case DECLARANT_EORI_NUMBER_MUST_BE_PROVIDED                            => routes.EnterDeclarantEoriNumberController.show()
+      case DECLARANT_EORI_NUMBER_MUST_BE_EQUAL_TO_THAT_OF_ACC14              => routes.EnterDeclarantEoriNumberController.show()
+      case CONSIGNEE_EORI_NUMBER_MUST_BE_PROVIDED                            => routes.EnterImporterEoriNumberController.show()
+      case CONSIGNEE_EORI_NUMBER_MUST_BE_EQUAL_TO_THAT_OF_ACC14              => routes.EnterImporterEoriNumberController.show()
+      case DECLARANT_EORI_NUMBER_DOES_NOT_HAVE_TO_BE_PROVIDED                => undefined
+      case CONSIGNEE_EORI_NUMBER_DOES_NOT_HAVE_TO_BE_PROVIDED                => undefined
+      case BANK_ACCOUNT_DETAILS_MUST_BE_DEFINED                              => routes.CheckBankDetailsController.show()
+      case BANK_ACCOUNT_DETAILS_MUST_NOT_BE_DEFINED                          => undefined
+      case _                                                                 => undefined
+    }
+
+  def routeForValidationErrors(errors: Seq[String]): Call =
+    errors.headOption.map(routeForValidationError).getOrElse(undefined)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SecurityPickerController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SecurityPickerController.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class SelectSecuritiesController @Inject() (
+class SecurityPickerController @Inject() (
   val jcc: JourneyControllerComponents
 )(implicit viewConfig: ViewConfig, ec: ExecutionContext)
     extends SecuritiesJourneyBaseController

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SelectDutiesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SelectDutiesController.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities
+
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.WorkInProgressMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class SelectDutiesController @Inject() (
+  val jcc: JourneyControllerComponents
+)(implicit viewConfig: ViewConfig, ec: ExecutionContext)
+    extends SecuritiesJourneyBaseController
+    with WorkInProgressMixin[SecuritiesJourney]

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyValidationErrors.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyValidationErrors.scala
@@ -62,6 +62,6 @@ object JourneyValidationErrors {
     "choosenReasonForSecurityRequiresGoodsToBeAlreadyExported"
   val MISSING_CLAIM_DUPLICATE_CHECK_STATUS_WITH_TPI04: String                   =
     "missingClaimDuplicateCheckStatusWithTPI04"
-  val SIMILAR_CLAIM_EXIST_ALREADY_IN_CDFPAY: String                             =
+  val SIMILAR_CLAIM_EXISTS_ALREADY_IN_CDFPAY: String                            =
     "similarClaimExistAlreadyInCDFPay"
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourney.scala
@@ -445,6 +445,8 @@ final class SecuritiesJourney private (
         )
       )
 
+  def prettyPrint: String = Json.prettyPrint(Json.toJson(this))
+
 }
 
 object SecuritiesJourney extends FluentImplicits[SecuritiesJourney] {
@@ -526,7 +528,7 @@ object SecuritiesJourney extends FluentImplicits[SecuritiesJourney] {
         MISSING_CLAIM_DUPLICATE_CHECK_STATUS_WITH_TPI04
       ) && Check[SecuritiesJourney](
         _.answers.similarClaimExistAlreadyInCDFPay.contains(false),
-        SIMILAR_CLAIM_EXIST_ALREADY_IN_CDFPAY
+        SIMILAR_CLAIM_EXISTS_ALREADY_IN_CDFPAY
       )
 
     val userCanProceedWithThisClaim: Check[SecuritiesJourney] =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/DisplayDeclaration.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/DisplayDeclaration.scala
@@ -63,6 +63,10 @@ final case class DisplayDeclaration(
   def getSecurityDepositIds: Option[List[String]] =
     displayResponseDetail.securityDetails.map(_.map(_.securityDepositId))
 
+  def isValidSecurityDepositId(securityDepositId: String): Boolean =
+    displayResponseDetail.securityDetails
+      .exists(_.exists(_.securityDepositId === securityDepositId))
+
   def getSecurityTaxCodesFor(securityDepositId: String): List[TaxCode] =
     getSecurityDetailsFor(securityDepositId)
       .map(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/DisplayDeclaration.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/DisplayDeclaration.scala
@@ -79,6 +79,11 @@ final case class DisplayDeclaration(
     getSecurityDetailsFor(securityDepositId)
       .flatMap(_.taxDetails.find(td => TaxCodes.findUnsafe(td.taxType) === taxCode))
 
+  def getTotalSecuritiesAmountFor(securityDepositIds: Set[String]): BigDecimal =
+    securityDepositIds
+      .map(getSecurityDetailsFor(_).map(_.totalAmount).map(BigDecimal.apply).getOrElse(BigDecimal("0.00")))
+      .sum
+
   def withDeclarationId(declarationId: String): DisplayDeclaration =
     copy(displayResponseDetail = displayResponseDetail.copy(declarationId = declarationId))
 
@@ -110,6 +115,15 @@ final case class DisplayDeclaration(
   def hasSameEoriAs(other: DisplayDeclaration): Boolean =
     this.getDeclarantEori === other.getDeclarantEori ||
       this.getConsigneeEori.exists(eori => other.getConsigneeEori.contains(eori))
+
+  def isFullSecurityAmount(securityDepositId: String, reclaimedAmount: BigDecimal): Boolean =
+    getSecurityDetailsFor(securityDepositId)
+      .exists(d => BigDecimal(d.totalAmount) === reclaimedAmount)
+
+  def isAllSelectedSecuritiesEligibleForGuaranteePayment(securityDepositIds: Set[String]): Boolean =
+    securityDepositIds
+      .map(sid => getSecurityDetailsFor(sid))
+      .forall(_.exists(_.isGuaranteeEligible))
 
 }
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/utils/DateUtils.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/utils/DateUtils.scala
@@ -14,24 +14,22 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaimfrontend.models
-
-import play.api.libs.functional.syntax._
-import play.api.libs.json.Format
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.utils
 
 import java.time.LocalDate
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.DateUtils
+import java.time.format.DateTimeFormatter
+import scala.util.Try
 
-final case class InspectionDate(value: LocalDate) extends AnyVal
+object DateUtils {
 
-object InspectionDate {
+  def displayFormat(maybeDate: Option[String]): Option[String] =
+    maybeDate.flatMap(displayFormat _)
 
-  implicit class InspectionDateOps(private val inspectionDate: InspectionDate) {
-    def checkYourDetailsDisplayFormat: String =
-      DateUtils.displayFormat(inspectionDate.value.toString).getOrElse("")
+  def displayFormat(date: String): Option[String] = {
+    val result = for {
+      t <- Try(LocalDate.parse(date, DateTimeFormatter.ofPattern("u-M-d")))
+      f <- Try(DateTimeFormatter.ofPattern("d MMMM yyyy").format(t))
+    } yield f
+    result.toOption
   }
-
-  implicit val format: Format[InspectionDate] =
-    implicitly[Format[LocalDate]].inmap(InspectionDate(_), _.value)
-
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/EvidenceDocumentsSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/EvidenceDocumentsSummary.scala
@@ -70,4 +70,38 @@ object EvidenceDocumentsSummary extends AnswerSummary[Seq[EvidenceDocument]] {
         )
       )
     )
+
+  def forSecurities(
+    answers: Seq[EvidenceDocument],
+    key: String,
+    changeCall: Call
+  )(implicit
+    messages: Messages
+  ): SummaryList =
+    SummaryList(
+      answers.map(document =>
+        SummaryListRow(
+          key = Key(Text(messages(s"supporting-evidence.choose-document-type.document-type.${document.documentType}"))),
+          value = Value(
+            HtmlContent(
+              Paragraph(
+                document.fileName,
+                messages(s"supporting-evidence.choose-document-type.document-type.${document.documentType}")
+              ).toString
+            )
+          ),
+          actions = Some(
+            Actions(
+              items = Seq(
+                ActionItem(
+                  href = changeCall.url,
+                  content = Text(messages("cya.change")),
+                  visuallyHiddenText = Some(messages(s"$key.label"))
+                )
+              )
+            )
+          )
+        )
+      )
+    )
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/SecuritiesCdsDisplayDeclarationSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/SecuritiesCdsDisplayDeclarationSummary.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
+
+import cats.implicits.catsSyntaxOptionId
+import play.api.i18n.Messages
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ReasonForSecurity
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.DateUtils
+import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+import uk.gov.hmrc.govukfrontend.views.Aliases.Value
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.ActionItem
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Actions
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Key
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+
+object SecuritiesCdsDisplayDeclarationSummary {
+
+  def apply(
+    declaration: DisplayDeclaration,
+    key: String,
+    mrnChangeCall: Call,
+    rfsChangeCall: Call
+  )(implicit
+    messages: Messages
+  ): SummaryList = SummaryList(
+    Seq(
+      SummaryListRow(
+        key = Key(HtmlContent(messages(s"$key.mrn-label"))),
+        value = Value(Text(declaration.displayResponseDetail.declarationId)),
+        actions = Some(
+          Actions(
+            items = Seq(
+              ActionItem(
+                href = mrnChangeCall.url,
+                content = Text(messages("cya.change")),
+                visuallyHiddenText = Some(messages(s"$key.mrn-label"))
+              )
+            )
+          )
+        )
+      ).some,
+      declaration.consigneeName.map { name =>
+        SummaryListRow(
+          key = Key(HtmlContent(messages(s"$key.importer-name-label"))),
+          value = Value(Text(name))
+        )
+      },
+      declaration.consigneeEmail.map { email =>
+        SummaryListRow(
+          key = Key(HtmlContent(messages(s"$key.importer-email-label"))),
+          value = Value(Text(email))
+        )
+      },
+      declaration.consigneeTelephone.map { telephone =>
+        SummaryListRow(
+          key = Key(HtmlContent(messages(s"$key.importer-telephone-label"))),
+          value = Value(Text(telephone))
+        )
+      },
+      declaration.consigneeAddress.map { address =>
+        SummaryListRow(
+          key = Key(HtmlContent(messages(s"$key.importer-address-label"))),
+          value = Value(HtmlContent(address))
+        )
+      },
+      SummaryListRow(
+        key = Key(HtmlContent(messages(s"$key.declarant-name-label"))),
+        value = Value(Text(declaration.declarantName))
+      ).some,
+      declaration.declarantContactAddress.map { address =>
+        SummaryListRow(
+          key = Key(HtmlContent(messages(s"$key.declarant-address-label"))),
+          value = Value(HtmlContent(address))
+        )
+      },
+      declaration.getReasonForSecurity.map(rfs =>
+        SummaryListRow(
+          key = Key(HtmlContent(messages(s"$key.reason-for-security-label"))),
+          value = Value(Text(messages(s"choose-reason-for-security.securities.${ReasonForSecurity.keyOf(rfs)}"))),
+          actions = Some(
+            Actions(
+              items = Seq(
+                ActionItem(
+                  href = rfsChangeCall.url,
+                  content = Text(messages("cya.change")),
+                  visuallyHiddenText = Some(messages(s"$key.reason-for-security-label"))
+                )
+              )
+            )
+          )
+        )
+      ),
+      DateUtils
+        .displayFormat(declaration.displayResponseDetail.acceptanceDate)
+        .map(formattedDate =>
+          SummaryListRow(
+            key = Key(HtmlContent(messages(s"$key.acceptance-date-label"))),
+            value = Value(Text(formattedDate))
+          )
+        ),
+      DateUtils
+        .displayFormat(declaration.displayResponseDetail.btaDueDate)
+        .map(formattedDate =>
+          SummaryListRow(
+            key = Key(HtmlContent(messages(s"$key.bta-due-date-label"))),
+            value = Value(Text(formattedDate))
+          )
+        )
+    ).flatMap(_.toList)
+  )
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/SecuritiesReclaimDetailsSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/SecuritiesReclaimDetailsSummary.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
+
+import cats.implicits.catsSyntaxOptionId
+import play.api.i18n.Messages
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ReasonForSecurity
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.DateUtils
+import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+import uk.gov.hmrc.govukfrontend.views.Aliases.Value
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.ActionItem
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Actions
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Key
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import scala.collection.immutable.SortedMap
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
+
+object SecuritiesReclaimDetailsSummary {
+
+  def apply(
+    securityDepositId: String,
+    reclaims: SortedMap[TaxCode, BigDecimal],
+    declaration: DisplayDeclaration,
+    key: String,
+    fullAmountChangeCall: String => Call,
+    dutiesSelectionChangeCall: String => Call,
+    reclaimAmountChangeCall: (String, TaxCode) => Call
+  )(implicit
+    messages: Messages
+  ): SummaryList = SummaryList(
+    Seq(
+      SummaryListRow(
+        key = Key(HtmlContent(messages(s"$key.claim-full-amount.label"))),
+        value = Value(
+          Text(
+            messages(
+              if (declaration.isFullSecurityAmount(securityDepositId, reclaims.values.sum))
+                s"$key.claim-full-amount.yes"
+              else
+                s"$key.claim-full-amount.no"
+            )
+          )
+        ),
+        actions = Some(
+          Actions(
+            items = Seq(
+              ActionItem(
+                href = fullAmountChangeCall(securityDepositId).url,
+                content = Text(messages("cya.change")),
+                visuallyHiddenText = Some(messages(s"$key.claim-full-amount.label"))
+              )
+            )
+          )
+        )
+      ),
+      SummaryListRow(
+        key = Key(HtmlContent(messages(s"$key.duties-selected.label"))),
+        value = Value(
+          HtmlContent(
+            reclaims.keys
+              .map(taxCode => messages(s"tax-code.${taxCode.value}"))
+              .mkString("<br>")
+          )
+        ),
+        actions = Some(
+          Actions(
+            items = Seq(
+              ActionItem(
+                href = dutiesSelectionChangeCall(securityDepositId).url,
+                content = Text(messages("cya.change")),
+                visuallyHiddenText = Some(messages(s"$key.duties-selected.label"))
+              )
+            )
+          )
+        )
+      )
+    ) ++ reclaims.map { case (taxCode, amount) =>
+      SummaryListRow(
+        key = Key(HtmlContent(messages(s"tax-code.${taxCode.value}"))),
+        value = Value(Text(amount.toPoundSterlingString)),
+        actions = Some(
+          Actions(
+            items = Seq(
+              ActionItem(
+                href = reclaimAmountChangeCall(securityDepositId, taxCode).url,
+                content = Text(messages("cya.change")),
+                visuallyHiddenText = Some(messages(s"tax-code.${taxCode.value}"))
+              )
+            )
+          )
+        )
+      )
+    }.toSeq ++ Seq(
+      SummaryListRow(
+        key = Key(HtmlContent(messages(s"$key.claim-total"))),
+        value = Value(Text(reclaims.values.sum.toPoundSterlingString))
+      )
+    )
+  )
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/SecuritiesSelectionSummary.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/SecuritiesSelectionSummary.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
+
+import cats.implicits.catsSyntaxOptionId
+import play.api.i18n.Messages
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ReasonForSecurity
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.DateUtils
+import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+import uk.gov.hmrc.govukfrontend.views.Aliases.Value
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.ActionItem
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Actions
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Key
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import scala.collection.immutable.SortedMap
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
+
+object SecuritiesSelectionSummary {
+
+  def apply(
+    securitiesReclaims: SortedMap[String, SortedMap[TaxCode, BigDecimal]],
+    declaration: DisplayDeclaration,
+    key: String,
+    changeCall: String => Call
+  )(implicit
+    messages: Messages
+  ): SummaryList = SummaryList(
+    declaration.getSecurityDepositIds.getOrElse(Nil).map { securityDepositId =>
+      SummaryListRow(
+        key = Key(HtmlContent(messages(s"$key.claim-for-security.label", securityDepositId))),
+        value = Value(
+          Text(
+            messages(
+              if (securitiesReclaims.contains(securityDepositId))
+                s"$key.claim-for-security.yes"
+              else
+                s"$key.claim-for-security.no"
+            )
+          )
+        ),
+        actions = Some(
+          Actions(
+            items = Seq(
+              ActionItem(
+                href = changeCall(securityDepositId).url,
+                content = Text(messages("cya.change")),
+                visuallyHiddenText = Some(messages(s"$key.claim-for-security.label"))
+              )
+            )
+          )
+        )
+      )
+    } ++ Seq(
+      SummaryListRow(
+        key = Key(HtmlContent(messages(s"$key.claim-for-security.total"))),
+        value = Value(
+          Text(declaration.getTotalSecuritiesAmountFor(securitiesReclaims.keySet).toPoundSterlingString)
+        )
+      )
+    )
+  )
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/securities/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/securities/check_your_answers.scala.html
@@ -1,0 +1,118 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.twirl.api.Html
+@import play.api.i18n.Messages
+@import play.api.mvc.Call
+@import play.api.mvc.Request
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.routes
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary._
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.utils.MessagesHelper._
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary._
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Key
+@import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+@import uk.gov.hmrc.govukfrontend.views.Aliases.Value
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DEC91Response
+
+@this(
+    layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
+    pageHeading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.page_heading,
+    summary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.summary,
+    submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
+    paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block,
+    formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+)
+
+@(claim: SecuritiesJourney.Output, displayDeclarationOpt: Option[DisplayDeclaration], exportDeclarationOpt: Option[DEC91Response], postAction: Call, subKey: Option[String] = None)(implicit request: Request[_], messages: Messages,viewConfig: ViewConfig)
+
+@key = @{"check-your-answers"}
+@title = @{messages(s"$key.title")}
+
+@layout(pageTitle = Some(s"$title")) {
+
+    @pageHeading(Html(title))
+
+    @displayDeclarationOpt.map { displayDeclaration =>
+        @pageHeading(Html(messages(s"$key.declaration-details.h2")), "govuk-heading-m govuk-!-margin-top-9", "h2")
+        @summary(SummaryList(SecuritiesCdsDisplayDeclarationSummary(
+            displayDeclaration, 
+            s"$key.declaration-details",
+            routes.EnterMovementReferenceNumberController.show(),
+            routes.ChooseReasonForSecurityController.show()
+        ).rows ++ 
+        SecuritiesSelectionSummary(
+            claim.securitiesReclaims, 
+            displayDeclaration,
+            key,
+            routes.SecurityPickerController.show(_)
+        ).rows ++
+        Seq(SummaryListRow(
+            key = Key(Text(messages(s"$key.payment-method.label"))),
+            value = Value(Text(
+                    messages(
+                        if(displayDeclaration.isAllSelectedSecuritiesEligibleForGuaranteePayment(claim.securitiesReclaims.keySet)){
+                             s"$key.payment-method.guarantee" 
+                        } else {
+                            s"$key.payment-method.bt"
+                        }
+        )))))))
+    }
+
+    @exportDeclarationOpt.map{exportDeclaration =>
+        @pageHeading(Html(messages(s"$key.export-declaration-details.h2")), "govuk-heading-m govuk-!-margin-top-9", "h2")  
+    }
+
+    @pageHeading(Html(messages(s"$key.contact-information.h2")), "govuk-heading-m govuk-!-margin-top-9", "h2")
+    @summary(ClaimantInformationSummary(claim.claimantInformation, s"$key.contact-information", routes.CheckClaimantDetailsController.show(), routes.CheckClaimantDetailsController.show()))
+
+     @displayDeclarationOpt.map { displayDeclaration =>
+        @claim.securitiesReclaims.map { case (securityDepositId, reclaims) =>
+            @pageHeading(Html(messages(s"$key.claim-for-security.h2", securityDepositId)), "govuk-heading-m govuk-!-margin-top-9", "h2")
+            @summary(SecuritiesReclaimDetailsSummary(
+                securityDepositId, 
+                reclaims, 
+                displayDeclaration, 
+                s"$key.claim-for-security", 
+                routes.ConfirmFullRepaymentController.show(_),
+                routes.SelectDutiesController.show(_),
+                routes.EnterClaimController.show(_,_)
+            ))
+        }
+    }
+
+
+
+    @claim.bankAccountDetails.map { bankAccountDetails =>
+        @pageHeading(Html(messages(s"$key.bank-details.h2")), "govuk-heading-m govuk-!-margin-top-9", "h2")
+        @summary(BankAccountDetailsSummary(bankAccountDetails, s"$key.bank-details", subKey, routes.CheckBankDetailsController.show()))
+    }
+
+    @pageHeading(Html(messages(s"$key.documents.h2")), "govuk-heading-m govuk-!-margin-top-9", "h2")
+    @summary(EvidenceDocumentsSummary.forSecurities(claim.supportingEvidences, s"$key.documents", routes.UploadFilesController.summary()))
+    
+    @pageHeading(Html(messages(s"$key.confirmation-statement.h2")), "govuk-heading-m govuk-!-margin-top-9", "h2")
+    @paragraph(Html(messages(s"$key.confirmation-statement")), Some("govuk-body"))
+
+    @formWithCSRF(postAction, 'novalidate -> "novalidate") {
+        @submitButton("button.accept-and-send")
+    }
+}
+

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/securities/choose_reason_for_security.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/securities/choose_reason_for_security.scala.html
@@ -40,13 +40,13 @@
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
 @radioItems = @{
-    reasonForSecurity.map { fileType =>
-        val fileTypeKey = ReasonForSecurity.keyOf(fileType)
+    reasonForSecurity.map { rfs =>
+        val rfsKey = ReasonForSecurity.keyOf(rfs)
         RadioItem(
-            id = Some(s"$key.$fileTypeKey"),
-            value = Some(fileTypeKey),
-            content = Text(messages(s"$key.$fileTypeKey")),
-            checked = form(s"$key").value.exists(_.contains(fileTypeKey))
+            id = Some(s"$key.$rfsKey"),
+            value = Some(rfsKey),
+            content = Text(messages(s"$key.$rfsKey")),
+            checked = form(s"$key").value.exists(_.contains(rfsKey))
         )
     }
 }

--- a/conf/messages
+++ b/conf/messages
@@ -1242,6 +1242,7 @@ check-your-answers.reference-number.scheduled.label=First <abbr title="Movement 
 check-your-answers.reference-number.rejectedgoods.scheduled.label=First <abbr title="Movement Reference Number">MRN</abbr>
 check-your-answers.reference-number.associated-mrn-label={0} <abbr title="Movement Reference Number">MRN</abbr>
 check-your-answers.reference-number.rejectedgoodsmultiple.label={0} <abbr title="Movement Reference Number">MRN</abbr>
+
 check-your-answers.declaration-details.label=Declaration details
 check-your-answers.declaration-details.mrn-label=<abbr title="Movement Reference Number">MRN</abbr>
 check-your-answers.declaration-details.multiple.mrn-label=First <abbr title="Movement Reference Number">MRN</abbr>
@@ -1256,6 +1257,10 @@ check-your-answers.declaration-details.importer-telephone-label=Importer telepho
 check-your-answers.declaration-details.importer-address-label=Importer address
 check-your-answers.declaration-details.declarant-name-label=Declarant name
 check-your-answers.declaration-details.declarant-address-label=Declarant address
+check-your-answers.declaration-details.reason-for-security-label=Reason for security
+check-your-answers.declaration-details.acceptance-date-label=Acceptance date
+check-your-answers.declaration-details.bta-due-date-label=Brought to account (BTA) due date
+
 check-your-answers.claimant-type.h2=Claimant type
 check-your-answers.claimant-type.l0=Type of claimant
 check-your-answers.duplicate-declaration-details.label=Duplicate declaration details
@@ -1310,6 +1315,8 @@ check-your-answers.bank-details.h2=Bank details
 check-your-answers.attached-documents.h2=Supporting documents
 check-your-answers.attached-documents.label=Uploaded
 check-your-answers.attached-documents.empty=No documents attached
+check-your-answers.documents.h2=Documents
+check-your-answers.documents.label={0}
 check-your-answers.scheduled-document.h2=Scheduled document
 check-your-answers.scheduled-document.label=Scheduled document
 check-your-answers.claimant-details.h2=Contact information for this claim
@@ -1342,6 +1349,9 @@ check-your-answers.repayment-method.h2=Repayment method
 check-your-answers.repayment-method.label=Method
 check-your-answers.repayment-method.cma=Current Month Adjustment (CMA)
 check-your-answers.repayment-method.bt=Bank account transfer
+check-your-answers.payment-method.label=Payment method
+check-your-answers.payment-method.bt=Bank account transfer
+check-your-answers.payment-method.guarantee=Guarantee
 check-your-answers.inspection.h2=Details of inspection
 check-your-answers.inspection.inspection-date=Inspection date
 check-your-answers.inspection.inspection-address=Inspection address
@@ -1353,6 +1363,19 @@ check-your-answers.claim-total.multiple.total=Total
 check-your-answers.claim-total.scheduled.total=Total
 check-your-answers.contact-information.change-hint.contact=Contact details
 check-your-answers.contact-information.change-hint.address=Contact address
+
+check-your-answers.claim-for-security.h2=Claim details for: {0}
+check-your-answers.claim-for-security.label=Claim for {0}
+check-your-answers.claim-for-security.yes=Yes
+check-your-answers.claim-for-security.no=No
+check-your-answers.claim-for-security.total=Total value of selected security IDs
+check-your-answers.claim-for-security.claim-total=Total
+check-your-answers.claim-for-security.claim-full-amount.label=Claim full amount
+check-your-answers.claim-for-security.claim-full-amount.yes=Yes
+check-your-answers.claim-for-security.claim-full-amount.no=No
+check-your-answers.claim-for-security.duties-selected.label=Duties selected
+
+check-your-answers.export-declaration-details.h2=Export declaration details
 
 #===================================================
 # INSPECTION ADDRESS TYPE

--- a/conf/securities.routes
+++ b/conf/securities.routes
@@ -1,4 +1,4 @@
-GET          /securities/enter-movement-reference-number               @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterMovementReferenceNumberController.enterMrn()
+GET          /securities/enter-movement-reference-number               @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterMovementReferenceNumberController.show()
 POST         /securities/enter-movement-reference-number               @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterMovementReferenceNumberController.submit()
 
 GET          /securities/choose-reason-for-security                    @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.ChooseReasonForSecurityController.show()
@@ -10,8 +10,8 @@ POST         /securities/enter-importer-eori                           @uk.gov.h
 GET          /securities/enter-declarant-eori                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterDeclarantEoriNumberController.show()
 POST         /securities/enter-declarant-eori                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterDeclarantEoriNumberController.submit()
 
-GET          /securities/select-securities                             @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.SelectSecuritiesController.show()
-POST         /securities/select-securities                             @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.SelectSecuritiesController.submit()
+GET          /securities/security-picker/:id                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.SecurityPickerController.show(id: String)
+POST         /securities/security-picker/:id                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.SecurityPickerController.submit(id: String)
 
 GET          /securities/check-declaration-details                     @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.CheckDeclarationDetailsController.show()
 POST         /securities/check-declaration-details                     @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.CheckDeclarationDetailsController.submit()
@@ -31,12 +31,14 @@ GET          /securities/claimant-details/problem-with-address         @uk.gov.h
 GET          /securities/claimant-details/change-contact-details       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterContactDetailsController.show()
 POST         /securities/claimant-details/change-contact-details       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterContactDetailsController.submit()
 
-GET          /securities/confirm-full-repayment                        @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.ConfirmFullRepaymentController.show()
-POST         /securities/confirm-full-repayment                        @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.ConfirmFullRepaymentController.submit()
+GET          /securities/confirm-full-repayment/:id                    @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.ConfirmFullRepaymentController.show(id: String)
+POST         /securities/confirm-full-repayment/:id                    @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.ConfirmFullRepaymentController.submit(id: String)
 
-GET          /securities/enter-claim                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterClaimController.show()
-GET          /securities/enter-claim/:taxCode                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterClaimController.showAmend(taxCode: TaxCode)
-POST         /securities/enter-claim                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterClaimController.submit()
+GET          /securities/select-duties/:id                             @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.SelectDutiesController.show(id: String)
+POST         /securities/select-duties/:id                             @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.SelectDutiesController.submit(id: String)
+
+GET          /securities/enter-claim/:id/:taxCode                      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterClaimController.show(id: String, taxCode: TaxCode)
+POST         /securities/enter-claim/:id/:taxCode                      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterClaimController.submit(id: String, taxCode: TaxCode)
 
 GET          /securities/check-claim                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.CheckClaimDetailsController.show()
 POST         /securities/check-claim                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.CheckClaimDetailsController.submit()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ChooseClaimTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/claims/ChooseClaimTypeControllerSpec.scala
@@ -178,7 +178,7 @@ class ChooseClaimTypeControllerSpec extends ControllerSpec with AuthSupport with
         val result = performAction(Seq(dataKey -> Securities.toString))
         checkIsRedirect(
           result,
-          securitiesRoutes.EnterMovementReferenceNumberController.enterMrn()
+          securitiesRoutes.EnterMovementReferenceNumberController.show()
         )
       }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckYourAnswersControllerSpec.scala
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities
+
+import org.jsoup.nodes.Document
+import org.scalatest.BeforeAndAfterEach
+import play.api.i18n.Lang
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
+import play.api.inject.bind
+import play.api.inject.guice.GuiceableModule
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.SecuritiesClaimConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.UploadDocumentsConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.PropertyBasedControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourneyGenerators._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen.genCaseNumber
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.support.SummaryMatchers
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.DateUtils
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.ClaimantInformationSummary
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+class CheckYourAnswersControllerSpec
+    extends PropertyBasedControllerSpec
+    with AuthSupport
+    with SessionSupport
+    with BeforeAndAfterEach
+    with SummaryInspectionAddress
+    with SummaryMatchers {
+
+  val mockConnector: SecuritiesClaimConnector                = mock[SecuritiesClaimConnector]
+  val mockUploadDocumentsConnector: UploadDocumentsConnector = mock[UploadDocumentsConnector]
+
+  def mockSubmitClaim(submitClaimRequest: SecuritiesClaimConnector.Request)(
+    response: Future[SecuritiesClaimConnector.Response]
+  ) =
+    (mockConnector
+      .submitClaim(_: SecuritiesClaimConnector.Request)(_: HeaderCarrier))
+      .expects(submitClaimRequest, *)
+      .returning(response)
+
+  def mockWipeOutCall() =
+    (mockUploadDocumentsConnector
+      .wipeOut(_: HeaderCarrier))
+      .expects(*)
+      .returning(Future.successful(()))
+
+  override val overrideBindings: List[GuiceableModule] =
+    List[GuiceableModule](
+      bind[AuthConnector].toInstance(mockAuthConnector),
+      bind[SessionCache].toInstance(mockSessionCache),
+      bind[SecuritiesClaimConnector].toInstance(mockConnector),
+      bind[UploadDocumentsConnector].toInstance(mockUploadDocumentsConnector)
+    )
+
+  val controller: CheckYourAnswersController = instanceOf[CheckYourAnswersController]
+
+  implicit val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
+
+  private lazy val featureSwitch = instanceOf[FeatureSwitchService]
+
+  private val messagesKey: String = "check-your-answers"
+
+  override def beforeEach(): Unit =
+    featureSwitch.enable(Feature.Securities)
+
+  def validateCheckYourAnswersPage(
+    doc: Document,
+    journey: SecuritiesJourney,
+    claim: SecuritiesJourney.Output
+  ) = {
+    val headers       = doc.select("h2.govuk-heading-m").eachText().asScala
+    val summaryKeys   = doc.select(".govuk-summary-list__key").eachText()
+    val summaryValues = doc.select(".govuk-summary-list__value").eachText()
+    val summaries     = summaryKeys.asScala.zip(summaryValues.asScala)
+
+    headers       should not be empty
+    summaryKeys   should not be empty
+    summaryValues should not be empty
+
+    headers should containOnlyDefinedElementsOf(
+      (Seq(
+        "Declaration details".expectedAlways,
+        "Export declaration details".expectedWhen(journey.requiresExportDeclaration),
+        "Contact information for this claim".expectedAlways,
+        "Bank details".expectedWhen(claim.bankAccountDetails),
+        "Documents".expectedAlways,
+        "Now send your application".expectedAlways
+      ) ++
+        claim.securitiesReclaims.keys.map(sid => s"Claim details for: $sid".expectedAlways)): _*
+    )
+
+    summaries should containOnlyDefinedPairsOf(
+      Seq(
+        ("MRN"                                  -> Some(claim.movementReferenceNumber.value)),
+        ("Contact details"                      -> Some(ClaimantInformationSummary.getContactDataString(claim.claimantInformation))),
+        ("Contact address"                      -> Some(ClaimantInformationSummary.getAddressDataString(claim.claimantInformation))),
+        ("Name on the account"                  -> claim.bankAccountDetails.map(_.accountName.value)),
+        ("Sort code"                            -> claim.bankAccountDetails.map(_.sortCode.masked)),
+        ("Account number"                       -> claim.bankAccountDetails.map(_.accountNumber.masked)),
+        ("Importer name"                        -> journey.answers.displayDeclaration.flatMap(_.consigneeName)),
+        ("Importer email"                       -> journey.answers.displayDeclaration.flatMap(_.consigneeEmail)),
+        ("Importer address"                     -> journey.answers.displayDeclaration.flatMap(d =>
+          d.displayResponseDetail.consigneeDetails.map(details =>
+            d.establishmentAddress(details.establishmentAddress).mkString(" ")
+          )
+        )),
+        ("Importer telephone"                   -> journey.answers.displayDeclaration.flatMap(_.consigneeTelephone)),
+        ("Declarant name"                       -> journey.answers.displayDeclaration.map(_.declarantName)),
+        ("Declarant address"                    -> journey.answers.displayDeclaration.map(d =>
+          d.establishmentAddress(d.displayResponseDetail.declarantDetails.establishmentAddress).mkString(" ")
+        )),
+        ("Reason for security"                  -> journey.answers.reasonForSecurity.map(rfs =>
+          messages(s"choose-reason-for-security.securities.${ReasonForSecurity.keyOf(rfs)}")
+        )),
+        ("Acceptance date"                      -> journey.answers.displayDeclaration
+          .map(_.displayResponseDetail.acceptanceDate)
+          .flatMap(DateUtils.displayFormat)),
+        ("Brought to account (BTA) due date"    -> journey.answers.displayDeclaration
+          .flatMap(_.displayResponseDetail.btaDueDate)
+          .flatMap(DateUtils.displayFormat)),
+        ("Total value of selected security IDs" -> journey.answers.displayDeclaration
+          .map(_.getTotalSecuritiesAmountFor(claim.securitiesReclaims.keySet).toPoundSterlingString)),
+        ("Payment method"                       -> Some(
+          if (
+            journey.answers.displayDeclaration
+              .map(_.isAllSelectedSecuritiesEligibleForGuaranteePayment(claim.securitiesReclaims.keySet))
+              .getOrElse(false)
+          )
+            "Guarantee"
+          else
+            "Bank account transfer"
+        ))
+      ) ++
+        journey.answers.displayDeclaration
+          .flatMap(_.getSecurityDepositIds)
+          .getOrElse(Seq.empty)
+          .map { sid =>
+            (s"Claim for $sid" -> Some(
+              if (claim.securitiesReclaims.contains(sid))
+                "Yes"
+              else
+                "No"
+            ))
+          } ++
+        claim.securitiesReclaims.flatMap { case (sid, reclaims) =>
+          Seq(
+            ("Claim full amount" -> Some(
+              if (
+                journey.answers.displayDeclaration
+                  .map(_.isFullSecurityAmount(sid, reclaims.values.sum))
+                  .getOrElse(false)
+              )
+                "Yes"
+              else
+                "No"
+            )),
+            ("Duties selected"   -> Some(
+              reclaims.keys.map(taxCode => messages(s"tax-code.${taxCode.value}")).mkString(" ")
+            )),
+            ("Total"             -> Some(
+              reclaims.values.sum.toPoundSterlingString
+            ))
+          ) ++
+            reclaims.map { case (taxCode, amount) =>
+              (messages(s"tax-code.${taxCode.value}") -> Some(amount.toPoundSterlingString))
+            }
+        } ++
+        claim.supportingEvidences
+          .map(document =>
+            (messages(s"supporting-evidence.choose-document-type.document-type.${document.documentType}") -> Some(
+              document.fileName + " " +
+                messages(s"supporting-evidence.choose-document-type.document-type.${document.documentType}")
+            ))
+          )
+    )
+  }
+
+  def validateConfirmationPage(doc: Document, caseNumber: String) =
+    doc.select(".cds-wrap-content--forced").text shouldBe caseNumber
+
+  "Check Your Answers Controller" when {
+
+    "Show check your answers page" must {
+
+      def performAction(): Future[Result] = controller.show()(FakeRequest())
+
+      "not find the page if securities feature is disabled" in {
+        featureSwitch.disable(Feature.Securities)
+        status(performAction()) shouldBe NOT_FOUND
+      }
+
+      "display the page if journey has complete answers" in {
+        forAll(completeJourneyGen) { journey =>
+          val claim          = journey.toOutput.getOrElse(fail("cannot get output of the journey"))
+          val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(updatedSession)
+          }
+
+          checkPageIsDisplayed(
+            performAction(),
+            messageFromMessageKey(s"$messagesKey.title"),
+            doc => validateCheckYourAnswersPage(doc, journey, claim)
+          )
+        }
+      }
+
+      "redirect to the proper page if any answer is missing" in {
+        val journey =
+          SecuritiesJourney
+            .empty(exampleEori)
+            .submitMovementReferenceNumber(exampleMrn)
+            .submitReasonForSecurityAndDeclaration(
+              exampleSecuritiesDisplayDeclaration.getReasonForSecurity.get,
+              exampleSecuritiesDisplayDeclaration
+            )
+            .getOrFail
+
+        val errors: Seq[String] = journey.toOutput.left.getOrElse(Seq.empty)
+
+        val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(updatedSession)
+        }
+
+        checkIsRedirect(performAction(), controller.routeForValidationErrors(errors))
+      }
+
+      "redirect to the submission confirmation page if journey already finalized" in {
+        forAll(completeJourneyGen) { journey =>
+          val updatedSession =
+            SessionData.empty.copy(securitiesJourney = journey.finalizeJourneyWith("dummy case reference").toOption)
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(updatedSession)
+          }
+
+          checkIsRedirect(performAction(), routes.CheckYourAnswersController.showConfirmation())
+        }
+
+      }
+    }
+
+    "Submitted the valid claim" must {
+
+      def performAction(): Future[Result] = controller.submit()(FakeRequest())
+
+      "redirect to the confirmation page if success" in {
+        forAll(completeJourneyGen) { journey =>
+          val claim          = journey.toOutput.getOrElse(fail("cannot get output of the journey"))
+          val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(updatedSession)
+            mockSubmitClaim(SecuritiesClaimConnector.Request(claim))(
+              Future.successful(SecuritiesClaimConnector.Response("foo-123-abc"))
+            )
+            mockWipeOutCall()
+            mockStoreSession(
+              updatedSession.copy(securitiesJourney =
+                journey.finalizeJourneyWith("foo-123-abc").toOption.orElse(Some(journey))
+              )
+            )(Right(()))
+          }
+          val result         = performAction()
+          checkIsRedirect(result, routes.CheckYourAnswersController.showConfirmation())
+        }
+      }
+
+      "show failure page if submission fails" in {
+        forAll(completeJourneyGen) { journey =>
+          val claim          = journey.toOutput.getOrElse(fail("cannot get output of the journey"))
+          val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(updatedSession)
+            mockSubmitClaim(SecuritiesClaimConnector.Request(claim))(
+              Future.failed(new Exception("blah"))
+            )
+          }
+          checkPageIsDisplayed(
+            performAction(),
+            messageFromMessageKey("submit-claim-error.title")
+          )
+        }
+      }
+    }
+
+    "Show confirmation page" must {
+
+      def performAction(): Future[Result] = controller.showConfirmation()(FakeRequest())
+
+      "not find the page if securities feature is disabled" in {
+        featureSwitch.disable(Feature.Securities)
+        status(performAction()) shouldBe NOT_FOUND
+      }
+
+      "display the page if journey has been finalized" in {
+        forAll(completeJourneyGen, genCaseNumber) { (journey, caseNumber) =>
+          val updatedSession =
+            SessionData.empty.copy(securitiesJourney = journey.finalizeJourneyWith(caseNumber).toOption)
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(updatedSession)
+          }
+
+          checkPageIsDisplayed(
+            performAction(),
+            messageFromMessageKey("confirmation-of-submission.title"),
+            doc => validateConfirmationPage(doc, caseNumber)
+          )
+        }
+      }
+
+      "redirect to the check your answers page if journey not yet finalized" in {
+        forAll(completeJourneyGen) { journey =>
+          val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(updatedSession)
+          }
+
+          checkIsRedirect(performAction(), routes.CheckYourAnswersController.show())
+        }
+
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ChooseReasonForSecurityControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ChooseReasonForSecurityControllerSpec.scala
@@ -39,7 +39,6 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourneyGenerators._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.ReasonForSecurityGen.genReasonForSecurity
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 
 import scala.concurrent.Future
@@ -104,8 +103,6 @@ class ChooseReasonForSecurityControllerSpec
       }
 
       "display the page for the first time" in {
-
-        val session = SessionData.empty.copy(securitiesJourney = Some(journey))
 
         inSequence {
           mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterMovementReferenceNumberControllerSpec.scala
@@ -78,7 +78,7 @@ class EnterMovementReferenceNumberControllerSpec
   "Movement Reference Number Controller" when {
     "Enter MRN page" must {
 
-      def performAction(): Future[Result] = controller.enterMrn()(FakeRequest())
+      def performAction(): Future[Result] = controller.show()(FakeRequest())
 
       "do not find the page if securities feature is disabled" in {
         featureSwitch.disable(Feature.Securities)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyGenerators.scala
@@ -168,10 +168,11 @@ trait JourneyGenerators extends JourneyTestData {
       declarantEORI      <- IdGen.genEori
       consigneeEORI      <- IdGen.genEori
       numberOfSecurities <- Gen.choose(2, 5)
-      reclaimsDetails    <- listOfExactlyN(
-                              numberOfSecurities,
-                              Gen.zip(Gen.nonEmptyListOf(Gen.alphaNumChar).map(String.valueOf), taxCodesWithAmountsGen)
-                            )
+      reclaimsDetails    <-
+        listOfExactlyN(
+          numberOfSecurities,
+          Gen.zip(listOfExactlyN(6, Gen.alphaNumChar).map(l => String.valueOf(l.toArray)), taxCodesWithAmountsGen)
+        )
     } yield buildSecuritiesDisplayDeclaration(
       securityReason = reasonForSecurity.acc14Code,
       declarantEORI = declarantEORI,

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyTestData.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyTestData.scala
@@ -245,7 +245,7 @@ trait JourneyTestData {
         acceptanceDate = "2021-10-11",
         declarantReferenceNumber = None,
         securityReason = Some(securityReason),
-        btaDueDate = None,
+        btaDueDate = Some("2022-03-22"),
         procedureCode = "procedure-code",
         btaSource = None,
         declarantDetails = DeclarantDetails(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneyFormatSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneyFormatSpec.scala
@@ -35,6 +35,25 @@ class SecuritiesJourneyFormatSpec extends AnyWordSpec with JsonFormatTest with M
     PropertyCheckConfiguration(minSuccessful = 100)
 
   "SecuritiesJourney.Answers" should {
+
+    "println sample journey in JSON format" in {
+      completeJourneyGen.sample.map { j =>
+        println("-" * 16)
+        println("Sample Securities journey session state:")
+        println("-" * 16)
+        println("{")
+        println(""""securitiesJourney" :""")
+        print(j.prettyPrint)
+        println("}")
+        println("-" * 16)
+        j.toOutput.foreach { output =>
+          println("Sample Securities journey output (backend API request payload):")
+          println(Json.prettyPrint(Json.toJson(output)))
+          println("-" * 16)
+        }
+      }
+    }
+
     "serialize into a JSON format and back" in {
       validateCanReadAndWriteJson(Answers(userEoriNumber = exampleEori))
       validateCanReadAndWriteJson(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneySpec.scala
@@ -1115,7 +1115,7 @@ class SecuritiesJourneySpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
     }
 
     "allow to change bankAccountDetails in a complete journey not guarantee eligible" in {
-      forAll(buildCompleteJourneyGen(allDutiesGuaranteeEligible = false)) { journey =>
+      forAll(buildCompleteJourneyGen(allDutiesGuaranteeEligibleOpt = Some(false))) { journey =>
         val journeyEither =
           journey.submitBankAccountDetails(exampleBankAccountDetails)
 
@@ -1124,7 +1124,7 @@ class SecuritiesJourneySpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
     }
 
     "reject change of the bankAccountDetails in a complete journey guarantee eligible" in {
-      forAll(buildCompleteJourneyGen(allDutiesGuaranteeEligible = true)) { journey =>
+      forAll(buildCompleteJourneyGen(allDutiesGuaranteeEligibleOpt = Some(true))) { journey =>
         val journeyEither =
           journey.submitBankAccountDetails(exampleBankAccountDetails)
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneyTestData.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneyTestData.scala
@@ -69,7 +69,7 @@ trait SecuritiesJourneyTestData extends JourneyTestData {
       .flatMapWhenDefined(declarantEoriNumber)(_.submitDeclarantEoriNumber _)
       .map(_.submitContactDetails(contactDetails))
       .mapWhenDefined(contactAddress)(_.submitContactAddress _)
-      .flatMap(_.selectSecurityDepositIds(reclaims.map(_._1)))
+      .flatMapEach(reclaims.map(_._1).distinct, (journey: SecuritiesJourney) => journey.selectSecurityDepositId(_))
       .flatMapEach(
         reclaims.groupBy(_._1).mapValues(_.map { case (_, tc, amount) => (tc, amount) }).toSeq,
         (journey: SecuritiesJourney) =>


### PR DESCRIPTION
This PR adds CYA page for Securities journey. Sample session state for securities can be generated by running `SecuritiesJourneyFormatSpec`.  External display  declaration details are not yet included as it depends on CDSR-1782.