### PR TITLE
CDSR-1560 Securities | US1:AC9 /enter-bank-details

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Forms.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/Forms.scala
@@ -148,9 +148,9 @@ object Forms {
 
   val enterBankDetailsForm: Form[BankAccountDetails] = Form(
     mapping(
-      "enter-bank-details.account-name"   -> accountNameMapping,
-      "enter-bank-details.sort-code"      -> sortCodeMapping,
-      "enter-bank-details.account-number" -> accountNumberMapping
+      "enter-bank-account-details.account-name"   -> accountNameMapping,
+      "enter-bank-account-details.sort-code"      -> sortCodeMapping,
+      "enter-bank-account-details.account-number" -> accountNumberMapping
     )(BankAccountDetails.apply)(BankAccountDetails.unapply)
   )
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/EnterBankAccountDetailsMixin.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/EnterBankAccountDetailsMixin.scala
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins
+
+import cats._
+import cats.data._
+import cats.implicits._
+import cats.syntax.all._
+import play.api.i18n.Messages
+import play.api.mvc.Results.BadRequest
+import play.api.mvc.Results.Redirect
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Call
+import play.api.mvc.Request
+import play.api.mvc.Result
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ServiceUnavailableError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled.routes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.Claim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.CdsError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.Indeterminate
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.No
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.Yes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.{Error => ReputationResponseError, _}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Syntax._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_bank_account_details
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+trait EnterBankAccountDetailsMixin {
+  this: Logging =>
+
+  implicit def enterBankAccountDetailsPage: enter_bank_account_details
+
+  trait JourneyWithBankAccount[T <: Claim[_]] {
+    def bankAccountType: Option[BankAccountType]
+    def submitBankAccountDetails(bankAccountDetails: BankAccountDetails): Either[String, T]
+  }
+
+  object JourneyWithSubmitBankAccount {
+    def instance[T <: Claim[_]](
+      journeyBankAccountType: => Option[BankAccountType],
+      journeySubmitBankAccountDetails: BankAccountDetails => Either[String, T]
+    ): JourneyWithBankAccount[T]                             = new JourneyWithBankAccount[T] {
+      def bankAccountType: Option[BankAccountType]                                            = journeyBankAccountType
+      def submitBankAccountDetails(bankAccountDetails: BankAccountDetails): Either[String, T] =
+        journeySubmitBankAccountDetails(bankAccountDetails)
+    }
+    // todo CDSR-1869 move this to
+    //  uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled.EnterBankAccountDetailsController
+    implicit def rejectedGoodsScheduledJourneyWithBankAccount(implicit
+      journey: RejectedGoodsScheduledJourney
+    ): JourneyWithBankAccount[RejectedGoodsScheduledJourney] =
+      instance(journey.answers.bankAccountType, journey.submitBankAccountDetails)
+  }
+
+  protected def handleBadReputation(
+    bankAccountDetails: BankAccountDetails,
+    reputation: BankAccountReputation,
+    postAction: Call
+  )(implicit
+    request: Request[_],
+    viewConfig: ViewConfig,
+    enterBankAccountDetailsPage: enter_bank_account_details,
+    messages: Messages
+  ): Result =
+    reputation match {
+      case BankAccountReputation(_, _, Some(errorResponse))                                                   =>
+        BadRequest(
+          enterBankAccountDetailsPage(
+            enterBankDetailsForm
+              .fill(bankAccountDetails)
+              .withError("enter-bank-account-details", s"error.${errorResponse.code}"),
+            postAction
+          )
+        )
+      case BankAccountReputation(Yes, Some(ReputationResponseError), None)                                    =>
+        BadRequest(
+          enterBankAccountDetailsPage(
+            enterBankDetailsForm
+              .fill(bankAccountDetails)
+              .withError("enter-bank-account-details", "error.account-exists-error"),
+            postAction
+          )
+        )
+      case BankAccountReputation(Yes, Some(No), None) | BankAccountReputation(Yes, Some(Indeterminate), None) =>
+        BadRequest(
+          enterBankAccountDetailsPage(
+            enterBankDetailsForm
+              .withError("enter-bank-account-details", "error.account-does-not-exist"),
+            postAction
+          )
+        )
+      case BankAccountReputation(No, _, None) | BankAccountReputation(ReputationResponseError, _, None)       =>
+        BadRequest(
+          enterBankAccountDetailsPage(
+            enterBankDetailsForm
+              .withError("enter-bank-account-details", "error.moc-check-no"),
+            postAction
+          )
+        )
+      case BankAccountReputation(Indeterminate, _, None)                                                      =>
+        BadRequest(
+          enterBankAccountDetailsPage(
+            enterBankDetailsForm
+              .withError("enter-bank-account-details", "error.moc-check-failed"),
+            postAction
+          )
+        )
+
+      case default: BankAccountReputation =>
+        logger.info(s"Reached default case - response: [$default]")
+        BadRequest(
+          enterBankAccountDetailsPage(
+            enterBankDetailsForm
+              .fill(bankAccountDetails)
+              .withError("enter-bank-account-details", "error.account-does-not-exist"),
+            postAction
+          )
+        )
+    }
+
+  protected def processCdsError[T : CdsError](error: T, errorPage: Call)(implicit
+    request: Request[_],
+    errorHandler: ErrorHandler
+  ): Result =
+    error match {
+      case e @ ServiceUnavailableError(_, _) =>
+        logger.warn(s"could not contact bank account service: $e")
+        Redirect(errorPage)
+      case e                                 =>
+        logAndDisplayError("could not process bank account details: ", e)
+    }
+
+  case class NextPage(
+    errorPath: Call,
+    retryPath: Call,
+    successPath: Call,
+    submitPath: Call,
+    getBankAccountTypePath: Call
+  )
+
+  private def processBankAccountReputation[T <: Claim[T]](
+    journey: T,
+    bankAccountReputation: BankAccountReputation,
+    bankAccountDetails: BankAccountDetails,
+    nextPage: NextPage
+  )(implicit
+    journeyWithBankAccount: JourneyWithBankAccount[T],
+    request: Request[_],
+    viewConfig: ViewConfig,
+    messages: Messages
+  ): (T, Result) = bankAccountReputation match {
+    case BankAccountReputation(Yes, Some(Yes), None) =>
+      journeyWithBankAccount
+        .submitBankAccountDetails(bankAccountDetails)
+        .fold(
+          error => {
+            logger.warn(s"cannot submit bank account details because of $error")
+            (
+              journey,
+              Redirect(nextPage.retryPath)
+            )
+          },
+          modifiedJourney =>
+            (
+              modifiedJourney,
+              Redirect(nextPage.successPath)
+            )
+        )
+    case badReputation                               =>
+      (journey, handleBadReputation(bankAccountDetails, badReputation, nextPage.submitPath))
+  }
+
+  private def getBankAccountType[T <: Claim[T]](journey: T, getBankAccountTypePage: Call)(implicit
+    journeyWithBankAccount: JourneyWithBankAccount[T]
+  ) =
+    journeyWithBankAccount.bankAccountType
+      .toRight((journey, Redirect(getBankAccountTypePage)))
+
+  protected def validateBankAccountDetails[T <: Claim[T]](
+    journey: T,
+    bankAccountDetails: BankAccountDetails,
+    postCode: Option[String],
+    nextPage: NextPage
+  )(implicit
+    journeyWithBankAccount: JourneyWithBankAccount[T],
+    bankAccountReputationService: BankAccountReputationService,
+    hc: HeaderCarrier,
+    request: Request[_],
+    viewConfig: ViewConfig,
+    errorHandler: ErrorHandler,
+    messages: Messages,
+    executionContext: ExecutionContext
+  ): Future[(T, Result)] =
+    getBankAccountType(journey, nextPage.getBankAccountTypePath)
+      .fold(
+        identity(_).asFuture: Future[(T, Result)],
+        bankAccountType =>
+          bankAccountReputationService
+            .checkBankAccountReputation(bankAccountType, bankAccountDetails, postCode)
+            .fold(
+              e => (journey, processCdsError(e, nextPage.errorPath)),
+              bankAccountReputation =>
+                processBankAccountReputation(journey, bankAccountReputation, bankAccountDetails, nextPage)
+            )
+      )
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/BankAccountController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/BankAccountController.scala
@@ -49,7 +49,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationS
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.util.toFuture
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.check_bank_account_details
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_bank_account_details
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -65,8 +66,8 @@ class BankAccountController @Inject() (
   val config: Configuration,
   val claimService: ClaimService,
   val bankAccountReputationService: BankAccountReputationService,
-  checkBankAccountDetailsPage: pages.check_bank_account_details,
-  enterBankAccountDetailsPage: pages.enter_bank_account_details
+  checkBankAccountDetailsPage: check_bank_account_details,
+  enterBankAccountDetailsPage: enter_bank_account_details
 )(implicit viewConfig: ViewConfig, ec: ExecutionContext, errorHandler: ErrorHandler)
     extends FrontendController(cc)
     with WithAuthAndSessionDataAction
@@ -160,24 +161,24 @@ class BankAccountController @Inject() (
       val errorKey = bankAccountReputation.otherError.map(_.code).getOrElse("account-does-not-exist")
       val form     = enterBankDetailsForm
         .fill(bankAccountDetails)
-        .withError("enter-bank-details", s"error.$errorKey")
+        .withError("enter-bank-account-details", s"error.$errorKey")
       BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
     } else if (bankAccountReputation.accountNumberWithSortCodeIsValid === ReputationResponse.No) {
       val form = enterBankDetailsForm
-        .withError("enter-bank-details", "error.moc-check-no")
+        .withError("enter-bank-account-details", "error.moc-check-no")
       BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
     } else if (bankAccountReputation.accountNumberWithSortCodeIsValid =!= ReputationResponse.Yes) {
       val form = enterBankDetailsForm
-        .withError("enter-bank-details", "error.moc-check-failed")
+        .withError("enter-bank-account-details", "error.moc-check-failed")
       BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
     } else if (bankAccountReputation.accountExists === Some(ReputationResponse.Error)) {
       val form = enterBankDetailsForm
         .fill(bankAccountDetails)
-        .withError("enter-bank-details", s"error.account-exists-error")
+        .withError("enter-bank-account-details", s"error.account-exists-error")
       BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
     } else if (bankAccountReputation.accountExists =!= Some(ReputationResponse.Yes)) {
       val form = enterBankDetailsForm
-        .withError("enter-bank-details", s"error.account-does-not-exist")
+        .withError("enter-bank-account-details", s"error.account-does-not-exist")
       BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
     } else {
       Redirect(OverpaymentsRoutes.BankAccountController.checkBankAccountDetails(journey))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/BankAccountController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/BankAccountController.scala
@@ -49,7 +49,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationS
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.util.toFuture
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.check_bank_account_details
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_bank_account_details
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -65,8 +66,8 @@ class BankAccountController @Inject() (
   val config: Configuration,
   val claimService: ClaimService,
   val bankAccountReputationService: BankAccountReputationService,
-  checkBankAccountDetailsPage: pages.check_bank_account_details,
-  enterBankAccountDetailsPage: pages.enter_bank_account_details
+  checkBankAccountDetailsPage: check_bank_account_details,
+  enterBankAccountDetailsPage: enter_bank_account_details
 )(implicit viewConfig: ViewConfig, ec: ExecutionContext, errorHandler: ErrorHandler)
     extends FrontendController(cc)
     with WithAuthAndSessionDataAction
@@ -132,7 +133,7 @@ class BankAccountController @Inject() (
     error match {
       case e @ ServiceUnavailableError(_, _) =>
         logger.warn(s"could not contact bank account service: $e")
-        Redirect(commonRoutes.ServiceUnavailableController.show)
+        Redirect(commonRoutes.ServiceUnavailableController.show())
       case e                                 =>
         logAndDisplayError("could not process bank account details: ", e)
     }
@@ -160,24 +161,24 @@ class BankAccountController @Inject() (
       val errorKey = bankAccountReputation.otherError.map(_.code).getOrElse("account-does-not-exist")
       val form     = enterBankDetailsForm
         .fill(bankAccountDetails)
-        .withError("enter-bank-details", s"error.$errorKey")
+        .withError("enter-bank-account-details", s"error.$errorKey")
       BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
     } else if (bankAccountReputation.accountNumberWithSortCodeIsValid === ReputationResponse.No) {
       val form = enterBankDetailsForm
-        .withError("enter-bank-details", "error.moc-check-no")
+        .withError("enter-bank-account-details", "error.moc-check-no")
       BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
     } else if (bankAccountReputation.accountNumberWithSortCodeIsValid =!= ReputationResponse.Yes) {
       val form = enterBankDetailsForm
-        .withError("enter-bank-details", "error.moc-check-failed")
+        .withError("enter-bank-account-details", "error.moc-check-failed")
       BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
     } else if (bankAccountReputation.accountExists === Some(ReputationResponse.Error)) {
       val form = enterBankDetailsForm
         .fill(bankAccountDetails)
-        .withError("enter-bank-details", s"error.account-exists-error")
+        .withError("enter-bank-account-details", s"error.account-exists-error")
       BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
     } else if (bankAccountReputation.accountExists =!= Some(ReputationResponse.Yes)) {
       val form = enterBankDetailsForm
-        .withError("enter-bank-details", s"error.account-does-not-exist")
+        .withError("enter-bank-account-details", s"error.account-does-not-exist")
       BadRequest(enterBankAccountDetailsPage(form, router.submitUrlForEnterBankAccountDetails()))
     } else {
       Redirect(OverpaymentsRoutes.BankAccountController.checkBankAccountDetails(journey))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/EnterBankAccountDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/EnterBankAccountDetailsController.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.Ba
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.{Error => ReputationResponseError, _}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_bank_account_details
 
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -47,11 +47,11 @@ class EnterBankAccountDetailsController @Inject() (
   val jcc: JourneyControllerComponents,
   val claimService: ClaimService,
   val bankAccountReputationService: BankAccountReputationService,
-  enterBankAccountDetailsPage: pages.enter_bank_account_details
+  enterBankAccountDetailsPage: enter_bank_account_details
 )(implicit val ec: ExecutionContext, viewConfig: ViewConfig, errorHandler: ErrorHandler)
     extends RejectedGoodsMultipleJourneyBaseController {
 
-  val formKey: String          = "enter-bank-details"
+  val formKey: String          = "enter-bank-account-details"
   private val postAction: Call = routes.EnterBankAccountDetailsController.submit()
 
   val show: Action[AnyContent] = actionReadJourney { implicit request => _ =>
@@ -71,7 +71,7 @@ class EnterBankAccountDetailsController @Inject() (
           enterBankAccountDetailsPage(
             enterBankDetailsForm
               .fill(bankAccountDetails)
-              .withError("enter-bank-details", s"error.${errorResponse.code}"),
+              .withError("enter-bank-account-details", s"error.${errorResponse.code}"),
             postAction
           )
         )
@@ -80,7 +80,7 @@ class EnterBankAccountDetailsController @Inject() (
           enterBankAccountDetailsPage(
             enterBankDetailsForm
               .fill(bankAccountDetails)
-              .withError("enter-bank-details", "error.account-exists-error"),
+              .withError("enter-bank-account-details", "error.account-exists-error"),
             postAction
           )
         )
@@ -88,7 +88,7 @@ class EnterBankAccountDetailsController @Inject() (
         BadRequest(
           enterBankAccountDetailsPage(
             enterBankDetailsForm
-              .withError("enter-bank-details", "error.account-does-not-exist"),
+              .withError("enter-bank-account-details", "error.account-does-not-exist"),
             postAction
           )
         )
@@ -96,7 +96,7 @@ class EnterBankAccountDetailsController @Inject() (
         BadRequest(
           enterBankAccountDetailsPage(
             enterBankDetailsForm
-              .withError("enter-bank-details", "error.moc-check-no"),
+              .withError("enter-bank-account-details", "error.moc-check-no"),
             postAction
           )
         )
@@ -104,7 +104,7 @@ class EnterBankAccountDetailsController @Inject() (
         BadRequest(
           enterBankAccountDetailsPage(
             enterBankDetailsForm
-              .withError("enter-bank-details", "error.moc-check-failed"),
+              .withError("enter-bank-account-details", "error.moc-check-failed"),
             postAction
           )
         )
@@ -115,7 +115,7 @@ class EnterBankAccountDetailsController @Inject() (
           enterBankAccountDetailsPage(
             enterBankDetailsForm
               .fill(bankAccountDetails)
-              .withError("enter-bank-details", "error.account-does-not-exist"),
+              .withError("enter-bank-account-details", "error.account-does-not-exist"),
             postAction
           )
         )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterBankAccountDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterBankAccountDetailsController.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ServiceUnavailableError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.EnterBankAccountDetailsMixin
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoods.{routes => rejectedGoodsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduledJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
@@ -29,7 +30,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.CdsError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.{Error => ReputationResponseError, _}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_bank_account_details
 
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -40,11 +41,11 @@ import scala.concurrent.Future
 class EnterBankAccountDetailsController @Inject() (
   val jcc: JourneyControllerComponents,
   val bankAccountReputationService: BankAccountReputationService,
-  enterBankAccountDetailsPage: pages.enter_bank_account_details
+  enterBankAccountDetailsPage: enter_bank_account_details
 )(implicit val ec: ExecutionContext, viewConfig: ViewConfig, errorHandler: ErrorHandler)
     extends RejectedGoodsScheduledJourneyBaseController {
 
-  val formKey: String          = "enter-bank-details"
+  val formKey: String          = "enter-bank-account-details"
   private val postAction: Call = routes.EnterBankAccountDetailsController.submit()
 
   val show: Action[AnyContent] = actionReadJourney { implicit request => _ =>
@@ -61,7 +62,7 @@ class EnterBankAccountDetailsController @Inject() (
           enterBankAccountDetailsPage(
             enterBankDetailsForm
               .fill(bankAccountDetails)
-              .withError("enter-bank-details", s"error.${errorResponse.code}"),
+              .withError("enter-bank-account-details", s"error.${errorResponse.code}"),
             postAction
           )
         )
@@ -70,7 +71,7 @@ class EnterBankAccountDetailsController @Inject() (
           enterBankAccountDetailsPage(
             enterBankDetailsForm
               .fill(bankAccountDetails)
-              .withError("enter-bank-details", "error.account-exists-error"),
+              .withError("enter-bank-account-details", "error.account-exists-error"),
             postAction
           )
         )
@@ -78,7 +79,7 @@ class EnterBankAccountDetailsController @Inject() (
         BadRequest(
           enterBankAccountDetailsPage(
             enterBankDetailsForm
-              .withError("enter-bank-details", "error.account-does-not-exist"),
+              .withError("enter-bank-account-details", "error.account-does-not-exist"),
             postAction
           )
         )
@@ -86,7 +87,7 @@ class EnterBankAccountDetailsController @Inject() (
         BadRequest(
           enterBankAccountDetailsPage(
             enterBankDetailsForm
-              .withError("enter-bank-details", "error.moc-check-no"),
+              .withError("enter-bank-account-details", "error.moc-check-no"),
             postAction
           )
         )
@@ -94,7 +95,7 @@ class EnterBankAccountDetailsController @Inject() (
         BadRequest(
           enterBankAccountDetailsPage(
             enterBankDetailsForm
-              .withError("enter-bank-details", "error.moc-check-failed"),
+              .withError("enter-bank-account-details", "error.moc-check-failed"),
             postAction
           )
         )
@@ -105,7 +106,7 @@ class EnterBankAccountDetailsController @Inject() (
           enterBankAccountDetailsPage(
             enterBankDetailsForm
               .fill(bankAccountDetails)
-              .withError("enter-bank-details", "error.account-does-not-exist"),
+              .withError("enter-bank-account-details", "error.account-does-not-exist"),
             postAction
           )
         )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterBankAccountDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterBankAccountDetailsController.scala
@@ -31,6 +31,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ServiceUnavailableError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.EnterBankAccountDetailsMixin
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoods.{routes => rejectedGoodsRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney
@@ -41,7 +42,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.Ba
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_bank_account_details
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -50,11 +51,11 @@ import scala.concurrent.Future
 class EnterBankAccountDetailsController @Inject() (
   val jcc: JourneyControllerComponents,
   val bankAccountReputationService: BankAccountReputationService,
-  enterBankAccountDetailsPage: pages.enter_bank_account_details
+  enterBankAccountDetailsPage: enter_bank_account_details
 )(implicit val ec: ExecutionContext, viewConfig: ViewConfig, errorHandler: ErrorHandler)
     extends RejectedGoodsSingleJourneyBaseController {
 
-  val formKey: String          = "enter-bank-details"
+  val formKey: String          = "enter-bank-account-details"
   private val postAction: Call = routes.EnterBankAccountDetailsController.submit()
 
   val show: Action[AnyContent] = actionReadJourney { implicit request => _ =>
@@ -93,27 +94,27 @@ class EnterBankAccountDetailsController @Inject() (
         case BankAccountReputation(_, _, Some(errorResponse))                             =>
           val form = enterBankDetailsForm
             .fill(bankAccountDetails)
-            .withError("enter-bank-details", s"error.${errorResponse.code}")
+            .withError("enter-bank-account-details", s"error.${errorResponse.code}")
           (journey, BadRequest(enterBankAccountDetailsPage(form, postAction)))
         case BankAccountReputation(No, _, None)                                           =>
           val form = enterBankDetailsForm
             .fill(bankAccountDetails)
-            .withError("enter-bank-details", "error.moc-check-no")
+            .withError("enter-bank-account-details", "error.moc-check-no")
           (journey, BadRequest(enterBankAccountDetailsPage(form, postAction)))
         case BankAccountReputation(sortCodeResponse, _, None) if sortCodeResponse =!= Yes =>
           val form = enterBankDetailsForm
             .fill(bankAccountDetails)
-            .withError("enter-bank-details", "error.moc-check-failed")
+            .withError("enter-bank-account-details", "error.moc-check-failed")
           (journey, BadRequest(enterBankAccountDetailsPage(form, postAction)))
         case BankAccountReputation(_, Some(ReputationResponse.Error), None)               =>
           val form = enterBankDetailsForm
             .fill(bankAccountDetails)
-            .withError("enter-bank-details", "error.account-exists-error")
+            .withError("enter-bank-account-details", "error.account-exists-error")
           (journey, BadRequest(enterBankAccountDetailsPage(form, postAction)))
         case BankAccountReputation(_, _, None)                                            =>
           val form = enterBankDetailsForm
             .fill(bankAccountDetails)
-            .withError("enter-bank-details", "error.account-does-not-exist")
+            .withError("enter-bank-account-details", "error.account-does-not-exist")
           (journey, BadRequest(enterBankAccountDetailsPage(form, postAction)))
       }
     )

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterBankAccountDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterBankAccountDetailsController.scala
@@ -18,16 +18,74 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities
 
 import com.google.inject.Inject
 import com.google.inject.Singleton
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Request
+import play.api.mvc.Result
+import shapeless.syntax.std.tuple.productTupleOps
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.common.{routes => commonRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.WorkInProgressMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.EnterBankAccountDetailsMixin
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.Yes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.Logging
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_bank_account_details
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 @Singleton
 class EnterBankAccountDetailsController @Inject() (
-  val jcc: JourneyControllerComponents
-)(implicit viewConfig: ViewConfig, ec: ExecutionContext)
+  val jcc: JourneyControllerComponents,
+  implicit val enterBankAccountDetailsPage: enter_bank_account_details,
+  implicit val bankAccountReputationService: BankAccountReputationService
+)(implicit viewConfig: ViewConfig, ec: ExecutionContext, errorHandler: ErrorHandler)
     extends SecuritiesJourneyBaseController
-    with WorkInProgressMixin[SecuritiesJourney]
+    with EnterBankAccountDetailsMixin
+    with Logging {
+
+  import JourneyWithSubmitBankAccount._
+  implicit def securitiesJourneyWithBankAccount(implicit
+    journey: SecuritiesJourney
+  ): JourneyWithBankAccount[SecuritiesJourney] =
+    instance(journey.answers.bankAccountType, journey.submitBankAccountDetails)
+
+  private val nextPage = NextPage(
+    errorPath = commonRoutes.ServiceUnavailableController.show(),
+    retryPath = routes.EnterBankAccountDetailsController.show(),
+    successPath = routes.CheckBankDetailsController.show(),
+    submitPath = routes.EnterBankAccountDetailsController.submit(),
+    getBankAccountTypePath = routes.ChooseBankAccountTypeController.show()
+  )
+
+  val show: Action[AnyContent] = actionReadJourney { implicit request => _ =>
+    Ok(enterBankAccountDetailsPage(enterBankDetailsForm, routes.EnterBankAccountDetailsController.submit())).asFuture
+  }
+
+  val submit: Action[AnyContent] = actionReadWriteJourney(
+    { implicit request => implicit journey =>
+      enterBankDetailsForm
+        .bindFromRequest()
+        .fold(
+          formWithErrors =>
+            (
+              journey,
+              BadRequest(
+                enterBankAccountDetailsPage(
+                  formWithErrors,
+                  nextPage.submitPath
+                )
+              )
+            ).asFuture,
+          validateBankAccountDetails(journey, _, None, nextPage)
+        )
+    },
+    fastForwardToCYAEnabled = false
+  )
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/utils/Syntax.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/utils/Syntax.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.utils
+
+import scala.concurrent.Future
+
+object Syntax {
+  implicit class Ops[A](val value: A) {
+    def asFuture: Future[A] = Future.successful(value)
+    def |>[B](f: A => B): B = f(value)
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/common/enter_bank_account_details.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/common/enter_bank_account_details.scala.html
@@ -33,7 +33,7 @@
 
 @(form: Form[BankAccountDetails], postAction: Call)(implicit request: Request[_], messages: Messages, viewConfig: ViewConfig)
 
-@key = @{"enter-bank-details"}
+@key = @{"enter-bank-account-details"}
 @title = @{messages(s"$key.title")}
 
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}

--- a/conf/messages
+++ b/conf/messages
@@ -1144,28 +1144,28 @@ select-bank-account-type.error.required=Choose if you are providing details for 
 #===================================================
 #  ENTER BANK DETAILS PAGE
 #===================================================
-enter-bank-details.title=Enter your bank account details
-enter-bank-details.p1=This is where you would like repayments to be made in the UK.
-enter-bank-details.p2=To use these bank details again, <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{0}">contact the <abbr title="Customs Declaration Service">CDS</abbr> team (opens in new tab)</a> via the imports and exports general enquiries.  Updating your bank details will only affect this claim and not past and future claims.
-enter-bank-details.account-name.label=Name on the account
-enter-bank-details.account-name.error.required=Enter the name on the account
-enter-bank-details.account-name.error.maxLength=Enter a valid account name
-enter-bank-details.account-name.invalid=Enter a valid account name
-enter-bank-details.sort-code.label=Sort code
-enter-bank-details.sort-code.help-text=Must be 6 digits long
-enter-bank-details.sort-code.error.required=Enter a sort code
-enter-bank-details.sort-code.invalid=Enter a valid sort code like 309430
-enter-bank-details.account-number.label=Account number
-enter-bank-details.account-number.help-text=Must be between 6 and 8 digits long
-enter-bank-details.account-number.error.required=Enter an account number
-enter-bank-details.account-number.error.length=Account number must be between 6 and 8 digits
-enter-bank-details.account-number.error.invalid=Enter a valid account number like 00733445
-enter-bank-details.error.moc-check-failed=We were unable to verify your sort code and account no. Try again using different details
-enter-bank-details.error.moc-check-no=Enter a valid combination of bank account number and sort code
-enter-bank-details.error.account-does-not-exist=We were unable to verify your sort code and account no. Try again using different details
-enter-bank-details.error.account-exists-error=The service was unavailable to verify your bank details. Try again later
-enter-bank-details.error.INVALID_ACCOUNT_NUMBER=Invalid account number
-enter-bank-details.error.INVALID_SORTCODE=Invalid sort code
+enter-bank-account-details.title=Enter your bank account details
+enter-bank-account-details.p1=This is where you would like repayments to be made in the UK.
+enter-bank-account-details.p2=To use these bank details again, <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{0}">contact the <abbr title="Customs Declaration Service">CDS</abbr> team (opens in new tab)</a> via the imports and exports general enquiries.  Updating your bank details will only affect this claim and not past and future claims.
+enter-bank-account-details.account-name.label=Name on the account
+enter-bank-account-details.account-name.error.required=Enter the name on the account
+enter-bank-account-details.account-name.error.maxLength=Enter a valid account name
+enter-bank-account-details.account-name.invalid=Enter a valid account name
+enter-bank-account-details.sort-code.label=Sort code
+enter-bank-account-details.sort-code.help-text=Must be 6 digits long
+enter-bank-account-details.sort-code.error.required=Enter a sort code
+enter-bank-account-details.sort-code.invalid=Enter a valid sort code like 309430
+enter-bank-account-details.account-number.label=Account number
+enter-bank-account-details.account-number.help-text=Must be between 6 and 8 digits long
+enter-bank-account-details.account-number.error.required=Enter an account number
+enter-bank-account-details.account-number.error.length=Account number must be between 6 and 8 digits
+enter-bank-account-details.account-number.error.invalid=Enter a valid account number like 00733445
+enter-bank-account-details.error.moc-check-failed=We were unable to verify your sort code and account no. Try again using different details
+enter-bank-account-details.error.moc-check-no=Enter a valid combination of bank account number and sort code
+enter-bank-account-details.error.account-does-not-exist=We were unable to verify your sort code and account no. Try again using different details
+enter-bank-account-details.error.account-exists-error=The service was unavailable to verify your bank details. Try again later
+enter-bank-account-details.error.INVALID_ACCOUNT_NUMBER=Invalid account number
+enter-bank-account-details.error.INVALID_SORTCODE=Invalid sort code
 
 #===================================================
 #  BANK ACCOUNT UNAVAILABLE PAGE

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -761,26 +761,26 @@ select-bank-account-type.error.required=
 #===================================================
 #  ENTER BANK DETAILS PAGE
 #===================================================
-enter-bank-details.title=Nodwch fanylion y cyfrif banc
-enter-bank-details.p1=
-enter-bank-details.p2=
-enter-bank-details.account-name.label=Enw’r cyfrif banc
-enter-bank-details.account-name.error.required=Nodwch enw cyfrif dilys
-enter-bank-details.account-name.error.maxLength=Nodwch enw cyfrif dilys
-enter-bank-details.account-name.invalid=Nodwch enw cyfrif dilys
-enter-bank-details.sort-code.label=Cod didoli
-enter-bank-details.sort-code.help-text=
-enter-bank-details.sort-code.error.required=Nodwch god didoli dilys
-enter-bank-details.sort-code.invalid=Nodwch god didoli dilys
-enter-bank-details.account-number.label=Rhif y cyfrif
-enter-bank-details.account-number.help-text=Mae’n rhaid iddo fod rhwng 6 ac 8 digid o hyd
-enter-bank-details.account-number.error.required=Nodwch rif cyfrif dilys.
-enter-bank-details.account-number.error.length=
-enter-bank-details.account-number.error.invalid=
-enter-bank-details.error.moc-check-failed=Mae’n rhaid i rif y cyfrif fod yn ddilys ar gyfer y cod didoli a roddir
-enter-bank-details.error.account-does-not-exist=Mae’n rhaid i rif y cyfrif fod yn perthyn i gyfrif banc gweithredol
-enter-bank-details.error.INVALID_ACCOUNT_NUMBER=Rhif cyfrif annilys
-enter-bank-details.error.INVALID_SORTCODE=Cod didoli annilys
+enter-bank-account-details.title=Nodwch fanylion y cyfrif banc
+enter-bank-account-details.p1=
+enter-bank-account-details.p2=
+enter-bank-account-details.account-name.label=Enw’r cyfrif banc
+enter-bank-account-details.account-name.error.required=Nodwch enw cyfrif dilys
+enter-bank-account-details.account-name.error.maxLength=Nodwch enw cyfrif dilys
+enter-bank-account-details.account-name.invalid=Nodwch enw cyfrif dilys
+enter-bank-account-details.sort-code.label=Cod didoli
+enter-bank-account-details.sort-code.help-text=
+enter-bank-account-details.sort-code.error.required=Nodwch god didoli dilys
+enter-bank-account-details.sort-code.invalid=Nodwch god didoli dilys
+enter-bank-account-details.account-number.label=Rhif y cyfrif
+enter-bank-account-details.account-number.help-text=Mae’n rhaid iddo fod rhwng 6 ac 8 digid o hyd
+enter-bank-account-details.account-number.error.required=Nodwch rif cyfrif dilys.
+enter-bank-account-details.account-number.error.length=
+enter-bank-account-details.account-number.error.invalid=
+enter-bank-account-details.error.moc-check-failed=Mae’n rhaid i rif y cyfrif fod yn ddilys ar gyfer y cod didoli a roddir
+enter-bank-account-details.error.account-does-not-exist=Mae’n rhaid i rif y cyfrif fod yn perthyn i gyfrif banc gweithredol
+enter-bank-account-details.error.INVALID_ACCOUNT_NUMBER=Rhif cyfrif annilys
+enter-bank-account-details.error.INVALID_SORTCODE=Cod didoli annilys
 
 #===================================================
 #  SUPPORTING EVIDENCE PAGES

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/BankAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/BankAccountControllerSpec.scala
@@ -152,7 +152,7 @@ class BankAccountControllerSpec
   def getGlobalErrors(doc: Document): Elements = doc.getElementsByClass("govuk-error-summary__list").select("li")
 
   def getAccountNameValue(doc: Document): String =
-    doc.select("input[name='enter-bank-details.account-name']").first().attr("value")
+    doc.select("input[name='enter-bank-account-details.account-name']").first().attr("value")
 
   "Bank Account Controller" when {
 
@@ -279,7 +279,7 @@ class BankAccountControllerSpec
           val doc              = Jsoup.parse(contentAsString(result))
           getAccountNameValue(doc) shouldBe ""
           val error = getGlobalErrors(doc).text()
-          error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
           status(result) shouldBe BAD_REQUEST
         }
       }
@@ -314,7 +314,7 @@ class BankAccountControllerSpec
             val doc              = Jsoup.parse(contentAsString(result))
             getAccountNameValue(doc) shouldBe ""
             val error = getGlobalErrors(doc).text()
-            error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed")
+            error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed")
             status(result) shouldBe BAD_REQUEST
           }
         )
@@ -345,7 +345,7 @@ class BankAccountControllerSpec
         val doc              = Jsoup.parse(contentAsString(result))
         getAccountNameValue(doc) shouldBe Business.accountName.value
         val error = getGlobalErrors(doc).text()
-        error          shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error")
+        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-exists-error")
         status(result) shouldBe BAD_REQUEST
       }
 
@@ -376,7 +376,7 @@ class BankAccountControllerSpec
           val doc              = Jsoup.parse(contentAsString(result))
           getAccountNameValue(doc) shouldBe ""
           val error = getGlobalErrors(doc).text()
-          error          shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist")
+          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-does-not-exist")
           status(result) shouldBe BAD_REQUEST
         }
 
@@ -405,7 +405,7 @@ class BankAccountControllerSpec
         val doc              = Jsoup.parse(contentAsString(result))
 
         val error = getGlobalErrors(doc).text()
-        error          shouldBe messageFromMessageKey("enter-bank-details.error.INVALID_ACCOUNT_NUMBER")
+        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.INVALID_ACCOUNT_NUMBER")
         status(result) shouldBe BAD_REQUEST
       }
 
@@ -494,7 +494,7 @@ class BankAccountControllerSpec
           val doc              = Jsoup.parse(contentAsString(result))
           getAccountNameValue(doc) shouldBe ""
           val error = getGlobalErrors(doc).text()
-          error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
           status(result) shouldBe BAD_REQUEST
         }
       }
@@ -528,7 +528,7 @@ class BankAccountControllerSpec
             val doc              = Jsoup.parse(contentAsString(result))
             getAccountNameValue(doc) shouldBe ""
             val error = getGlobalErrors(doc).text()
-            error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed")
+            error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed")
             status(result) shouldBe BAD_REQUEST
           }
         )
@@ -559,7 +559,7 @@ class BankAccountControllerSpec
         val doc              = Jsoup.parse(contentAsString(result))
         getAccountNameValue(doc) shouldBe Personal.accountName.value
         val error = getGlobalErrors(doc).text()
-        error          shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error")
+        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-exists-error")
         status(result) shouldBe BAD_REQUEST
 
       }
@@ -591,7 +591,7 @@ class BankAccountControllerSpec
           val doc              = Jsoup.parse(contentAsString(result))
           getAccountNameValue(doc) shouldBe ""
           val error = getGlobalErrors(doc).text()
-          error          shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist")
+          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-does-not-exist")
           status(result) shouldBe BAD_REQUEST
         }
 
@@ -619,7 +619,7 @@ class BankAccountControllerSpec
         val doc              = Jsoup.parse(contentAsString(result))
 
         val error = getGlobalErrors(doc).text()
-        error          shouldBe messageFromMessageKey("enter-bank-details.error.INVALID_SORTCODE")
+        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.INVALID_SORTCODE")
         status(result) shouldBe BAD_REQUEST
       }
 
@@ -652,10 +652,10 @@ class BankAccountControllerSpec
 
   "Form Validation" must {
     val form          = enterBankDetailsForm
-    val accountName   = "enter-bank-details.account-name"
-    val isBusiness    = "enter-bank-details.is-business-account"
-    val sortCode      = "enter-bank-details.sort-code"
-    val accountNumber = "enter-bank-details.account-number"
+    val accountName   = "enter-bank-account-details.account-name"
+    val isBusiness    = "enter-bank-account-details.is-business-account"
+    val sortCode      = "enter-bank-account-details.sort-code"
+    val accountNumber = "enter-bank-account-details.account-number"
 
     val goodData = Map(
       accountName   -> "Barkhan Seer",

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/BankAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/BankAccountControllerSpec.scala
@@ -152,7 +152,7 @@ class BankAccountControllerSpec
   def getGlobalErrors(doc: Document): Elements = doc.getElementsByClass("govuk-error-summary__list").select("li")
 
   def getAccountNameValue(doc: Document): String =
-    doc.select("input[name='enter-bank-details.account-name']").first().attr("value")
+    doc.select("input[name='enter-bank-account-details.account-name']").first().attr("value")
 
   "Bank Account Controller" when {
 
@@ -279,7 +279,7 @@ class BankAccountControllerSpec
           val doc              = Jsoup.parse(contentAsString(result))
           getAccountNameValue(doc) shouldBe ""
           val error = getGlobalErrors(doc).text()
-          error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
           status(result) shouldBe BAD_REQUEST
         }
       }
@@ -314,7 +314,7 @@ class BankAccountControllerSpec
             val doc              = Jsoup.parse(contentAsString(result))
             getAccountNameValue(doc) shouldBe ""
             val error = getGlobalErrors(doc).text()
-            error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed")
+            error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed")
             status(result) shouldBe BAD_REQUEST
           }
         )
@@ -345,7 +345,7 @@ class BankAccountControllerSpec
         val doc              = Jsoup.parse(contentAsString(result))
         getAccountNameValue(doc) shouldBe Business.accountName.value
         val error = getGlobalErrors(doc).text()
-        error          shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error")
+        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-exists-error")
         status(result) shouldBe BAD_REQUEST
       }
 
@@ -376,7 +376,7 @@ class BankAccountControllerSpec
           val doc              = Jsoup.parse(contentAsString(result))
           getAccountNameValue(doc) shouldBe ""
           val error = getGlobalErrors(doc).text()
-          error          shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist")
+          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-does-not-exist")
           status(result) shouldBe BAD_REQUEST
         }
 
@@ -405,7 +405,7 @@ class BankAccountControllerSpec
         val doc              = Jsoup.parse(contentAsString(result))
 
         val error = getGlobalErrors(doc).text()
-        error          shouldBe messageFromMessageKey("enter-bank-details.error.INVALID_ACCOUNT_NUMBER")
+        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.INVALID_ACCOUNT_NUMBER")
         status(result) shouldBe BAD_REQUEST
       }
 
@@ -494,7 +494,7 @@ class BankAccountControllerSpec
           val doc              = Jsoup.parse(contentAsString(result))
           getAccountNameValue(doc) shouldBe ""
           val error = getGlobalErrors(doc).text()
-          error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
           status(result) shouldBe BAD_REQUEST
         }
       }
@@ -528,7 +528,7 @@ class BankAccountControllerSpec
             val doc              = Jsoup.parse(contentAsString(result))
             getAccountNameValue(doc) shouldBe ""
             val error = getGlobalErrors(doc).text()
-            error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed")
+            error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed")
             status(result) shouldBe BAD_REQUEST
           }
         )
