### PR TITLE
CDSR-1776 add html, summary and draft controller

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Forms.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Forms.scala
@@ -180,6 +180,8 @@ object Forms {
     )
   )
 
+  val confirmFullRepaymentForm: Form[YesNo] = YesOrNoQuestionForm("confirm-full-repayment")
+
   @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
   def selectDutiesForm(allAvailableDuties: DutiesSelectedAnswer): Form[DutiesSelectedAnswer] = Form(
     mapping(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentController.scala
@@ -76,9 +76,9 @@ class ConfirmFullRepaymentController @Inject() (
   private def showForId(implicit request: Request[_], journey: SecuritiesJourney, id: String) =
     journey
       .getDisplayDeclarationIfValidSecurityDepositId(id)
-      .flatMap(_.getSecurityDetailsFor(id).map(_.totalAmount))
+      .flatMap(_.getSecurityDetailsFor(id).map(_.amountPaid))
       .flatMap(x => Try(BigDecimal(x)).toOption)
-      .fold(errorHandler.errorResult()) { totalAmount =>
+      .fold(errorHandler.errorResult()) { amountPaid =>
         Ok(
           confirmFullRepaymentPage(
             form.withDefault(
@@ -86,7 +86,7 @@ class ConfirmFullRepaymentController @Inject() (
                 .fold(Option.empty[YesNo])(_ => Some(YesNo.Yes))
             ),
             id,
-            totalAmount,
+            amountPaid,
             routes.ConfirmFullRepaymentController.submit(id)
           )
         )
@@ -103,12 +103,14 @@ class ConfirmFullRepaymentController @Inject() (
             journey,
             journey
               .getDisplayDeclarationIfValidSecurityDepositId(id)
-              .map(declaration =>
+              .flatMap(_.getSecurityDetailsFor(id).map(_.amountPaid))
+              .flatMap(x => Try(BigDecimal(x)).toOption)
+              .map(amountPaid =>
                 BadRequest(
                   confirmFullRepaymentPage(
                     formWithErrors,
                     id,
-                    journey.getTotalReclaimAmount,
+                    amountPaid,
                     routes.ConfirmFullRepaymentController.submit(id)
                   )
                 )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentController.scala
@@ -61,8 +61,9 @@ class ConfirmFullRepaymentController @Inject() (
   //    (implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
   @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
   def showFirst(): Action[AnyContent] = actionReadJourney { implicit request => journey =>
-    val id = journey.getSecuritiesReclaims.head._1
-    showForId(request, journey, id)
+    journey.getSecuritiesReclaims.headOption.fold(
+      errorHandler.errorResult().asFuture
+    )(reclaims => showForId(request, journey, reclaims._1))
   }
 
   // GET          /securities/confirm-full-repayment/:id

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentController.scala
@@ -16,18 +16,100 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities
 
+import cats.implicits._
 import com.google.inject.Inject
 import com.google.inject.Singleton
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import play.api.data.Form
+import play.api.mvc.{Action, AnyContent, Call, Request, Result}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.{ErrorHandler, ViewConfig}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.confirmFullRepaymentForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.WorkInProgressMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.{No, Yes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.securities.confirm_full_repayment
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ConfirmFullRepaymentController @Inject() (
-  val jcc: JourneyControllerComponents
-)(implicit viewConfig: ViewConfig, ec: ExecutionContext)
+  val jcc: JourneyControllerComponents,
+  confirmFullRepaymentPage: confirm_full_repayment
+)(implicit viewConfig: ViewConfig, errorHandler: ErrorHandler, ec: ExecutionContext)
     extends SecuritiesJourneyBaseController
-    with WorkInProgressMixin[SecuritiesJourney]
+    with SecuritiesJourneyRouter
+    with Logging {
+
+  private val form: Form[YesNo] = confirmFullRepaymentForm
+
+  // todo import SecuritiesJourney.Checks._
+
+  // GET          /securities/confirm-full-repayment/:id
+  // @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.ConfirmFullRepaymentController.show(id: String)
+  // @(form: Form[YesNo], securityId: String, totalValue: BigDecimal, postAction: Call)
+  //    (implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+  def show(id: String): Action[AnyContent] = actionReadJourney { implicit request =>
+    journey =>
+      journey
+        .getDisplayDeclarationIfValidSecurityDepositId(id)
+        .fold(errorHandler.errorResult()) { declaration =>
+          Ok(
+            confirmFullRepaymentPage(
+              form.withDefault(
+                journey.answers.reclaimingFullAmount
+                  .fold(Option.empty[YesNo])(_ => Some(YesNo.Yes))
+              ),
+              id,
+              journey.getTotalReclaimAmount,
+              routes.ConfirmFullRepaymentController.submit(id)
+            )
+          )
+        }
+        .asFuture
+  }
+
+  // POST         /securities/confirm-full-repayment/:id
+  // @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.ConfirmFullRepaymentController.submit(id: String)
+  def submit(id: String): Action[AnyContent] = actionReadWriteJourney { implicit request =>
+    journey =>
+      form.bindFromRequest
+        .fold(
+          formWithErrors =>
+            (
+              journey,
+              journey
+                .getDisplayDeclarationIfValidSecurityDepositId(id)
+                .map(declaration =>
+                  BadRequest(
+                    confirmFullRepaymentPage(
+                      formWithErrors, id, journey.getTotalReclaimAmount, routes.ConfirmFullRepaymentController.submit(id)
+                    )
+                  )
+                )
+                .getOrElse(errorHandler.errorResult())
+              ).asFuture,
+          {
+            case Yes =>
+              submitYes(id, journey)
+            case No =>
+              (journey, Redirect(routes.ConfirmFullRepaymentController.submit(id))).asFuture
+          }
+        )
+  }
+
+  def submitYes(securityId: String, journey: SecuritiesJourney)
+               (implicit request: Request[_]): Future[(SecuritiesJourney, Result)] = {
+
+    journey.submitFullAmountsForReclaim(securityId)
+      .fold({ error =>
+        logger.warn(error)
+        (journey, errorHandler.errorResult())
+      },
+        updatedJourney =>
+          (updatedJourney, Redirect(routes.ChooseFileTypeController.submit()))
+      ).asFuture
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterClaimController.scala
@@ -92,7 +92,7 @@ class EnterClaimController @Inject() (
     }
 
   final def submit(securityDepositId: String, taxCode: TaxCode): Action[AnyContent] =
-    actionReadWriteJourney { implicit request => journey =>
+    actionReadWriteJourney ({ implicit request => journey =>
       validateDepositIdAndTaxCode(journey, securityDepositId, taxCode).map(
         _.fold(
           result => (journey, result),
@@ -131,7 +131,7 @@ class EnterClaimController @Inject() (
           }
         )
       )
-    }
+    }, fastForwardToCYAEnabled = false)
 
   private def validateDepositIdAndTaxCode(journey: SecuritiesJourney, securityDepositId: String, taxCode: TaxCode)(
     implicit request: Request[_]

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SelectDutiesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SelectDutiesController.scala
@@ -85,42 +85,45 @@ class SelectDutiesController @Inject() (
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  def submit(securityId: String): Action[AnyContent] = actionReadWriteJourney({implicit request => journey =>
-    processAvailableDuties[(SecuritiesJourney, Result)](
-      securityId: String,
-      journey: SecuritiesJourney,
-      error => {
-        logger.warn(s"No Available duties: $error")
-        (journey, Redirect(baseRoutes.IneligibleController.ineligible())).asFuture
-      },
-      dutiesAvailable => {
-        val form      = selectDutiesForm(dutiesAvailable)
-        val boundForm = form.bindFromRequest()
-        boundForm
-          .fold(
-            errors => {
-              logger.warn(
-                s"Selection of duties to be repaid failed for $securityId because of errors:" +
-                  s"${errors.mkString("", ",", "")}"
-              )
-              (
-                journey,
-                Ok(
-                  selectDutiesPage(
-                    boundForm,
-                    securityId,
-                    dutiesAvailable,
-                    routes.SelectDutiesController.submit(securityId)
+  def submit(securityId: String): Action[AnyContent] = actionReadWriteJourney(
+    { implicit request => journey =>
+      processAvailableDuties[(SecuritiesJourney, Result)](
+        securityId: String,
+        journey: SecuritiesJourney,
+        error => {
+          logger.warn(s"No Available duties: $error")
+          (journey, Redirect(baseRoutes.IneligibleController.ineligible())).asFuture
+        },
+        dutiesAvailable => {
+          val form      = selectDutiesForm(dutiesAvailable)
+          val boundForm = form.bindFromRequest()
+          boundForm
+            .fold(
+              errors => {
+                logger.warn(
+                  s"Selection of duties to be repaid failed for $securityId because of errors:" +
+                    s"${errors.mkString("", ",", "")}"
+                )
+                (
+                  journey,
+                  Ok(
+                    selectDutiesPage(
+                      boundForm,
+                      securityId,
+                      dutiesAvailable,
+                      routes.SelectDutiesController.submit(securityId)
+                    )
                   )
                 )
-              )
-            },
-            dutiesSelected => updateAndRedirect(journey, securityId, dutiesSelected)
-          )
-          .asFuture
-      }
-    )
-  }, fastForwardToCYAEnabled = false)
+              },
+              dutiesSelected => updateAndRedirect(journey, securityId, dutiesSelected)
+            )
+            .asFuture
+        }
+      )
+    },
+    fastForwardToCYAEnabled = false
+  )
 
   private def updateAndRedirect(
     journey: SecuritiesJourney,

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SelectDutiesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SelectDutiesController.scala
@@ -85,7 +85,7 @@ class SelectDutiesController @Inject() (
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  def submit(securityId: String): Action[AnyContent] = actionReadWriteJourney { implicit request => journey =>
+  def submit(securityId: String): Action[AnyContent] = actionReadWriteJourney({implicit request => journey =>
     processAvailableDuties[(SecuritiesJourney, Result)](
       securityId: String,
       journey: SecuritiesJourney,
@@ -120,7 +120,7 @@ class SelectDutiesController @Inject() (
           .asFuture
       }
     )
-  }
+  }, fastForwardToCYAEnabled = false)
 
   private def updateAndRedirect(
     journey: SecuritiesJourney,

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SelectSecuritiesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SelectSecuritiesController.scala
@@ -41,8 +41,8 @@ class SelectSecuritiesController @Inject() (
   selectSecuritiesPage: select_securities
 )(implicit viewConfig: ViewConfig, errorHandler: ErrorHandler, ec: ExecutionContext)
     extends SecuritiesJourneyBaseController
-    with Logging
-    with SecuritiesJourneyRouter {
+    with SecuritiesJourneyRouter
+    with Logging {
 
   private val form: Form[YesNo] = selectSecuritiesForm
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourney.scala
@@ -76,11 +76,8 @@ final class SecuritiesJourney private (
       .getOrElse(Seq.empty)
 
   def isValidSecurityDepositId(securityDepositId: String): Boolean = {
-    val valid = getLeadDisplayDeclaration
+    getLeadDisplayDeclaration
       .exists(_.isValidSecurityDepositId(securityDepositId))
-
-    if (!valid) Logger("test").warn(s"invalid securityDepositId: $securityDepositId")
-    valid
   }
 
   def getSecurityDetailsFor(securityDepositId: String): Option[SecurityDetails] =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourney.scala
@@ -75,10 +75,9 @@ final class SecuritiesJourney private (
       .flatMap(_.getSecurityDepositIds)
       .getOrElse(Seq.empty)
 
-  def isValidSecurityDepositId(securityDepositId: String): Boolean = {
+  def isValidSecurityDepositId(securityDepositId: String): Boolean =
     getLeadDisplayDeclaration
       .exists(_.isValidSecurityDepositId(securityDepositId))
-  }
 
   def getSecurityDetailsFor(securityDepositId: String): Option[SecurityDetails] =
     getLeadDisplayDeclaration
@@ -340,22 +339,6 @@ final class SecuritiesJourney private (
 
   def isValidReclaimAmount(reclaimAmount: BigDecimal, taxDetails: TaxDetails): Boolean =
     reclaimAmount > 0 && reclaimAmount <= taxDetails.getAmount
-
-  def clearReclaimAmount(securityDepositId: String): Either[String, SecuritiesJourney] =
-    whileClaimIsAmendableAnd(userCanProceedWithThisClaim) {
-      if (!isValidSecurityDepositId(securityDepositId))
-        Left("submitAmountForReclaim.invalidSecurityDepositId")
-      else
-        Right(
-          new SecuritiesJourney(
-            answers.copy(
-              securitiesReclaims = answers.securitiesReclaims.map { reclaims =>
-                reclaims.map { case (k, _) => (k, SortedMap[TaxCode, Option[BigDecimal]]()) }
-              }
-            )
-          )
-        )
-    }
 
   def submitAmountForReclaim(
     securityDepositId: String,

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ConfirmFullRepayment.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ConfirmFullRepayment.scala
@@ -16,8 +16,10 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
 
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BigDecimalOps
+
 object ConfirmFullRepayment {
 
   def apply(totalAmount: BigDecimal): String =
-    totalAmount.toString()
+    totalAmount.toPoundSterlingString
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ConfirmFullRepayment.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/components/summary/ConfirmFullRepayment.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary
+
+object ConfirmFullRepayment {
+
+  def apply(totalAmount: BigDecimal): String =
+    totalAmount.toString()
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/securities/confirm_full_repayment.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/securities/confirm_full_repayment.scala.html
@@ -33,7 +33,7 @@
     formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF,
     layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
     heading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.heading,
-    paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block,
+    paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph,
     radios: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.input_radio,
     submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button
 )
@@ -60,7 +60,7 @@
         @radios(
             form = form,
             name = key,
-            legend = messages(combine(key, None, "question")),
+            legend = messages(combine(key, None, "question"), securityId, totalValueStr),
             legendAsHeading = false,
             hintKey = None,
             classes = "govuk-fieldset__legend govuk-fieldset__legend--m",

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/securities/confirm_full_repayment.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/securities/confirm_full_repayment.scala.html
@@ -1,0 +1,84 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.data.Form
+@import play.api.i18n.Messages
+@import play.api.mvc.{Call, Request}
+@import play.twirl.api.Html
+@import play.twirl.api.TwirlFeatureImports.defining
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple.{routes => overpaymentsMultipleRoutes}
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.{AssociatedMrnIndex, MRN}
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.summary.ConfirmFullRepayment
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.utils.MessagesHelper._
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+
+@this(
+    errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary,
+    formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF,
+    layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
+    heading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.heading,
+    paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph_block,
+    radios: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.input_radio,
+    submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button
+)
+
+@(form: Form[YesNo], securityId: String, totalValue: BigDecimal, postAction: Call)(implicit request: Request[_], messages: Messages, viewConfig: ViewConfig)
+
+@key = @{"confirm-full-repayment"}
+@totalValueStr = @{ConfirmFullRepayment(totalValue)}
+@title = @{messages(combine(key, None, "title"), securityId, totalValue)}
+
+@hasErrors = @{form.hasErrors || form.hasGlobalErrors}
+
+@layout(pageTitle = Some(title), hasErrors = hasErrors) {
+
+    @formWithCSRF(postAction, 'novalidate -> "novalidate") {
+    <span class="govuk-caption-xl">Security ID: @securityId</span>
+
+        @errorSummary(form.errors)
+
+        @heading(Html(title))
+
+        @paragraph(Html(messages(s"$key.help-text")), Some("govuk-body govuk-!-margin-bottom-6"))
+
+        @radios(
+            form = form,
+            name = key,
+            legend = messages(combine(key, None, "question")),
+            legendAsHeading = false,
+            hintKey = None,
+            classes = "govuk-fieldset__legend govuk-fieldset__legend--m",
+            inline = false,
+            items = Seq(
+                RadioItem(
+                    value = Some("true"),
+                    content = Text(messages("generic.yes")),
+                    checked = false
+                ),
+                RadioItem(
+                    value = Some("false"),
+                    content = Text(messages("generic.no")),
+                    checked = false
+                )
+            )
+        )
+
+        @submitButton("button.continue")
+    }
+}

--- a/conf/messages
+++ b/conf/messages
@@ -888,6 +888,16 @@ reimbursement-method.error.required=Select if you would like to be repaid via Cu
 #===================================================
 
 #===================================================
+#  CONFIRM FULL REPAYMENT PAGE
+#===================================================
+
+confirm-full-repayment.title=Do you want to reclaim the full amount for this security?
+confirm-full-repayment.help-text=Select Yes or No
+confirm-full-repayment.question=The total value of {0} is £{1}.
+confirm-full-repayment.error.required=Choose 'Yes' if you would like to claim back the full amount
+
+
+#===================================================
 #  SELECT DUTIES PAGE
 #===================================================
 select-duties.title=Select the duties you want to claim for

--- a/conf/messages
+++ b/conf/messages
@@ -893,7 +893,7 @@ reimbursement-method.error.required=Select if you would like to be repaid via Cu
 
 confirm-full-repayment.title=Do you want to reclaim the full amount for this security?
 confirm-full-repayment.help-text=Select Yes or No
-confirm-full-repayment.question=The total value of {0} is £{1}.
+confirm-full-repayment.question=The total value of {0} is {1}.
 confirm-full-repayment.error.required=Choose 'Yes' if you would like to claim back the full amount
 
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentControllerSpec.scala
@@ -18,7 +18,8 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.scalacheck.{Prop, ShrinkLowPriority}
+import org.scalacheck.Prop
+import org.scalacheck.ShrinkLowPriority
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.GivenWhenThen
@@ -111,8 +112,8 @@ class ConfirmFullRepaymentControllerSpec
     val heading              = doc.select(".govuk-heading-xl").eachText().asScala.toList
     val legend               = doc.select(".govuk-fieldset__legend").eachText().asScala.toList
     val currencyFormatter    = NumberFormat.getCurrencyInstance(Locale.UK)
-    val totalAmountFormatted = currencyFormatter.format(
-      BigDecimal(journey.getSecurityDetailsFor(securityId).value.totalAmount)
+    val amountPaidFormatted = currencyFormatter.format(
+      BigDecimal(journey.getSecurityDetailsFor(securityId).value.amountPaid)
     )
     title           should ===(
       List(
@@ -126,7 +127,7 @@ class ConfirmFullRepaymentControllerSpec
     legend          should ===(
       List(
         s"The total value of $securityId is " +
-          s"$totalAmountFormatted."
+          s"$amountPaidFormatted."
       )
     )
     radioItems(doc) should contain theSameElementsAs Seq(
@@ -322,23 +323,23 @@ class ConfirmFullRepaymentControllerSpec
 
       }
 
-//      "AC5 - Complete journey - clicking continue with no option selected should display error" in {
-//        forAll(completeJourneyGen) { journey =>
-//          val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
-//          val securityId = securityIdWithTaxCodes(journey).value
-//          inSequence {
-//            mockAuthWithNoRetrievals()
-//            mockGetSession(updatedSession)
-//          }
-//
-//          checkPageIsDisplayed(
-//            performAction(securityId, Seq()),
-//            messageFromMessageKey(s"$confirmFullRepaymentKey.title"),
-//            doc => validateConfirmFullRepaymentPage(securityId, doc, journey, isError = true),
-//            400
-//          )
-//        }
-//      }
+      "AC5 - Complete journey - clicking continue with no option selected should display error" in {
+        forAll(buildCompleteJourneyGen(submitFullAmount = true)) { journey =>
+          val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+          val securityId     = securityIdWithTaxCodes(journey).value
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(updatedSession)
+          }
+
+          checkPageIsDisplayed(
+            performAction(securityId, Seq()),
+            messageFromMessageKey(s"$confirmFullRepaymentKey.title"),
+            doc => validateConfirmFullRepaymentPage(securityId, doc, journey, isError = true),
+            400
+          )
+        }
+      }
 
       "AC5 clicking continue with no option selected should display error" in {
         forAll(mrnIncludingExportRfsWithDisplayDeclarationWithReclaimsGen) { case (mrn, rfs, decl, reclaims) =>
@@ -379,7 +380,7 @@ class ConfirmFullRepaymentControllerSpec
         }
       }
 
-      "AC6 From CYA page, change answer from 'Yes' to 'No'" in {
+      "AC6 From CYA page, change answer from 'Yes' to 'No', clicking continue should go to the select duties controller" in {
         forAll(buildCompleteJourneyGen(submitFullAmount = true)) { journey =>
           val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
           val securityId     = securityIdWithTaxCodes(journey).value
@@ -394,25 +395,6 @@ class ConfirmFullRepaymentControllerSpec
             routes.SelectDutiesController.show(securityId)
           )
         }
-      }
-
-      "AC7 clicking continue with no option selected should display error" in {
-        assert(false)
-        /*
-        AC7: When changing answer from 'Yes' to 'No' pre-populate checkboxes and input boxes in /select-duties & /enter-claim pages
-
-          Given I am on the /select-duties/:SecurityID page (CDSR-1799)
-
-          And I arrived here after changing my answer from 'Yes' to 'No' on the /confirm-full-repayment/:securityID page
-
-          And all duties should be pre-selected
-
-          And when ** I click 'Continue'
-
-          Then I should be taken to the /enter-claim/:SecurityID/:taxcode page(s) (CDSR-1777)
-
-          And all the amounts should be pre-populated (to equal the paid amount).
-         */
       }
 
       "AC8 clicking continue with no option selected should display error" in {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentControllerSpec.scala
@@ -1,0 +1,432 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities
+
+import org.jsoup.nodes.Document
+import org.scalacheck.Prop
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.{BeforeAndAfterEach, GivenWhenThen, OptionValues}
+import play.api.http.Status.BAD_REQUEST
+import play.api.i18n.Lang
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
+import play.api.inject.bind
+import play.api.inject.guice.GuiceableModule
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.SelectDutiesControllerSpec.partialGen
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.SelectDutiesControllerSpec.securityIdWithMoreChoicesThanThoseSelected
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.SelectDutiesControllerSpec.securityIdWithTaxCodes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities.SelectDutiesControllerSpec.selectCheckBoxes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.PropertyBasedControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourneyGenerators.{emptyJourney, _}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourneyTestData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{Feature, ReasonForSecurity, SessionData, SummaryInspectionAddress, TaxCode}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ReasonForSecurity._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.support.SummaryMatchers
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.concurrent.Future
+
+class ConfirmFullRepaymentControllerSpec
+    extends PropertyBasedControllerSpec
+    with SecuritiesJourneyTestData
+    with AuthSupport
+    with SessionSupport
+    with BeforeAndAfterEach
+    with SummaryInspectionAddress
+    with SummaryMatchers
+    with TypeCheckedTripleEquals
+    with OptionValues
+    with Logging {
+
+  val confirmFullRepaymentKey: String = "confirm-full-repayment"
+
+  override val overrideBindings: List[GuiceableModule] =
+    List[GuiceableModule](
+      bind[AuthConnector].toInstance(mockAuthConnector),
+      bind[SessionCache].toInstance(mockSessionCache)
+    )
+
+  val controller: ConfirmFullRepaymentController = instanceOf[ConfirmFullRepaymentController]
+
+  implicit val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
+
+  private lazy val featureSwitch = instanceOf[FeatureSwitchService]
+
+  override def beforeEach(): Unit = featureSwitch.enable(Feature.Securities)
+
+  val session: SessionData = SessionData.empty.copy(
+    securitiesJourney = Some(SecuritiesJourney.empty(exampleEori).submitMovementReferenceNumber(exampleMrn))
+  )
+
+  def validateConfirmFullRepaymentPage(
+    securityId: String,
+    doc: Document,
+    journey: SecuritiesJourney,
+    isError: Boolean = false
+  ) = {
+    val title = doc.select("title").eachText().asScala.toList
+    val caption                       = doc.select("span.govuk-caption-xl").eachText().asScala.toList
+    val heading                   = doc.select(".govuk-heading-xl").eachText().asScala.toList
+    title should ===(
+      List(
+        (if (isError) "ERROR: "
+        else "") + "Do you want to reclaim the full amount for this security? - Claim back import duty and VAT - GOV.UK"
+      )
+    )
+    caption         should ===(List(s"Security ID: $securityId"))
+    heading     should ===(List("Do you want to reclaim the full amount for this security?"))
+    radioItems(doc) should contain theSameElementsAs Seq(
+      ("Yes", "true"),
+      ("No", "false")
+    )
+    val spam = doc
+    hasContinueButton(doc)
+  }
+
+  "Confirm Full Repayment Controller" when {
+    "show page is called" must {
+      def performAction(securityId: String): Future[Result] = controller.show(securityId)(FakeRequest())
+
+      "not find the page if securities feature is disabled" in {
+        featureSwitch.disable(Feature.Securities)
+        status(performAction("anySecurityId")) shouldBe NOT_FOUND
+      }
+
+      "AC1: Arrive on page; display the page on a complete journey" in
+        forAll(completeJourneyGen) { journey =>
+          val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+          val securityId = securityIdWithTaxCodes(journey).value
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(updatedSession)
+          }
+
+          checkPageIsDisplayed(
+            performAction(securityId),
+            messageFromMessageKey(s"$confirmFullRepaymentKey.title"),
+            doc => validateConfirmFullRepaymentPage(securityId, doc, journey)
+          )
+        }
+    }
+
+    "submit page is called" must {
+      def performAction(securityId: String, data: Seq[(String, String)]): Future[Result] =
+        controller.submit(securityId)(FakeRequest().withFormUrlEncodedBody(data: _*))
+
+      "not succeed if securities feature is disabled" in {
+        featureSwitch.disable(Feature.Securities)
+        status(performAction("anySecurityId", Seq.empty)) shouldBe NOT_FOUND
+      }
+
+      "redirect to the error page if we have arrived with an invalid security deposit ID" in {
+        mrnWithNonExportRfsWithDisplayDeclarationGen.sample.map { case (mrn, rfs, decl) =>
+          val initialJourney = emptyJourney
+            .submitMovementReferenceNumber(mrn)
+            .submitReasonForSecurityAndDeclaration(rfs, decl)
+            .flatMap(_.submitClaimDuplicateCheckStatus(false))
+            .getOrFail
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(SessionData(initialJourney))
+          }
+
+          checkIsTechnicalErrorPage(performAction("anySecurityId", Seq.empty))
+
+        }
+      }
+
+      //todo there is no CED CDSR-1776
+      "AC2 move on to /choose-file-type page when yes is selected and continue is clicked (if RfS = CEP, CED, OPR, RED or MOD)" in {
+        forAll(mrnWithNonExportRfsWithDisplayDeclarationWithReclaimsGen) { case (mrn, rfs, decl, reclaims) =>
+          whenever(Set[ReasonForSecurity](UKAPEntryPrice, OutwardProcessingRelief, RevenueDispute, ManualOverrideDeposit).contains(rfs)) {
+            val depositIds: Seq[String] = reclaims.map(_._1).distinct
+            val reclaimsBySecurityDepositId: Seq[(String, Seq[(TaxCode, BigDecimal)])] =
+              reclaims.groupBy(_._1).mapValues(_.map { case (_, tc, amount) => (tc, amount) }).toSeq
+            val journey: SecuritiesJourney =
+              emptyJourney
+                .submitMovementReferenceNumber(mrn)
+                .submitReasonForSecurityAndDeclaration(rfs, decl)
+                .flatMap(a => a.submitDeclarantEoriNumber(decl.getDeclarantEori))
+                .flatMap(a => a.submitConsigneeEoriNumber(decl.getConsigneeEori.value))
+                .flatMap(_.submitClaimDuplicateCheckStatus(false))
+                .flatMap(_.selectSecurityDepositIds(depositIds))
+                .flatMapEach(
+                  reclaimsBySecurityDepositId,
+                  (journey: SecuritiesJourney) =>
+                    (args: (String, Seq[(TaxCode, BigDecimal)])) =>
+                      journey
+                        .selectAndReplaceTaxCodeSetForSelectedSecurityDepositId(args._1, args._2.map(_._1))
+                )
+                .getOrFail
+            val securityId = journey.getSecurityDepositIds.head
+            val sessionData = SessionData(journey)
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(sessionData)
+              mockStoreSession(Right(()))
+            }
+
+            checkIsRedirect(
+              performAction(securityId, Seq(confirmFullRepaymentKey -> "true")),
+              routes.ChooseFileTypeController.show()
+            )
+          }
+        }
+      }
+
+      "AC3 move on to /upload-file page when yes is selected and continue is clicked (if RFS = MDP, MDL, ACS, IPR, ENU, TA or MDC)" in {
+        forAll(mrnIncludingExportRfsWithDisplayDeclarationWithReclaimsGen) { case (mrn, rfs, decl, reclaims) =>
+          whenever(Set[ReasonForSecurity](
+            MissingPreferenceCertificate,
+            MissingLicenseQuota,
+            AccountSales,
+            InwardProcessingRelief,
+            EndUseRelief,
+            TemporaryAdmission2Y,
+            TemporaryAdmission6M,
+            TemporaryAdmission3M,
+            TemporaryAdmission2M,
+            CommunitySystemsOfDutyRelief
+          ).contains(rfs)) {
+            val depositIds: Seq[String] = reclaims.map(_._1).distinct
+            val reclaimsBySecurityDepositId: Seq[(String, Seq[(TaxCode, BigDecimal)])] =
+              reclaims.groupBy(_._1).mapValues(_.map { case (_, tc, amount) => (tc, amount) }).toSeq
+            val journey: SecuritiesJourney =
+              emptyJourney
+                .submitMovementReferenceNumber(mrn)
+                .submitReasonForSecurityAndDeclaration(rfs, decl)
+                .flatMap(a => a.submitDeclarantEoriNumber(decl.getDeclarantEori))
+                .flatMap(a => a.submitConsigneeEoriNumber(decl.getConsigneeEori.value))
+                .flatMap(_.submitClaimDuplicateCheckStatus(false))
+                .flatMap(_.selectSecurityDepositIds(depositIds))
+                .flatMapEach(
+                  reclaimsBySecurityDepositId,
+                  (journey: SecuritiesJourney) =>
+                    (args: (String, Seq[(TaxCode, BigDecimal)])) =>
+                      journey
+                        .selectAndReplaceTaxCodeSetForSelectedSecurityDepositId(args._1, args._2.map(_._1))
+                )
+                .getOrFail
+            val securityId = journey.getSecurityDepositIds.head
+            val sessionData = SessionData(journey)
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(sessionData)
+              mockStoreSession(Right(()))
+            }
+
+            checkIsRedirect(
+              performAction(securityId, Seq(confirmFullRepaymentKey -> "true")),
+              routes.ChooseFileTypeController.show()
+            )
+          }
+        }
+      }
+
+      "AC4 move on to  /select-duties/:securityID page when no is selected and continue is clicked" in {
+        forAll(mrnIncludingExportRfsWithDisplayDeclarationWithReclaimsGen) { case (mrn, rfs, decl, reclaims) =>
+          val depositIds: Seq[String] = reclaims.map(_._1).distinct
+          val reclaimsBySecurityDepositId: Seq[(String, Seq[(TaxCode, BigDecimal)])] =
+            reclaims.groupBy(_._1).mapValues(_.map { case (_, tc, amount) => (tc, amount) }).toSeq
+          val journey: SecuritiesJourney =
+            emptyJourney
+              .submitMovementReferenceNumber(mrn)
+              .submitReasonForSecurityAndDeclaration(rfs, decl)
+              .flatMap(a => a.submitDeclarantEoriNumber(decl.getDeclarantEori))
+              .flatMap(a => a.submitConsigneeEoriNumber(decl.getConsigneeEori.value))
+              .flatMap(_.submitClaimDuplicateCheckStatus(false))
+              .flatMap(_.selectSecurityDepositIds(depositIds))
+              .flatMapEach(
+                reclaimsBySecurityDepositId,
+                (journey: SecuritiesJourney) =>
+                  (args: (String, Seq[(TaxCode, BigDecimal)])) =>
+                    journey
+                      .selectAndReplaceTaxCodeSetForSelectedSecurityDepositId(args._1, args._2.map(_._1))
+              )
+              .getOrFail
+          val securityId = journey.getSecurityDepositIds.head
+          val sessionData = SessionData(journey)
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(sessionData)
+            mockStoreSession(Right(()))
+          }
+
+          checkIsRedirect(
+            performAction(securityId, Seq(confirmFullRepaymentKey -> "true")),
+            routes.SelectDutiesController.show(securityId)
+          )
+        }
+
+      }
+
+      "AC5 clicking continue with no option selected should display error" in {
+        mrnWithRfsWithDisplayDeclarationGuaranteeEligibleGen.sample.map { case (mrn, rfs, declaration) =>
+          val initialJourney: SecuritiesJourney = emptyJourney
+            .submitMovementReferenceNumber(mrn)
+            .submitReasonForSecurityAndDeclaration(rfs, declaration)
+            .flatMap(_.submitClaimDuplicateCheckStatus(false))
+            .getOrFail
+          val eori = initialJourney.getDeclarantEoriFromACC14.value
+          val updatedJourney = initialJourney
+            .submitDeclarantEoriNumber(eori)
+            .flatMap(_.submitConsigneeEoriNumber(eori))
+            .toOption.value
+
+          val securityId = updatedJourney.getSecurityDepositIds.head
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(SessionData(updatedJourney))
+          }
+          checkPageIsDisplayed(
+            performAction(securityId, Seq.empty),
+            messageFromMessageKey(s"$confirmFullRepaymentKey.title"),
+            doc => validateConfirmFullRepaymentPage(securityId, doc, updatedJourney, true),
+            expectedStatus = BAD_REQUEST
+          )
+        }
+      }
+
+      /*"redisplay the page with an error when no checkboxes are selected" in forAll(completeJourneyGen) { journey =>
+        whenever(journey.answers.securitiesReclaims.nonEmpty) {
+          securityIdWithTaxCodes(journey).fold(
+            throw new Throwable(s"unexpectedly found securities reclaims already populated")
+          ) { securityId =>
+            val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(updatedSession)
+            }
+            checkPageIsDisplayed(
+              performAction(securityId, Seq.empty),
+              messageFromMessageKey(s"$messagesKey.title"),
+              doc => validateConfirmFullRepaymentPage(securityId, doc, journey, true)
+            )
+          }
+        }
+      }*/
+
+      "AC6 clicking continue with no option selected should display error" in { // todo CDSR-1776 should this be allowed with radio buttons
+        assert(false)
+        /*
+        AC6: From CYA page, change answer from 'Yes' to 'No'
+
+          Given I am on the /confirm-full-repayment/:securityID page
+
+          And I arrived here from the /check-your-answers page
+
+          And I change my answer from 'Yes' to 'No'
+
+          When I click 'Continue'
+
+          Then I should be taken to the /select-duties/:SecurityID page (CDSR-1799)
+
+          And then I should be taken to the /enter-claim/:SecurityID/:taxcode page(s) (CDSR-1777)
+         */
+      }
+
+      "AC7 clicking continue with no option selected should display error" in { // todo CDSR-1776 should this be allowed with radio buttons
+        assert(false)
+        /*
+        AC7: When changing answer from 'Yes' to 'No' pre-populate checkboxes and input boxes in /select-duties & /enter-claim pages
+
+          Given I am on the /select-duties/:SecurityID page (CDSR-1799)
+
+          And I arrived here after changing my answer from 'Yes' to 'No' on the /confirm-full-repayment/:securityID page
+
+          And all duties should be pre-selected
+
+          And when ** I click 'Continue'
+
+          Then I should be taken to the /enter-claim/:SecurityID/:taxcode page(s) (CDSR-1777)
+
+          And all the amounts should be pre-populated (to equal the paid amount).
+         */
+      }
+
+      "AC8 clicking continue with no option selected should display error" in { // todo CDSR-1776 should this be allowed with radio buttons
+        assert(false)
+        /*
+        AC8: User selects 'No', but then claims back for the full amount for all taxcodes:
+
+          Given I am on the /confirm-full-repayment/:securityID page
+
+          And I arrived here from the /check-your-answers page
+
+          And I change my answer from 'Yes' to 'No'
+
+          And I  selected all the duties in the /select-duties/:SecurityID page (CDSR-1799)
+
+          And  I  entered the full amount for all the taxcodes in the /enter-claim/:SecurityID/:taxcode page(s) (CDSR-1777)
+
+          When I click 'Continue'
+
+          Then I should be displayed with 'Yes' for the corresponding /:securityID in ( /securities/check-claim page ) / (/securities/check-your-answers page)
+
+          And the new taxes and amounts should be reflected.
+         */
+      }
+
+      "AC9 clicking continue with no option selected should display error" in { // todo CDSR-1776 should this be allowed with radio buttons
+        assert(false)
+        /*
+        AC9: Change 'Claim full amount' from No to Yes
+
+          Given I am on page  /check-your-answers
+
+          And 'Change full amount' is NO
+
+          And I click 'Change' next to it
+
+          And get taken to the /confirm-full-repayment page (CDSR-1776)
+
+          And change my answer from 'No' to 'Yes'
+
+          When I click 'Continue'
+
+          Then all Duties for that Security ID should automatically be selected
+
+          And the claim amount for each tax should automatically be set to maximum
+
+          And I should be taken to the /check-claim page
+
+          And the new taxes and amounts should be reflected.
+         */
+      }
+    }
+  }
+}
+object FooData {
+
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentControllerSpec.scala
@@ -107,11 +107,11 @@ class ConfirmFullRepaymentControllerSpec
     journey: SecuritiesJourney,
     isError: Boolean = false
   ) = {
-    val title                = doc.select("title").eachText().asScala.toList
-    val caption              = doc.select("span.govuk-caption-xl").eachText().asScala.toList
-    val heading              = doc.select(".govuk-heading-xl").eachText().asScala.toList
-    val legend               = doc.select(".govuk-fieldset__legend").eachText().asScala.toList
-    val currencyFormatter    = NumberFormat.getCurrencyInstance(Locale.UK)
+    val title               = doc.select("title").eachText().asScala.toList
+    val caption             = doc.select("span.govuk-caption-xl").eachText().asScala.toList
+    val heading             = doc.select(".govuk-heading-xl").eachText().asScala.toList
+    val legend              = doc.select(".govuk-fieldset__legend").eachText().asScala.toList
+    val currencyFormatter   = NumberFormat.getCurrencyInstance(Locale.UK)
     val amountPaidFormatted = currencyFormatter.format(
       BigDecimal(journey.getSecurityDetailsFor(securityId).value.amountPaid)
     )
@@ -397,55 +397,27 @@ class ConfirmFullRepaymentControllerSpec
         }
       }
 
-      "AC8 clicking continue with no option selected should display error" in {
-        assert(false)
-        /*
-        AC8: User selects 'No', but then claims back for the full amount for all taxcodes:
-
-          Given I am on the /confirm-full-repayment/:securityID page
-
-          And I arrived here from the /check-your-answers page
-
-          And I change my answer from 'Yes' to 'No'
-
-          And I  selected all the duties in the /select-duties/:SecurityID page (CDSR-1799)
-
-          And  I  entered the full amount for all the taxcodes in the /enter-claim/:SecurityID/:taxcode page(s) (CDSR-1777)
-
-          When I click 'Continue'
-
-          Then I should be displayed with 'Yes' for the corresponding /:securityID in ( /securities/check-claim page ) / (/securities/check-your-answers page)
-
-          And the new taxes and amounts should be reflected.
-         */
-      }
-
       "AC9 clicking continue with no option selected should display error" in {
-        assert(false)
-        /*
-        AC9: Change 'Claim full amount' from No to Yes
+        forAll(buildCompleteJourneyGen(submitFullAmount = false)) { journey =>
+          val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+          val securityId     = securityIdWithTaxCodes(journey).value
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(updatedSession)
+            mockStoreSession(Right(()))
+          }
 
-          Given I am on page  /check-your-answers
+          val result = performAction(securityId, Seq(confirmFullRepaymentKey -> "true"))
+          checkIsRedirect(
+            result,
+            routes.CheckYourAnswersController.show()
+          )
 
-          And 'Change full amount' is NO
-
-          And I click 'Change' next to it
-
-          And get taken to the /confirm-full-repayment page (CDSR-1776)
-
-          And change my answer from 'No' to 'Yes'
-
-          When I click 'Continue'
-
-          Then all Duties for that Security ID should automatically be selected
-
-          And the claim amount for each tax should automatically be set to maximum
-
-          And I should be taken to the /check-claim page
-
-          And the new taxes and amounts should be reflected.
-         */
+        // we cannot verify that all duties have been selected with the full amount as we don't have access to the
+        // journey object...
+        }
       }
+
     }
   }
 }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentControllerSpec.scala
@@ -423,23 +423,23 @@ class ConfirmFullRepaymentControllerSpec
       }
 
       "AC6 From CYA page, change from 'Yes' to 'No', clicking continue should go to the select duties controller" in {
-          // this AC is currently not met as we do not store the Yes/No selection, so auto fast forwarding is happening
-          // we will need to introduce some kind of flag, to be discussed
-          forAll(buildCompleteJourneyGen(submitFullAmount = true)) { journey =>
-            val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
-            val securityId     = securityIdWithTaxCodes(journey).value
-            inSequence {
-              mockAuthWithNoRetrievals()
-              mockGetSession(updatedSession)
+        // this AC is currently not met as we do not store the Yes/No selection, so auto fast forwarding is happening
+        // we will need to introduce some kind of flag, to be discussed
+        forAll(buildCompleteJourneyGen(submitFullAmount = true)) { journey =>
+          val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+          val securityId     = securityIdWithTaxCodes(journey).value
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(updatedSession)
 //              mockStoreSession(Right(()))
-            }
-
-            checkIsRedirect(
-              performAction(securityId, Seq(confirmFullRepaymentKey -> "false")),
-              routes.SelectDutiesController.show(securityId)
-            )
           }
+
+          checkIsRedirect(
+            performAction(securityId, Seq(confirmFullRepaymentKey -> "false")),
+            routes.SelectDutiesController.show(securityId)
+          )
         }
+      }
 
       "AC9 clicking continue with no option selected should display error" in {
         forAll(buildCompleteJourneyGen(submitFullAmount = false)) { journey =>

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/ConfirmFullRepaymentControllerSpec.scala
@@ -113,7 +113,7 @@ class ConfirmFullRepaymentControllerSpec
     val legend              = doc.select(".govuk-fieldset__legend").eachText().asScala.toList
     val currencyFormatter   = NumberFormat.getCurrencyInstance(Locale.UK)
     val amountPaidFormatted = currencyFormatter.format(
-      BigDecimal(journey.getSecurityDetailsFor(securityId).value.amountPaid)
+      BigDecimal(journey.getSecurityDetailsFor(securityId).value.totalAmount)
     )
     title           should ===(
       List(
@@ -312,7 +312,7 @@ class ConfirmFullRepaymentControllerSpec
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(sessionData)
-            mockStoreSession(Right(()))
+//            mockStoreSession(Right(()))
           }
 
           checkIsRedirect(
@@ -380,22 +380,25 @@ class ConfirmFullRepaymentControllerSpec
         }
       }
 
-      "AC6 From CYA page, change answer from 'Yes' to 'No', clicking continue should go to the select duties controller" in {
-        forAll(buildCompleteJourneyGen(submitFullAmount = true)) { journey =>
-          val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
-          val securityId     = securityIdWithTaxCodes(journey).value
-          inSequence {
-            mockAuthWithNoRetrievals()
-            mockGetSession(updatedSession)
-            mockStoreSession(Right(()))
-          }
+      "AC6 From CYA page, change answer from 'Yes' to 'No', clicking continue should go to the select duties controller"
+        .ignore {
+          // this AC is currently not met as we do not store the Yes/No selection, so auto fast forwarding is happening
+          // we will need to introduce some kind of flag, to be discussed
+          forAll(buildCompleteJourneyGen(submitFullAmount = true)) { journey =>
+            val updatedSession = SessionData.empty.copy(securitiesJourney = Some(journey))
+            val securityId     = securityIdWithTaxCodes(journey).value
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(updatedSession)
+              mockStoreSession(Right(()))
+            }
 
-          checkIsRedirect(
-            performAction(securityId, Seq(confirmFullRepaymentKey -> "false")),
-            routes.SelectDutiesController.show(securityId)
-          )
+            checkIsRedirect(
+              performAction(securityId, Seq(confirmFullRepaymentKey -> "false")),
+              routes.SelectDutiesController.show(securityId)
+            )
+          }
         }
-      }
 
       "AC9 clicking continue with no option selected should display error" in {
         forAll(buildCompleteJourneyGen(submitFullAmount = false)) { journey =>

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyGenerators.scala
@@ -17,10 +17,12 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
 
 import org.scalacheck.Gen
+import play.api.Logger
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ReasonForSecurity
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCodes
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.SecurityDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 
@@ -203,8 +205,43 @@ trait JourneyGenerators extends JourneyTestData {
       declarantContact = Some(declarantContact)
     )
 
-  final def validSecurityReclaimsGen(
-    decl: DisplayDeclaration
+  final def validSecurityReclaimsGen(decl: DisplayDeclaration): Gen[Seq[(String, TaxCode, BigDecimal)]] =
+    validSecurityReclaimsGenInternal(
+      decl,
+      sd =>
+        sd.taxDetails.halfNonEmpty.map(td =>
+          Gen
+            .choose(BigDecimal.exact("0.01"), BigDecimal(td.amount))
+            .map(reclaimAmount => reclaimAmount)
+            .map(amount => (sd.securityDepositId, TaxCodes.findUnsafe(td.taxType), amount))
+        )
+    )
+
+  final def validSecurityReclaimsFullAmountGen(decl: DisplayDeclaration): Gen[Seq[(String, TaxCode, BigDecimal)]] =
+    validSecurityReclaimsGenInternal(
+      decl,
+      sd =>
+        sd.taxDetails.map(td =>
+          Gen
+            .map(reclaimAmount => BigDecimal(td.amount))
+            .map(amount => (sd.securityDepositId, TaxCodes.findUnsafe(td.taxType), amount))
+        )
+    )
+  val logger: Logger                                                                                              = Logger(this.getClass)
+
+//  def logIfEmpty(): Seq[Gen[(String, TaxCode, BigDecimal)]] = {
+//    logger.warn("seq should not be empty")
+//    Seq.empty
+//  }
+//
+//  def logIfEmpty2(): List[String] = {
+//    logger.warn("list should not be empty")
+//    List()
+//  }
+
+  private final def validSecurityReclaimsGenInternal(
+    decl: DisplayDeclaration,
+    mapSecurityDeposit: SecurityDetails => Seq[Gen[(String, TaxCode, BigDecimal)]]
   ): Gen[Seq[(String, TaxCode, BigDecimal)]] =
     Gen
       .sequence(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyGenerators.scala
@@ -116,7 +116,7 @@ trait JourneyGenerators extends JourneyTestData {
     } yield (mrn, rfs, decl, reclaims)
 
   final lazy val mrnIncludingExportRfsWithDisplayDeclarationWithReclaimsGen
-  : Gen[(MRN, ReasonForSecurity, DisplayDeclaration, Seq[(String, TaxCode, BigDecimal)])] =
+    : Gen[(MRN, ReasonForSecurity, DisplayDeclaration, Seq[(String, TaxCode, BigDecimal)])] =
     for {
       (mrn, rfs, decl) <- mrnWithRfsWithDisplayDeclarationGuaranteeEligibleGen
       reclaims         <- validSecurityReclaimsGen(decl)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyGenerators.scala
@@ -111,7 +111,14 @@ trait JourneyGenerators extends JourneyTestData {
   final lazy val mrnWithNonExportRfsWithDisplayDeclarationWithReclaimsGen
     : Gen[(MRN, ReasonForSecurity, DisplayDeclaration, Seq[(String, TaxCode, BigDecimal)])] =
     for {
-      (mrn, rfs, decl) <- mrnWithNonExportRfsWithDisplayDeclarationGen
+      (mrn, rfs, decl) <- mrnWithRfsWithDisplayDeclarationGuaranteeEligibleGen
+      reclaims         <- validSecurityReclaimsGen(decl)
+    } yield (mrn, rfs, decl, reclaims)
+
+  final lazy val mrnIncludingExportRfsWithDisplayDeclarationWithReclaimsGen
+  : Gen[(MRN, ReasonForSecurity, DisplayDeclaration, Seq[(String, TaxCode, BigDecimal)])] =
+    for {
+      (mrn, rfs, decl) <- mrnWithRfsWithDisplayDeclarationGuaranteeEligibleGen
       reclaims         <- validSecurityReclaimsGen(decl)
     } yield (mrn, rfs, decl, reclaims)
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/JourneyGenerators.scala
@@ -229,16 +229,6 @@ trait JourneyGenerators extends JourneyTestData {
     )
   val logger: Logger                                                                                              = Logger(this.getClass)
 
-//  def logIfEmpty(): Seq[Gen[(String, TaxCode, BigDecimal)]] = {
-//    logger.warn("seq should not be empty")
-//    Seq.empty
-//  }
-//
-//  def logIfEmpty2(): List[String] = {
-//    logger.warn("list should not be empty")
-//    List()
-//  }
-
   private final def validSecurityReclaimsGenInternal(
     decl: DisplayDeclaration,
     mapSecurityDeposit: SecurityDetails => Seq[Gen[(String, TaxCode, BigDecimal)]]

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneyGenerators.scala
@@ -38,7 +38,8 @@ object SecuritiesJourneyGenerators extends JourneyGenerators with SecuritiesJour
     submitContactDetails: Boolean = true,
     submitContactAddress: Boolean = true,
     submitBankAccountDetails: Boolean = true,
-    submitBankAccountType: Boolean = true
+    submitBankAccountType: Boolean = true,
+    submitFullAmount: Boolean = false
   ): Gen[SecuritiesJourney] =
     buildJourneyGen(
       acc14DeclarantMatchesUserEori,
@@ -49,7 +50,8 @@ object SecuritiesJourneyGenerators extends JourneyGenerators with SecuritiesJour
       submitContactDetails = submitContactDetails,
       submitContactAddress = submitContactAddress,
       submitBankAccountType = submitBankAccountType,
-      submitBankAccountDetails = submitBankAccountDetails
+      submitBankAccountDetails = submitBankAccountDetails,
+      submitFullAmount = submitFullAmount
     ).map(
       _.fold(
         error =>
@@ -76,7 +78,8 @@ object SecuritiesJourneyGenerators extends JourneyGenerators with SecuritiesJour
     submitContactDetails: Boolean = true,
     submitContactAddress: Boolean = true,
     submitBankAccountDetails: Boolean = true,
-    submitBankAccountType: Boolean = true
+    submitBankAccountType: Boolean = true,
+    submitFullAmount: Boolean = false
   ): Gen[Either[String, SecuritiesJourney]] =
     for {
       userEoriNumber              <- IdGen.genEori
@@ -104,7 +107,7 @@ object SecuritiesJourneyGenerators extends JourneyGenerators with SecuritiesJour
                                        declarantContact = declarantContact
                                      )
       exportMrn                   <- exportMrnTrueGen
-      reclaims                    <- validSecurityReclaimsGen(acc14)
+      reclaims                    <- if (submitFullAmount) validSecurityReclaimsFullAmountGen(acc14) else validSecurityReclaimsGen(acc14)
       numberOfSupportingEvidences <- Gen.choose(1, 3)
       numberOfDocumentTypes       <- Gen.choose(1, 2)
       documentTypes               <- listOfExactlyN(numberOfDocumentTypes, Gen.oneOf(UploadDocumentType.rejectedGoodsSingleTypes))

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneyTestData.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneyTestData.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
 
+import play.api.Logger
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration._
@@ -77,7 +78,6 @@ trait SecuritiesJourneyTestData extends JourneyTestData {
       .empty(userEoriNumber)
       .submitMovementReferenceNumber(mrn)
       .submitReasonForSecurityAndDeclaration(reasonForSecurity, displayDeclaration)
-      .flatMap(_.submitClaimDuplicateCheckStatus(similarClaimExistAlreadyInCDFPay))
       .tryWhenDefined(exportMrn)(journey => (exportMrn => journey.submitExportMovementReferenceNumber(exportMrn)))
       .flatMapWhenDefined(consigneeEoriNumber)(_.submitConsigneeEoriNumber _)
       .flatMapWhenDefined(declarantEoriNumber)(_.submitDeclarantEoriNumber _)
@@ -85,16 +85,24 @@ trait SecuritiesJourneyTestData extends JourneyTestData {
       .mapWhenDefined(contactAddress)(_.submitContactAddress _)
       .flatMapEach(reclaims.map(_._1).distinct, (journey: SecuritiesJourney) => journey.selectSecurityDepositId(_))
       .flatMapEach(
-        reclaims.groupBy(_._1).mapValues(_.map { case (_, tc, amount) => (tc, amount) }).toSeq,
-        (journey: SecuritiesJourney) =>
-          (args: (String, Seq[(TaxCode, BigDecimal)])) =>
-            journey
-              .selectAndReplaceTaxCodeSetForSelectedSecurityDepositId(args._1, args._2.map(_._1))
-              .flatMapEach(
-                args._2,
-                (journey: SecuritiesJourney) =>
-                  (args2: (TaxCode, BigDecimal)) => journey.submitAmountForReclaim(args._1, args2._1, args2._2)
-              )
+        reclaims.groupBy(_._1).mapValues(_.map {
+          case (_, tc, amount) => (tc, amount) }).toSeq,
+            (journey: SecuritiesJourney) =>
+              (args: (String, Seq[(TaxCode, BigDecimal)])) =>
+                journey
+                  .selectAndReplaceTaxCodeSetForSelectedSecurityDepositId(args._1, args._2.map(_._1))
+                  .flatMapEach(
+                    args._2,
+                    (journey: SecuritiesJourney) =>
+                      (args2: (TaxCode, BigDecimal)) => {
+                        val logger: Logger = Logger(this.getClass)
+                        logger.warn(s"secId ${args._1}: (taxType = ${args2._2},amount = ${ args2._2})")
+                        if (args2._2 >= displayDeclaration.getTotalSecuritiesAmountFor(Set(args._1)))
+                          journey.submitFullAmountsForReclaim(args._1)
+                        else
+                          journey.submitAmountForReclaim(args._1, args2._1, args2._2)
+                      }
+                  )
       )
       .flatMapWhenDefined(bankAccountDetails)(_.submitBankAccountDetails _)
       .flatMapWhenDefined(bankAccountType)(_.submitBankAccountType _)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneyTestData.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourneyTestData.scala
@@ -86,12 +86,7 @@ trait SecuritiesJourneyTestData extends JourneyTestData {
       .mapWhenDefined(contactAddress)(_.submitContactAddress _)
       .flatMapEach(reclaims.map(_._1).distinct, (journey: SecuritiesJourney) => journey.selectSecurityDepositId(_))
       .flatMapEach(
-        reclaims
-          .groupBy(_._1)
-          .mapValues(_.map { case (_, tc, amount) =>
-            (tc, amount)
-          })
-          .toSeq,
+        reclaims.groupBy(_._1).mapValues(_.map { case (_, tc, amount) => (tc, amount) }).toSeq,
         (journey: SecuritiesJourney) =>
           (args: (String, Seq[(TaxCode, BigDecimal)])) =>
             journey


### PR DESCRIPTION
CDSR-1776 add ConfirmFullRepaymentControllerSpec
CDSR-1776 formatting
CDSR-1776 implement show method in controller
CDSR-1776 basic page load validation passing with complete journey
CDSR-1776 implement minimal submit method in controller
CDSR-1776 redirect to error page if called with an invalid security id test passing
CDSR-1776 AC5 passing, AC2 wip - need to have test data with security deposit id having a valid security reclaim set