### PR TITLE
[CDSR-1550] Securities | US1:AC4 /check-declaration-details

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/WorkInProgressMixin.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/WorkInProgressMixin.scala
@@ -21,7 +21,6 @@ import play.api.mvc.AnyContent
 import play.api.mvc.Request
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBaseController
 import java.util.UUID
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
 
 trait WorkInProgressMixin[Journey] {
   self: JourneyBaseController[Journey] =>

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/CheckYourAnswersController.scala
@@ -41,8 +41,7 @@ class CheckYourAnswersController @Inject() (
   submitClaimFailedPage: claimPages.submit_claim_error
 )(implicit val ec: ExecutionContext, viewConfig: ViewConfig)
     extends RejectedGoodsMultipleJourneyBaseController
-    with Logging
-    with RejectedGoodsMultipleJourneyRouter {
+    with Logging {
 
   private val postAction: Call             = routes.CheckYourAnswersController.submit()
   private val showConfirmationAction: Call = routes.CheckYourAnswersController.showConfirmation()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/RejectedGoodsMultipleJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/RejectedGoodsMultipleJourneyBaseController.scala
@@ -26,7 +26,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
 import scala.concurrent.ExecutionContext
 
 abstract class RejectedGoodsMultipleJourneyBaseController(implicit ec: ExecutionContext)
-    extends JourneyBaseController[RejectedGoodsMultipleJourney] {
+    extends JourneyBaseController[RejectedGoodsMultipleJourney]
+    with RejectedGoodsMultipleJourneyRouter {
 
   final override val requiredFeature: Option[Feature] =
     Some(Feature.RejectedGoods)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/CheckYourAnswersController.scala
@@ -42,8 +42,7 @@ class CheckYourAnswersController @Inject() (
   submitClaimFailedPage: claimPages.submit_claim_error
 )(implicit val ec: ExecutionContext, viewConfig: ViewConfig)
     extends RejectedGoodsScheduledJourneyBaseController
-    with Logging
-    with RejectedGoodsScheduledJourneyRouter {
+    with Logging {
 
   private val postAction: Call             = routes.CheckYourAnswersController.submit()
   private val showConfirmationAction: Call = routes.CheckYourAnswersController.showConfirmation()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/RejectedGoodsScheduledJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/RejectedGoodsScheduledJourneyBaseController.scala
@@ -27,7 +27,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
 import scala.concurrent.ExecutionContext
 
 abstract class RejectedGoodsScheduledJourneyBaseController(implicit ec: ExecutionContext)
-    extends JourneyBaseController[RejectedGoodsScheduledJourney] {
+    extends JourneyBaseController[RejectedGoodsScheduledJourney]
+    with RejectedGoodsScheduledJourneyRouter {
 
   final override val requiredFeature: Option[Feature] =
     Some(Feature.RejectedGoods)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckYourAnswersController.scala
@@ -41,8 +41,7 @@ class CheckYourAnswersController @Inject() (
   submitClaimFailedPage: claimPages.submit_claim_error
 )(implicit val ec: ExecutionContext, viewConfig: ViewConfig)
     extends RejectedGoodsSingleJourneyBaseController
-    with Logging
-    with RejectedGoodsSingleJourneyRouter {
+    with Logging {
 
   private val postAction: Call             = routes.CheckYourAnswersController.submit()
   private val showConfirmationAction: Call = routes.CheckYourAnswersController.showConfirmation()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/RejectedGoodsSingleJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/RejectedGoodsSingleJourneyBaseController.scala
@@ -26,7 +26,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
 import scala.concurrent.ExecutionContext
 
 abstract class RejectedGoodsSingleJourneyBaseController(implicit ec: ExecutionContext)
-    extends JourneyBaseController[RejectedGoodsSingleJourney] {
+    extends JourneyBaseController[RejectedGoodsSingleJourney]
+    with RejectedGoodsSingleJourneyRouter {
 
   final override val requiredFeature: Option[Feature] =
     Some(Feature.RejectedGoods)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckDeclarationDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckDeclarationDetailsController.scala
@@ -26,6 +26,8 @@ import scala.concurrent.ExecutionContext
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
+import com.github.arturopala.validator.Validator.Validate
 
 @Singleton
 class CheckDeclarationDetailsController @Inject() (
@@ -35,6 +37,15 @@ class CheckDeclarationDetailsController @Inject() (
     extends SecuritiesJourneyBaseController {
 
   private val postAction: Call = routes.CheckDeclarationDetailsController.submit
+
+  import SecuritiesJourney.Checks._
+
+  override val actionPrecondition: Option[Validate[SecuritiesJourney]] =
+    Some(
+      hasMRNAndDisplayDeclarationAndRfS &
+        canContinueTheClaimWithChoosenRfS &
+        declarantOrImporterEoriMatchesUserOrHasBeenVerified
+    )
 
   val show: Action[AnyContent] =
     simpleActionReadWriteJourney { implicit request => journey =>

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckYourAnswersController.scala
@@ -41,8 +41,7 @@ class CheckYourAnswersController @Inject() (
   submitClaimFailedPage: claimPages.submit_claim_error
 )(implicit val ec: ExecutionContext, viewConfig: ViewConfig)
     extends SecuritiesJourneyBaseController
-    with Logging
-    with SecuritiesJourneyRouter {
+    with Logging {
 
   private val postAction: Call             = routes.CheckYourAnswersController.submit()
   private val showConfirmationAction: Call = routes.CheckYourAnswersController.showConfirmation()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterMovementReferenceNumberController.scala
@@ -27,31 +27,26 @@ import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionDataExtractor
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.EnterMovementReferenceNumberController.movementReferenceNumberForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{securities => pages}
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 @Singleton
 class EnterMovementReferenceNumberController @Inject() (
   val jcc: JourneyControllerComponents,
   enterMovementReferenceNumberPage: pages.enter_movement_reference_number
 )(implicit viewConfig: ViewConfig, ec: ExecutionContext)
-    extends SecuritiesJourneyBaseController
-    with SessionDataExtractor {
+    extends SecuritiesJourneyBaseController {
 
   val show: Action[AnyContent] = actionReadJourney { implicit request => journey =>
-    Future.successful {
-      Ok(
-        enterMovementReferenceNumberPage(
-          movementReferenceNumberForm.withDefault(journey.answers.movementReferenceNumber),
-          routes.EnterMovementReferenceNumberController.submit()
-        )
+    Ok(
+      enterMovementReferenceNumberPage(
+        movementReferenceNumberForm.withDefault(journey.answers.movementReferenceNumber),
+        routes.EnterMovementReferenceNumberController.submit()
       )
-    }
+    ).asFuture
   }
 
   val submit: Action[AnyContent] = actionReadWriteJourney { implicit request => journey =>

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SecuritiesJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SecuritiesJourneyBaseController.scala
@@ -26,7 +26,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
 import scala.concurrent.ExecutionContext
 
 abstract class SecuritiesJourneyBaseController(implicit ec: ExecutionContext)
-    extends JourneyBaseController[SecuritiesJourney] {
+    extends JourneyBaseController[SecuritiesJourney]
+    with SecuritiesJourneyRouter {
 
   final override val requiredFeature: Option[Feature] =
     Some(Feature.Securities)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SecuritiesJourneyRouter.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SecuritiesJourneyRouter.scala
@@ -46,10 +46,12 @@ trait SecuritiesJourneyRouter {
       case CONSIGNEE_EORI_NUMBER_DOES_NOT_HAVE_TO_BE_PROVIDED                => undefined
       case BANK_ACCOUNT_DETAILS_MUST_BE_DEFINED                              => routes.CheckBankDetailsController.show()
       case BANK_ACCOUNT_DETAILS_MUST_NOT_BE_DEFINED                          => undefined
-      case _                                                                 => undefined
+      case _                                                                 =>
+        println("undefined error case")
+        undefined
     }
 
-  def routeForValidationErrors(errors: Seq[String]): Call =
+  final def routeForValidationErrors(errors: Seq[String]): Call =
     errors.headOption.map(routeForValidationError).getOrElse(undefined)
 
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
@@ -544,7 +544,7 @@ final class RejectedGoodsMultipleJourney private (
     whileClaimIsAmendable {
       validate(this)
         .fold(
-          errors => Left(errors.headOption.getOrElse("completeWith.invalidJourney")),
+          errors => Left(errors.headMessage),
           _ => Right(new RejectedGoodsMultipleJourney(answers = this.answers, caseNumber = Some(caseNumber)))
         )
     }
@@ -561,8 +561,9 @@ final class RejectedGoodsMultipleJourney private (
 
   /** Validates the journey and retrieves the output. */
   @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
-  def toOutput: Either[List[String], RejectedGoodsMultipleJourney.Output] =
-    validate(this)
+  def toOutput: Either[Seq[String], RejectedGoodsMultipleJourney.Output] =
+    validate(this).left
+      .map(_.messages)
       .flatMap(_ =>
         (for {
           movementReferenceNumbers <- answers.movementReferenceNumbers

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsScheduledJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsScheduledJourney.scala
@@ -443,7 +443,7 @@ final class RejectedGoodsScheduledJourney private (
     whileClaimIsAmendable {
       validate(this)
         .fold(
-          errors => Left(errors.headOption.getOrElse("completeWith.invalidJourney")),
+          errors => Left(errors.headMessage),
           _ => Right(new RejectedGoodsScheduledJourney(answers = this.answers, caseNumber = Some(caseNumber)))
         )
     }
@@ -460,8 +460,9 @@ final class RejectedGoodsScheduledJourney private (
 
   /** Validates the journey and retrieves the output. */
   @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
-  def toOutput: Either[List[String], RejectedGoodsScheduledJourney.Output] =
-    validate(this)
+  def toOutput: Either[Seq[String], RejectedGoodsScheduledJourney.Output] =
+    validate(this).left
+      .map(_.messages)
       .flatMap(_ =>
         (for {
           mrn                    <- getLeadMovementReferenceNumber

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
@@ -403,7 +403,7 @@ final class RejectedGoodsSingleJourney private (
     whileClaimIsAmendable {
       validate(this)
         .fold(
-          errors => Left(errors.headOption.getOrElse("completeWith.invalidJourney")),
+          errors => Left(errors.headMessage),
           _ => Right(new RejectedGoodsSingleJourney(answers = this.answers, caseNumber = Some(caseNumber)))
         )
     }
@@ -420,8 +420,9 @@ final class RejectedGoodsSingleJourney private (
 
   /** Validates the journey and retrieves the output. */
   @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
-  def toOutput: Either[List[String], RejectedGoodsSingleJourney.Output] =
-    validate(this)
+  def toOutput: Either[Seq[String], RejectedGoodsSingleJourney.Output] =
+    validate(this).left
+      .map(_.messages)
       .flatMap(_ =>
         (for {
           mrn                    <- getLeadMovementReferenceNumber

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -15,7 +15,7 @@ object AppDependencies {
     "org.typelevel"         %% "cats-core"                  % "2.7.0",
     "com.github.kxbmap"     %% "configs"                    % "0.5.0",
     "org.julienrf"          %% "play-json-derived-codecs"   % "7.0.0",
-    "com.github.arturopala" %% "validator"                  % "0.9.0"
+    "com.github.arturopala" %% "validator"                  % "0.14.0"
   )
 
   val test = Seq(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckDeclarationDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckDeclarationDetailsControllerSpec.scala
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities
+
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.http.Status.NOT_FOUND
+import play.api.inject.bind
+import play.api.inject.guice.GuiceableModule
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.api.test.Helpers.status
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourneyGenerators.EitherOps
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourneyGenerators._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+
+import scala.concurrent.Future
+import org.jsoup.nodes.Document
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
+import scala.collection.JavaConverters._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.support.SummaryMatchers
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ReasonForSecurity
+import play.api.i18n.MessagesApi
+import play.api.i18n.Messages
+import play.api.i18n.Lang
+import play.api.i18n.MessagesImpl
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.DateUtils
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import scala.collection.immutable.SortedMap
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
+
+class CheckDeclarationDetailsControllerSpec
+    extends ControllerSpec
+    with AuthSupport
+    with SessionSupport
+    with BeforeAndAfterEach
+    with ScalaCheckPropertyChecks
+    with SummaryMatchers {
+
+  val mockClaimsService: ClaimService = mock[ClaimService]
+
+  override val overrideBindings: List[GuiceableModule] =
+    List[GuiceableModule](
+      bind[AuthConnector].toInstance(mockAuthConnector),
+      bind[SessionCache].toInstance(mockSessionCache),
+      bind[ClaimService].toInstance(mockClaimsService)
+    )
+
+  val controller: CheckDeclarationDetailsController = instanceOf[CheckDeclarationDetailsController]
+
+  private lazy val featureSwitch = instanceOf[FeatureSwitchService]
+
+  implicit val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
+
+  private val messagesKey: String = "check-declaration-details"
+
+  override def beforeEach(): Unit = featureSwitch.enable(Feature.Securities)
+
+  def validateCheckDeclarationDetailsPage(
+    doc: Document,
+    journey: SecuritiesJourney
+  ) = {
+    val headers       = doc.select("h2.govuk-heading-m").eachText().asScala
+    val summaryKeys   = doc.select(".govuk-summary-list__key").eachText()
+    val summaryValues = doc.select(".govuk-summary-list__value").eachText()
+    val summaries     = summaryKeys.asScala.zip(summaryValues.asScala)
+
+    headers     shouldBe empty
+    summaryKeys   should not be empty
+    summaryValues should not be empty
+
+    val securitiesReclaims: SortedMap[String, SortedMap[TaxCode, BigDecimal]] = journey.getSecuritiesReclaims
+
+    summaries should containOnlyDefinedPairsOf(
+      Seq(
+        ("MRN"                                  -> journey.getLeadMovementReferenceNumber.map(_.value)),
+        ("Importer name"                        -> journey.answers.displayDeclaration.flatMap(_.consigneeName)),
+        ("Importer email"                       -> journey.answers.displayDeclaration.flatMap(_.consigneeEmail)),
+        ("Importer address"                     -> journey.answers.displayDeclaration.flatMap(d =>
+          d.displayResponseDetail.consigneeDetails.map(details =>
+            d.establishmentAddress(details.establishmentAddress).mkString(" ")
+          )
+        )),
+        ("Importer telephone"                   -> journey.answers.displayDeclaration.flatMap(_.consigneeTelephone)),
+        ("Declarant name"                       -> journey.answers.displayDeclaration.map(_.declarantName)),
+        ("Declarant address"                    -> journey.answers.displayDeclaration.map(d =>
+          d.establishmentAddress(d.displayResponseDetail.declarantDetails.establishmentAddress).mkString(" ")
+        )),
+        ("Reason for security"                  -> journey.answers.reasonForSecurity.map(rfs =>
+          messages(s"choose-reason-for-security.securities.${ReasonForSecurity.keyOf(rfs)}")
+        )),
+        ("Acceptance date"                      -> journey.answers.displayDeclaration
+          .map(_.displayResponseDetail.acceptanceDate)
+          .flatMap(DateUtils.displayFormat)),
+        ("Brought to account (BTA) due date"    -> journey.answers.displayDeclaration
+          .flatMap(_.displayResponseDetail.btaDueDate)
+          .flatMap(DateUtils.displayFormat)),
+        ("Total value of selected security IDs" -> journey.answers.displayDeclaration
+          .map(_.getTotalSecuritiesAmountFor(journey.getSecuritiesReclaims.keySet).toPoundSterlingString)),
+        ("Amount paid of selected security IDs" -> journey.answers.displayDeclaration
+          .map(_.getTotalSecuritiesPaidAmountFor(journey.getSecuritiesReclaims.keySet).toPoundSterlingString)),
+        ("Payment method available"             -> (if (securitiesReclaims.isEmpty)
+                                          Some("Unavailable")
+                                        else
+                                          journey.answers.displayDeclaration
+                                            .map(
+                                              _.isAllSelectedSecuritiesEligibleForGuaranteePayment(
+                                                securitiesReclaims.keySet
+                                              )
+                                            )
+                                            .map {
+                                              case true  => "Guarantee"
+                                              case false => "Bank account transfer"
+                                            }))
+      ) ++
+        journey.answers.displayDeclaration
+          .flatMap(_.getSecurityDepositIds)
+          .getOrElse(Seq.empty)
+          .map { sid =>
+            (s"Claim for $sid" -> Some(
+              if (securitiesReclaims.contains(sid))
+                "Yes"
+              else
+                "No"
+            ))
+          }
+    )
+
+  }
+
+  "CheckDeclarationDetailsController" when {
+
+    "show page" must {
+
+      def performAction(): Future[Result] = controller.show()(FakeRequest())
+
+      "not find the page if securities feature is disabled" in {
+        featureSwitch.disable(Feature.Securities)
+        status(performAction()) shouldBe NOT_FOUND
+      }
+
+      "redirect to the enter movement reference number if empty journey" in {
+        val initialJourney = emptyJourney
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(SessionData(initialJourney))
+        }
+
+        checkIsRedirect(
+          performAction(),
+          routes.EnterMovementReferenceNumberController.show()
+        )
+      }
+
+      "redirect to the enter declarant eori page if EORI hasn't pass validation" in {
+        forAll(mrnWithNonExportRfsWithDisplayDeclarationGen) { case (mrn, rfs, decl) =>
+          val declarationWithNonMatchingEori = decl.withConsigneeEori(Eori("foo")).withDeclarantEori(Eori("bar"))
+          val depositIds                     = decl.getSecurityDepositIds.getOrElse(Seq.empty)
+          whenever(depositIds.nonEmpty) {
+            val initialJourney = emptyJourney
+              .submitMovementReferenceNumber(mrn)
+              .submitReasonForSecurityAndDeclaration(rfs, declarationWithNonMatchingEori)
+              .flatMap(_.submitClaimDuplicateCheckStatus(false))
+              .getOrFail
+
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(SessionData(initialJourney))
+            }
+
+            checkIsRedirect(
+              performAction(),
+              routes.EnterDeclarantEoriNumberController.show()
+            )
+          }
+        }
+      }
+
+      "display the page if at least one security has been selected" in {
+        forAll(mrnWithNonExportRfsWithDisplayDeclarationGen) { case (mrn, rfs, decl) =>
+          val depositIds = decl.getSecurityDepositIds.getOrElse(Seq.empty)
+          whenever(depositIds.nonEmpty) {
+            val initialJourney = emptyJourney
+              .submitMovementReferenceNumber(mrn)
+              .submitReasonForSecurityAndDeclaration(rfs, decl)
+              .flatMap(_.submitClaimDuplicateCheckStatus(false))
+              .flatMap(_.selectSecurityDepositId(depositIds.head))
+              .getOrFail
+
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(SessionData(initialJourney))
+              mockStoreSession(SessionData(initialJourney.submitCheckDeclarationDetailsChangeMode(true)))(Right(()))
+            }
+
+            checkPageIsDisplayed(
+              performAction(),
+              messageFromMessageKey(s"$messagesKey.title"),
+              doc => validateCheckDeclarationDetailsPage(doc, initialJourney)
+            )
+          }
+        }
+      }
+
+      "display the page if none security has been selected" in {
+        forAll(mrnWithNonExportRfsWithDisplayDeclarationGen) { case (mrn, rfs, decl) =>
+          val initialJourney = emptyJourney
+            .submitMovementReferenceNumber(mrn)
+            .submitReasonForSecurityAndDeclaration(rfs, decl)
+            .flatMap(_.submitClaimDuplicateCheckStatus(false))
+            .getOrFail
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(SessionData(initialJourney))
+            mockStoreSession(SessionData(initialJourney.submitCheckDeclarationDetailsChangeMode(true)))(Right(()))
+          }
+
+          checkPageIsDisplayed(
+            performAction(),
+            messageFromMessageKey(s"$messagesKey.title"),
+            doc => validateCheckDeclarationDetailsPage(doc, initialJourney)
+          )
+
+        }
+      }
+
+    }
+
+    "submit" must {
+
+      def performAction(data: (String, String)*): Future[Result] =
+        controller.submit()(FakeRequest().withFormUrlEncodedBody(data: _*))
+
+      "do not find the page if securities feature is disabled" in {
+        featureSwitch.disable(Feature.Securities)
+
+        status(performAction()) shouldBe NOT_FOUND
+      }
+
+      "continue to the check claimant details page if some securities has been selected" in {
+        forAll(mrnWithNonExportRfsWithDisplayDeclarationGen) { case (mrn, rfs, decl) =>
+          val depositIds = decl.getSecurityDepositIds.getOrElse(Seq.empty)
+          whenever(depositIds.nonEmpty) {
+
+            val initialJourney = emptyJourney
+              .submitMovementReferenceNumber(mrn)
+              .submitReasonForSecurityAndDeclaration(rfs, decl)
+              .flatMap(_.submitClaimDuplicateCheckStatus(false))
+              .flatMap(_.selectSecurityDepositId(depositIds.head))
+              .map(_.submitCheckDeclarationDetailsChangeMode(true))
+              .getOrFail
+
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(SessionData(initialJourney))
+              mockStoreSession(SessionData(initialJourney.submitCheckDeclarationDetailsChangeMode(false)))(Right(()))
+            }
+
+            checkIsRedirect(
+              performAction(),
+              routes.CheckClaimantDetailsController.show()
+            )
+          }
+        }
+      }
+
+      "re-display the check declaration details page if none securities selected" in {
+        forAll(mrnWithNonExportRfsWithDisplayDeclarationGen) { case (mrn, rfs, decl) =>
+          val depositIds = decl.getSecurityDepositIds.getOrElse(Seq.empty)
+          whenever(depositIds.nonEmpty) {
+
+            val initialJourney = emptyJourney
+              .submitMovementReferenceNumber(mrn)
+              .submitReasonForSecurityAndDeclaration(rfs, decl)
+              .flatMap(_.submitClaimDuplicateCheckStatus(false))
+              .map(_.submitCheckDeclarationDetailsChangeMode(true))
+              .getOrFail
+
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(SessionData(initialJourney))
+              mockStoreSession(SessionData(initialJourney.submitCheckDeclarationDetailsChangeMode(false)))(Right(()))
+            }
+
+            checkIsRedirect(
+              performAction(),
+              routes.CheckDeclarationDetailsController.show()
+            )
+          }
+        }
+      }
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SelectSecuritiesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SelectSecuritiesControllerSpec.scala
@@ -125,7 +125,7 @@ class SelectSecuritiesControllerSpec
         status(performAction("foo")) shouldBe NOT_FOUND
       }
 
-      "display the page if an invalid security deposit ID" in {
+      "redirect to the ineligible page if an invalid security deposit ID" in {
         mrnWithNonExportRfsWithDisplayDeclarationGen.sample.map { case (mrn, rfs, decl) =>
           val initialJourney = emptyJourney
             .submitMovementReferenceNumber(mrn)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneySpec.scala
@@ -105,14 +105,14 @@ class RejectedGoodsMultipleJourneySpec
 
     "check incompleteness if less than two MRNs" in {
       forAll(buildCompleteJourneyGen(minNumberOfMRNs = 1, maxNumberOfMRNs = 1)) { journey =>
-        RejectedGoodsMultipleJourney.validator.apply(journey) shouldBe Left(
-          List(MISSING_SECOND_MOVEMENT_REFERENCE_NUMBER)
+        RejectedGoodsMultipleJourney.validator(journey).headErrorString shouldBe Some(
+          MISSING_SECOND_MOVEMENT_REFERENCE_NUMBER
         )
-        journey.answers.checkYourAnswersChangeMode            shouldBe false
-        journey.hasCompleteReimbursementClaims                shouldBe true
-        journey.hasCompleteSupportingEvidences                shouldBe true
-        journey.hasCompleteAnswers                            shouldBe false
-        journey.isFinalized                                   shouldBe false
+        journey.answers.checkYourAnswersChangeMode                      shouldBe false
+        journey.hasCompleteReimbursementClaims                          shouldBe true
+        journey.hasCompleteSupportingEvidences                          shouldBe true
+        journey.hasCompleteAnswers                                      shouldBe false
+        journey.isFinalized                                             shouldBe false
       }
     }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneySpec.scala
@@ -906,8 +906,7 @@ class SecuritiesJourneySpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
         submitConsigneeDetails = false
       )
       forAll(journeyGen) { result =>
-        val journey = result.getOrElse(fail("Journey building has failed."))
-        journey.hasCompleteAnswers shouldBe false
+        result.isLeft shouldBe true
       }
     }
 


### PR DESCRIPTION
Thiis PR apart from implementing CDSR-1550 also upgrades validator library and introduces optional action precondition checks support in the base journey controller. We will try to introduce action precondition checks across all Securities' controllers and later retrospectively in the RejectedGoods.