@@ -559,7 +559,7 @@ class BankAccountControllerSpec
         val doc              = Jsoup.parse(contentAsString(result))
         getAccountNameValue(doc) shouldBe Personal.accountName.value
         val error = getGlobalErrors(doc).text()
-        error          shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error")
+        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-exists-error")
         status(result) shouldBe BAD_REQUEST
 
       }
@@ -591,7 +591,7 @@ class BankAccountControllerSpec
           val doc              = Jsoup.parse(contentAsString(result))
           getAccountNameValue(doc) shouldBe ""
           val error = getGlobalErrors(doc).text()
-          error          shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist")
+          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-does-not-exist")
           status(result) shouldBe BAD_REQUEST
         }
 
@@ -619,7 +619,7 @@ class BankAccountControllerSpec
         val doc              = Jsoup.parse(contentAsString(result))
 
         val error = getGlobalErrors(doc).text()
-        error          shouldBe messageFromMessageKey("enter-bank-details.error.INVALID_SORTCODE")
+        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.INVALID_SORTCODE")
         status(result) shouldBe BAD_REQUEST
       }
 
@@ -652,10 +652,10 @@ class BankAccountControllerSpec
 
   "Form Validation" must {
     val form          = enterBankDetailsForm
-    val accountName   = "enter-bank-details.account-name"
-    val isBusiness    = "enter-bank-details.is-business-account"
-    val sortCode      = "enter-bank-details.sort-code"
-    val accountNumber = "enter-bank-details.account-number"
+    val accountName   = "enter-bank-account-details.account-name"
+    val isBusiness    = "enter-bank-account-details.is-business-account"
+    val sortCode      = "enter-bank-account-details.sort-code"
+    val accountNumber = "enter-bank-account-details.account-number"
 
     val goodData = Map(
       accountName   -> "Barkhan Seer",

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/BankAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/BankAccountControllerSpec.scala
@@ -152,7 +152,7 @@ class BankAccountControllerSpec
   def getGlobalErrors(doc: Document): Elements = doc.getElementsByClass("govuk-error-summary__list").select("li")
 
   def getAccountNameValue(doc: Document): String =
-    doc.select("input[name='enter-bank-details.account-name']").first().attr("value")
+    doc.select("input[name='enter-bank-account-details.account-name']").first().attr("value")
 
   "Bank Account Controller" when {
 
@@ -279,7 +279,7 @@ class BankAccountControllerSpec
       //          val doc              = Jsoup.parse(contentAsString(result))
       //          getAccountNameValue(doc) shouldBe ""
       //          val error = getGlobalErrors(doc).text()
-      //          error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+      //          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
       //          status(result) shouldBe BAD_REQUEST
       //        }
       //      }
@@ -314,7 +314,7 @@ class BankAccountControllerSpec
       //            val doc              = Jsoup.parse(contentAsString(result))
       //            getAccountNameValue(doc) shouldBe ""
       //            val error = getGlobalErrors(doc).text()
-      //            error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed")
+      //            error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed")
       //            status(result) shouldBe BAD_REQUEST
       //          }
       //        )
@@ -345,7 +345,7 @@ class BankAccountControllerSpec
       //        val doc              = Jsoup.parse(contentAsString(result))
       //        getAccountNameValue(doc) shouldBe Business.accountName.value
       //        val error = getGlobalErrors(doc).text()
-      //        error          shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error")
+      //        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-exists-error")
       //        status(result) shouldBe BAD_REQUEST
       //      }
       //
@@ -376,7 +376,7 @@ class BankAccountControllerSpec
       //          val doc              = Jsoup.parse(contentAsString(result))
       //          getAccountNameValue(doc) shouldBe ""
       //          val error = getGlobalErrors(doc).text()
-      //          error          shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist")
+      //          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-does-not-exist")
       //          status(result) shouldBe BAD_REQUEST
       //        }
       //
@@ -405,7 +405,7 @@ class BankAccountControllerSpec
       //        val doc              = Jsoup.parse(contentAsString(result))
       //
       //        val error = getGlobalErrors(doc).text()
-      //        error          shouldBe messageFromMessageKey("enter-bank-details.error.INVALID_ACCOUNT_NUMBER")
+      //        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.INVALID_ACCOUNT_NUMBER")
       //        status(result) shouldBe BAD_REQUEST
       //      }
       //
@@ -494,7 +494,7 @@ class BankAccountControllerSpec
           val doc              = Jsoup.parse(contentAsString(result))
           getAccountNameValue(doc) shouldBe ""
           val error = getGlobalErrors(doc).text()
-          error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
           status(result) shouldBe BAD_REQUEST
         }
       }
@@ -528,7 +528,7 @@ class BankAccountControllerSpec
             val doc              = Jsoup.parse(contentAsString(result))
             getAccountNameValue(doc) shouldBe ""
             val error = getGlobalErrors(doc).text()
-            error          shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed")
+            error          shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed")
             status(result) shouldBe BAD_REQUEST
           }
         )
