### PR TITLE
Fix test using wrong message

### DIFF
--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterMovementReferenceNumberControllerSpec.scala
@@ -181,7 +181,7 @@ class EnterMovementReferenceNumberControllerSpec
         checkPageIsDisplayed(
           performAction(enterMovementReferenceNumberKey -> ""),
           messageFromMessageKey("enter-movement-reference-number.rejected-goods.single.title"),
-          doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-movement-reference-number.invalid.number"),
+          doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-movement-reference-number.error.required"),
           expectedStatus = BAD_REQUEST
         )
       }


### PR DESCRIPTION
Recent content change revealed a test using the wrong messages parameter.