### PR TITLE
[CDSR-1804] remove `unsafe-inline`, use CSPNonce, change back links impl

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,15 +14,14 @@ const CDSR = {
     errorInputElement: document.querySelector('#file-upload-error'),
     errorsShowing: false,
 
-    backLinkContainer: document.querySelector('#cdsr-back-link'),
+    backLinkAnchor: document.querySelector('.govuk-back-link'),
 
     Init: () => {
 
         // Add back link
 
-        if (CDSR.backLinkContainer) {
-            const backLink = `<a href="javascript:history.back()" class="govuk-back-link">Back</a>`;
-            CDSR.backLinkContainer.innerHTML = backLink;
+        if (CDSR.backLinkAnchor) {
+            CDSR.backLinkAnchor.addEventListener('click', CDSR.NavigateBack);
         }
 
         // Initialise file upload check
@@ -39,6 +38,11 @@ const CDSR = {
             feedbackLink.setAttribute('target', '_blank');
         }
 
+    },
+
+    NavigateBack: (event) => {
+        event.preventDefault();
+        history.back();
     },
 
     CheckFileInputs: (event) => {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/Head.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/Head.scala.html
@@ -15,11 +15,13 @@
  *@
 
 @import play.twirl.api.Html
+@import play.api.mvc.Request
+@import views.html.helper.CSPNonce
 
 @this()
 
-@(headBlock: Option[Html] = None)
+@(headBlock: Option[Html] = None)(implicit request: Request[_])
 @headBlock
 <!--[if lte IE 8]><script src='@controllers.routes.Assets.versioned("javascripts/html5shiv.min.js")'></script><![endif]-->
 <!--[if lte IE 8]><link href='@controllers.routes.Assets.versioned("stylesheets/application-ie-8.css")' rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if gt IE 8]><!--><link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+<!--[if gt IE 8]><!--><link @{CSPNonce.attr} href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/Layout.scala.html
@@ -40,6 +40,9 @@
 @import views.html.helper.CSPNonce
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.routes.StartController
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcReportTechnicalIssueHelper
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukBackLink
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.backlink.BackLink
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 
 @this(
         head: Head,
@@ -47,7 +50,8 @@
         hmrcReportTechnicalIssueHelper: HmrcReportTechnicalIssueHelper,
         StandardAlphaBanner: StandardAlphaBanner,
         languageSelect: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.language_select,
-        hmrcTimeoutDialog: uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcTimeoutDialog
+        hmrcTimeoutDialog: uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcTimeoutDialog,
+        govukBackLink: GovukBackLink
 )
 
 @(
@@ -84,15 +88,17 @@
 
 @scripts = {
 @scriptsBlock
-    <script src='@_root_.controllers.routes.Assets.versioned("lib/govuk-frontend/govuk/all.js")'></script>
-    <script src='@_root_.controllers.routes.Assets.versioned("lib/hmrc-frontend/hmrc/all.js")'></script>
-    <script src='@_root_.controllers.routes.Assets.versioned("javascripts/application.js")'></script>
+    <script @{CSPNonce.attr} src='@_root_.controllers.routes.Assets.versioned("lib/govuk-frontend/govuk/all.js")'></script>
+    <script @{CSPNonce.attr} src='@_root_.controllers.routes.Assets.versioned("lib/hmrc-frontend/hmrc/all.js")'></script>
+    <script @{CSPNonce.attr} src='@_root_.controllers.routes.Assets.versioned("javascripts/application.js")'></script>
 }
 
 @beforeContentBlock = {
     <div class="cds-user-banner cds-no-border">
         @if(!suppressBackLink) {
-            <div id="cdsr-back-link"></div>
+            <div id="cdsr-back-link">
+                @govukBackLink(BackLink(content = Text(messages("back.text"))))
+            </div>
         }
         <div>
         @if(viewConfig.enableLanguageSwitching) {@languageSelect()}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -42,10 +42,20 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.http.errorHandler = "uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler"
 
 play.filters.enabled += play.filters.csp.CSPFilter
-play.filters.csp.directives {
-  default-src = "'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com data:"
-  script-src = null
-  object-src = null
+play.filters.csp{
+  
+  directives {
+    default-src = "'self' localhost:12345 localhost:9000 localhost:9032 www.google-analytics.com data:"
+    script-src = ${play.filters.csp.nonce.pattern}
+    object-src = null
+    style-src = "'self'"
+  }
+
+  nonce {
+    enabled = true
+    pattern = "%CSP_NONCE_PATTERN%"
+    header = false
+  }
 }
 
 # Play Modules

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,7 +45,7 @@ play.filters.enabled += play.filters.csp.CSPFilter
 play.filters.csp{
   
   directives {
-    default-src = "'self' localhost:12345 localhost:9000 localhost:9032 www.google-analytics.com data:"
+    default-src = "'self' localhost:12345 localhost:9000 localhost:9032 www.google-analytics.com www.googletagmanager.com data:"
     script-src = ${play.filters.csp.nonce.pattern}
     object-src = null
     style-src = "'self'"


### PR DESCRIPTION
This PR attemps to remove use of `unsafe-inline` CSP by:
- using CSPNonce for locally hosted scripts
- removal of javascript:history.back() URLs in favour of click event handling