@@ -559,7 +559,7 @@ class BankAccountControllerSpec
         val doc              = Jsoup.parse(contentAsString(result))
         getAccountNameValue(doc) shouldBe Personal.accountName.value
         val error = getGlobalErrors(doc).text()
-        error          shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error")
+        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-exists-error")
         status(result) shouldBe BAD_REQUEST
 
       }
@@ -591,7 +591,7 @@ class BankAccountControllerSpec
           val doc              = Jsoup.parse(contentAsString(result))
           getAccountNameValue(doc) shouldBe ""
           val error = getGlobalErrors(doc).text()
-          error          shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist")
+          error          shouldBe messageFromMessageKey("enter-bank-account-details.error.account-does-not-exist")
           status(result) shouldBe BAD_REQUEST
         }
 
@@ -619,7 +619,7 @@ class BankAccountControllerSpec
         val doc              = Jsoup.parse(contentAsString(result))
 
         val error = getGlobalErrors(doc).text()
-        error          shouldBe messageFromMessageKey("enter-bank-details.error.INVALID_SORTCODE")
+        error          shouldBe messageFromMessageKey("enter-bank-account-details.error.INVALID_SORTCODE")
         status(result) shouldBe BAD_REQUEST
       }
 
@@ -652,10 +652,10 @@ class BankAccountControllerSpec
 
   "Form Validation" must {
     val form          = enterBankDetailsForm
-    val accountName   = "enter-bank-details.account-name"
-    val isBusiness    = "enter-bank-details.is-business-account"
-    val sortCode      = "enter-bank-details.sort-code"
-    val accountNumber = "enter-bank-details.account-number"
+    val accountName   = "enter-bank-account-details.account-name"
+    val isBusiness    = "enter-bank-account-details.is-business-account"
+    val sortCode      = "enter-bank-account-details.sort-code"
+    val accountNumber = "enter-bank-account-details.account-number"
 
     val goodData = Map(
       accountName   -> "Barkhan Seer",

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/EnterBankAccountDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/EnterBankAccountDetailsControllerSpec.scala
@@ -67,7 +67,7 @@ class EnterBankAccountDetailsControllerSpec
     with MockBankAccountReputationService {
 
   private def getInputBoxValue(doc: Document, inputBoxSubKey: String): Option[String] =
-    selectedInputBox(doc, s"enter-bank-details.$inputBoxSubKey")
+    selectedInputBox(doc, s"enter-bank-account-details.$inputBoxSubKey")
 
   override val overrideBindings: List[GuiceableModule] =
     List[GuiceableModule](
@@ -84,7 +84,7 @@ class EnterBankAccountDetailsControllerSpec
   implicit val request: Request[_] = FakeRequest()
 
   private lazy val featureSwitch  = instanceOf[FeatureSwitchService]
-  private val messagesKey: String = "enter-bank-details"
+  private val messagesKey: String = "enter-bank-account-details"
 
   override def beforeEach(): Unit =
     featureSwitch.enable(Feature.RejectedGoods)
@@ -133,9 +133,9 @@ class EnterBankAccountDetailsControllerSpec
           performAction(),
           messageFromMessageKey(s"$messagesKey.title"),
           doc => {
-            selectedInputBox(doc, "enter-bank-details.account-name")   shouldBe Some("")
-            selectedInputBox(doc, "enter-bank-details.sort-code")      shouldBe Some("")
-            selectedInputBox(doc, "enter-bank-details.account-number") shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-account-details.account-name")   shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-account-details.sort-code")      shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-account-details.account-number") shouldBe Some("")
           }
         )
 
@@ -198,7 +198,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -220,7 +222,10 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error"),
+            doc =>
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-exists-error"
+              ),
             BAD_REQUEST
           )
         }
@@ -243,7 +248,7 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no"),
+            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no"),
             BAD_REQUEST
           )
         }
@@ -266,7 +271,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-exists-error"
+              )
               getInputBoxValue(doc, "account-name")   shouldBe Some(bankAccountDetails.accountName.value)
               getInputBoxValue(doc, "sort-code")      shouldBe Some(bankAccountDetails.sortCode.value)
               getInputBoxValue(doc, "account-number") shouldBe Some(bankAccountDetails.accountNumber.value)
@@ -294,7 +301,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              )
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -323,7 +332,7 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -351,7 +360,7 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed")
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -379,7 +388,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -430,7 +441,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -452,7 +465,10 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error"),
+            doc =>
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-exists-error"
+              ),
             BAD_REQUEST
           )
         }
@@ -476,7 +492,7 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -504,7 +520,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-exists-error"
+              )
               getInputBoxValue(doc, "account-name")   shouldBe Some(bankAccountDetails.accountName.value)
               getInputBoxValue(doc, "sort-code")      shouldBe Some(bankAccountDetails.sortCode.value)
               getInputBoxValue(doc, "account-number") shouldBe Some(bankAccountDetails.accountNumber.value)
@@ -532,7 +550,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              )
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -561,7 +581,7 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -589,7 +609,7 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed")
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -617,7 +637,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -711,10 +733,10 @@ class EnterBankAccountDetailsControllerSpec
 
   "Form Validation" must {
     val form          = enterBankDetailsForm
-    val accountName   = "enter-bank-details.account-name"
-    val isBusiness    = "enter-bank-details.is-business-account"
-    val sortCode      = "enter-bank-details.sort-code"
-    val accountNumber = "enter-bank-details.account-number"
+    val accountName   = "enter-bank-account-details.account-name"
+    val isBusiness    = "enter-bank-account-details.is-business-account"
+    val sortCode      = "enter-bank-account-details.sort-code"
+    val accountNumber = "enter-bank-account-details.account-number"
 
     val goodData = Map(
       accountName   -> "Barkhan Seer",

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterBankAccountDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterBankAccountDetailsControllerSpec.scala
@@ -67,7 +67,7 @@ class EnterBankAccountDetailsControllerSpec
     with MockBankAccountReputationService {
 
   private def getInputBoxValue(doc: Document, inputBoxSubKey: String): Option[String] =
-    selectedInputBox(doc, s"enter-bank-details.$inputBoxSubKey")
+    selectedInputBox(doc, s"enter-bank-account-details.$inputBoxSubKey")
 
   override val overrideBindings: List[GuiceableModule] =
     List[GuiceableModule](
@@ -84,7 +84,7 @@ class EnterBankAccountDetailsControllerSpec
   implicit val request: Request[_] = FakeRequest()
 
   private lazy val featureSwitch  = instanceOf[FeatureSwitchService]
-  private val messagesKey: String = "enter-bank-details"
+  private val messagesKey: String = "enter-bank-account-details"
 
   override def beforeEach(): Unit =
     featureSwitch.enable(Feature.RejectedGoods)
@@ -133,9 +133,9 @@ class EnterBankAccountDetailsControllerSpec
           performAction(),
           messageFromMessageKey(s"$messagesKey.title"),
           doc => {
-            selectedInputBox(doc, "enter-bank-details.account-name")   shouldBe Some("")
-            selectedInputBox(doc, "enter-bank-details.sort-code")      shouldBe Some("")
-            selectedInputBox(doc, "enter-bank-details.account-number") shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-account-details.account-name")   shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-account-details.sort-code")      shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-account-details.account-number") shouldBe Some("")
           }
         )
 
@@ -198,7 +198,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -220,7 +222,10 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error"),
+            doc =>
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-exists-error"
+              ),
             BAD_REQUEST
           )
         }
@@ -243,7 +248,7 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no"),
+            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no"),
             BAD_REQUEST
           )
         }
@@ -266,7 +271,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-exists-error"
+              )
               getInputBoxValue(doc, "account-name")   shouldBe Some(bankAccountDetails.accountName.value)
               getInputBoxValue(doc, "sort-code")      shouldBe Some(bankAccountDetails.sortCode.value)
               getInputBoxValue(doc, "account-number") shouldBe Some(bankAccountDetails.accountNumber.value)
@@ -294,7 +301,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              )
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -323,7 +332,7 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -351,7 +360,7 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed")
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -379,7 +388,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -430,7 +441,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -452,7 +465,10 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error"),
+            doc =>
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-exists-error"
+              ),
             BAD_REQUEST
           )
         }
@@ -476,7 +492,7 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -504,7 +520,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-exists-error"
+              )
               getInputBoxValue(doc, "account-name")   shouldBe Some(bankAccountDetails.accountName.value)
               getInputBoxValue(doc, "sort-code")      shouldBe Some(bankAccountDetails.sortCode.value)
               getInputBoxValue(doc, "account-number") shouldBe Some(bankAccountDetails.accountNumber.value)
@@ -532,7 +550,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              )
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -561,7 +581,7 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no")
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -589,7 +609,7 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc => {
-              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed")
+              getErrorSummary(doc)                    shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed")
               getInputBoxValue(doc, "account-name")   shouldBe Some("")
               getInputBoxValue(doc, "sort-code")      shouldBe Some("")
               getInputBoxValue(doc, "account-number") shouldBe Some("")
@@ -617,7 +637,9 @@ class EnterBankAccountDetailsControllerSpec
             controller.validateBankAccountDetails(journey, bankAccountDetails, postCode).map(_._2),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -713,10 +735,10 @@ class EnterBankAccountDetailsControllerSpec
 
   "Form Validation" must {
     val form          = enterBankDetailsForm
-    val accountName   = "enter-bank-details.account-name"
-    val isBusiness    = "enter-bank-details.is-business-account"
-    val sortCode      = "enter-bank-details.sort-code"
-    val accountNumber = "enter-bank-details.account-number"
+    val accountName   = "enter-bank-account-details.account-name"
+    val isBusiness    = "enter-bank-account-details.is-business-account"
+    val sortCode      = "enter-bank-account-details.sort-code"
+    val accountNumber = "enter-bank-account-details.account-number"
 
     val goodData = Map(
       accountName   -> "Barkhan Seer",

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterBankAccountDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterBankAccountDetailsControllerSpec.scala
@@ -81,7 +81,7 @@ class EnterBankAccountDetailsControllerSpec
   implicit val request: Request[_] = FakeRequest()
 
   private lazy val featureSwitch  = instanceOf[FeatureSwitchService]
-  private val messagesKey: String = "enter-bank-details"
+  private val messagesKey: String = "enter-bank-account-details"
 
   override def beforeEach(): Unit =
     featureSwitch.enable(Feature.RejectedGoods)
@@ -130,9 +130,9 @@ class EnterBankAccountDetailsControllerSpec
           performAction(),
           messageFromMessageKey(s"$messagesKey.title"),
           doc => {
-            selectedInputBox(doc, "enter-bank-details.account-name")   shouldBe Some("")
-            selectedInputBox(doc, "enter-bank-details.sort-code")      shouldBe Some("")
-            selectedInputBox(doc, "enter-bank-details.account-number") shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-account-details.account-name")   shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-account-details.sort-code")      shouldBe Some("")
+            selectedInputBox(doc, "enter-bank-account-details.account-number") shouldBe Some("")
           }
         )
 
@@ -198,7 +198,9 @@ class EnterBankAccountDetailsControllerSpec
             validatedResult(bankAccountDetails, Some(BankAccountType.Personal), postCode),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -220,7 +222,10 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             validatedResult(bankAccountDetails, Some(BankAccountType.Personal), postCode),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error"),
+            doc =>
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-exists-error"
+              ),
             BAD_REQUEST
           )
         }
@@ -243,7 +248,7 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             validatedResult(bankAccountDetails, Some(BankAccountType.Personal), postCode),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no"),
+            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no"),
             BAD_REQUEST
           )
         }
@@ -267,7 +272,8 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             validatedResult(bankAccountDetails, Some(BankAccountType.Personal), postCode),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed"),
+            doc =>
+              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed"),
             BAD_REQUEST
           )
         }
@@ -291,7 +297,9 @@ class EnterBankAccountDetailsControllerSpec
             validatedResult(bankAccountDetails, Some(BankAccountType.Personal), postCode),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -337,7 +345,9 @@ class EnterBankAccountDetailsControllerSpec
             validatedResult(bankAccountDetails, Some(BankAccountType.Business), postCode),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -359,7 +369,10 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             validatedResult(bankAccountDetails, Some(BankAccountType.Business), postCode),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-exists-error"),
+            doc =>
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-exists-error"
+              ),
             BAD_REQUEST
           )
         }
@@ -382,7 +395,7 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             validatedResult(bankAccountDetails, Some(BankAccountType.Business), postCode),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-no"),
+            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-no"),
             BAD_REQUEST
           )
         }
@@ -406,7 +419,8 @@ class EnterBankAccountDetailsControllerSpec
           checkPageIsDisplayed(
             validatedResult(bankAccountDetails, Some(BankAccountType.Business), postCode),
             messageFromMessageKey(s"$messagesKey.title"),
-            doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.moc-check-failed"),
+            doc =>
+              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-account-details.error.moc-check-failed"),
             BAD_REQUEST
           )
         }
@@ -430,7 +444,9 @@ class EnterBankAccountDetailsControllerSpec
             validatedResult(bankAccountDetails, Some(BankAccountType.Business), postCode),
             messageFromMessageKey(s"$messagesKey.title"),
             doc =>
-              getErrorSummary(doc) shouldBe messageFromMessageKey("enter-bank-details.error.account-does-not-exist"),
+              getErrorSummary(doc) shouldBe messageFromMessageKey(
+                "enter-bank-account-details.error.account-does-not-exist"
+              ),
             BAD_REQUEST
           )
         }
@@ -521,10 +537,10 @@ class EnterBankAccountDetailsControllerSpec
 
   "Form Validation" must {
     val form          = enterBankDetailsForm
-    val accountName   = "enter-bank-details.account-name"
-    val isBusiness    = "enter-bank-details.is-business-account"
-    val sortCode      = "enter-bank-details.sort-code"
-    val accountNumber = "enter-bank-details.account-number"
+    val accountName   = "enter-bank-account-details.account-name"
+    val isBusiness    = "enter-bank-account-details.is-business-account"
+    val sortCode      = "enter-bank-account-details.sort-code"
+    val accountNumber = "enter-bank-account-details.account-number"
 
     val goodData = Map(
       accountName   -> "Barkhan Seer",

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterBankAccountDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterBankAccountDetailsControllerSpec.scala
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities
+
+import org.jsoup.nodes.Document
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.OptionValues
+import play.api.i18n.Lang
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
+import play.api.inject.bind
+import play.api.inject.guice.GuiceableModule
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ServiceUnavailableError
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.MockBankAccountReputationService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.PropertyBasedControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.common.{routes => commonRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourneyGenerators._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.BankAccountReputation
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.bankaccountreputation.response.ReputationResponse.Yes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DisplayResponseDetailGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.Future
+
+class EnterBankAccountDetailsControllerSpec
+    extends PropertyBasedControllerSpec
+    with AuthSupport
+    with SessionSupport
+    with BeforeAndAfterEach
+    with MockBankAccountReputationService
+    with OptionValues {
+
+  val messagesKey: String = "enter-bank-account-details"
+
+  override val overrideBindings: List[GuiceableModule] =
+    List[GuiceableModule](
+      bind[AuthConnector].toInstance(mockAuthConnector),
+      bind[SessionCache].toInstance(mockSessionCache),
+      bind[BankAccountReputationService].toInstance(mockBankAccountReputationService)
+    )
+
+  val controller: EnterBankAccountDetailsController = instanceOf[EnterBankAccountDetailsController]
+
+  implicit val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
+
+  implicit val ec: ExecutionContextExecutor = ExecutionContext.global
+
+  private lazy val featureSwitch = instanceOf[FeatureSwitchService]
+
+  override def beforeEach(): Unit =
+    featureSwitch.enable(Feature.Securities)
+
+  def validateEnterBankAccountDetailsPage(
+    doc: Document,
+    journey: SecuritiesJourney,
+    expectedBankAccountDetails: BankAccountDetails =
+      BankAccountDetails(AccountName(""), SortCode(""), AccountNumber("")),
+    error: Boolean = false
+  ) = {
+    val title         = doc.select("title").eachText().asScala.toList
+    val heading       = doc.select(".govuk-heading-xl").eachText().asScala.toList
+    val accountName   =
+      doc.select("input[name='enter-bank-account-details.account-name']").first().attr("value")
+    val sortCode      =
+      doc.select("input[name='enter-bank-account-details.sort-code']").first().attr("value")
+    val accountNumber =
+      doc.select("input[name='enter-bank-account-details.account-number']").first().attr("value")
+    title         should ===(
+      List(
+        (if (error) "ERROR: "
+         else "") + "Enter your bank account details - Claim back import duty and VAT - GOV.UK"
+      )
+    )
+    heading       should ===(List("Enter your bank account details"))
+    accountName   should ===(expectedBankAccountDetails.accountName.value)
+    sortCode      should ===(expectedBankAccountDetails.sortCode.value)
+    accountNumber should ===(expectedBankAccountDetails.accountNumber.value)
+  }
+
+  "Enter Bank Account Details Controller" when {
+    "Show Enter Bank Account Details page" must {
+
+      def performAction(): Future[Result] =
+        controller.show(FakeRequest())
+
+      "do not find the page if rejected goods feature is disabled" in {
+        featureSwitch.disable(Feature.Securities)
+
+        status(performAction()) shouldBe NOT_FOUND
+      }
+
+      "Display the page" in {
+        forAll(completeJourneyGen) { journey =>
+          val session = SessionData(journey)
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(session)
+          }
+          checkPageIsDisplayed(
+            performAction(),
+            messageFromMessageKey(s"$messagesKey.title"),
+            doc => validateEnterBankAccountDetailsPage(doc, journey)
+          )
+        }
+      }
+    }
+
+    "Submit Enter Bank Account Details page" must {
+
+      def performAction(data: Seq[(String, String)]): Future[Result] =
+        controller.submit()(
+          FakeRequest().withFormUrlEncodedBody(data: _*)
+        )
+
+      "do not find the page if securities feature is disabled" in {
+        featureSwitch.disable(Feature.Securities)
+        status(performAction(Seq.empty)) shouldBe NOT_FOUND
+      }
+
+      "Continue when Mandatory fields are filled and bank account is unavailable" in {
+        forAll(completeJourneyGen, genBankAccountDetails) { case (journey, bankAccountDetails) =>
+          val session                = SessionData(journey)
+          val bankAccountDataToEnter = Seq(
+            "enter-bank-account-details.account-name"   -> bankAccountDetails.accountName.value,
+            "enter-bank-account-details.sort-code"      -> bankAccountDetails.sortCode.value,
+            "enter-bank-account-details.account-number" -> bankAccountDetails.accountNumber.value
+          )
+          journey.answers.bankAccountType
+            .fold {
+              inSequence {
+                mockAuthWithNoRetrievals()
+                mockGetSession(session)
+              }
+              checkIsRedirect(
+                performAction(bankAccountDataToEnter),
+                routes.ChooseBankAccountTypeController.show()
+              )
+            } { bankAccountType =>
+              inSequence {
+                mockAuthWithNoRetrievals()
+                mockGetSession(session)
+                mockBankAccountReputation(
+                  bankAccountType,
+                  bankAccountDetails,
+                  None,
+                  Left[ConnectorError, BankAccountReputation](ServiceUnavailableError("this is a mock service"))
+                )
+              }
+              checkIsRedirect(
+                performAction(bankAccountDataToEnter),
+                commonRoutes.ServiceUnavailableController.show()
+              )
+            }
+        }
+      }
+
+      "Continue when Mandatory fields are filled and bank account is available" in {
+        forAll(completeJourneyGen, genBankAccountDetails) { case (journey, bankAccountDetails) =>
+          val session                = SessionData(journey)
+          val bankAccountDataToEnter = Seq(
+            "enter-bank-account-details.account-name"   -> bankAccountDetails.accountName.value,
+            "enter-bank-account-details.sort-code"      -> bankAccountDetails.sortCode.value,
+            "enter-bank-account-details.account-number" -> bankAccountDetails.accountNumber.value
+          )
+          journey.answers.bankAccountType
+            .fold {
+              inSequence {
+                mockAuthWithNoRetrievals()
+                mockGetSession(session)
+              }
+              checkIsRedirect(
+                performAction(bankAccountDataToEnter),
+                routes.ChooseBankAccountTypeController.show()
+              )
+            } { bankAccountType =>
+              inSequence {
+                mockAuthWithNoRetrievals()
+                mockGetSession(session)
+                mockBankAccountReputation(
+                  bankAccountType,
+                  bankAccountDetails,
+                  None,
+                  Right[ConnectorError, BankAccountReputation](
+                    BankAccountReputation(Yes, Some(Yes))
+                  )
+                )
+                mockStoreSession(Right(()))
+              }
+              checkIsRedirect(
+                performAction(bankAccountDataToEnter),
+                routes.CheckBankDetailsController.show()
+              )
+            }
+        }
+      }
+
+      "Display errors when account details are blank" in {
+        forAll(completeJourneyGen) { journey =>
+          whenever(journey.answers.bankAccountType.isDefined) {
+            val session                = SessionData(journey)
+            val bankAccountDataToEnter = Seq(
+              "enter-bank-account-details.account-name"   -> "",
+              "enter-bank-account-details.sort-code"      -> "",
+              "enter-bank-account-details.account-number" -> ""
+            )
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(session)
+            }
+            checkPageIsDisplayed(
+              performAction(bankAccountDataToEnter),
+              messageFromMessageKey(s"$messagesKey.title"),
+              doc => {
+                validateEnterBankAccountDetailsPage(
+                  doc,
+                  journey,
+                  BankAccountDetails(AccountName(""), SortCode(""), AccountNumber("")),
+                  true
+                )
+                doc
+                  .select(".govuk-error-summary__list > li:nth-child(1) > a")
+                  .text() should ===("Enter the name on the account")
+                doc
+                  .select(".govuk-error-summary__list > li:nth-child(2) > a")
+                  .text() should ===("Enter a sort code")
+                doc
+                  .select(".govuk-error-summary__list > li:nth-child(3) > a")
+                  .text() should ===("Enter an account number")
+              },
+              BAD_REQUEST
+            )
+          }
+        }
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
…tDetailsController, refactor common code and template

CDSR-1560 refactor common code
CDSR-1560 AC1 passing
CDSR-1560 factor out common code into EnterBankDetailsMixin
CDSR-1560 submit with securities feature disabled passing
CDSR-1560 add EnterBankAccountDetailsMixin
CDSR-1560 update error message key from enter-bank-details to enter-bank-acount-details in rejected goods scheduled controller
CDSR-1560 Continue when Mandatory fields are filled and bank account is availablei/unavailable passing
CDSR-1560 Display errors when account details are blank passing