### PR TITLE
[CDSR-1113] add LimitedAccess feature and configurable allow list of EORI numbers

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/Feature.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/Feature.scala
@@ -27,12 +27,14 @@ object Feature {
   case object RejectedGoods extends Feature { val name = "rejected-goods" }
   case object Securities extends Feature { val name = "securities" }
   case object InternalUploadDocuments extends Feature { val name = "internal-upload-documents" }
+  case object LimitedAccess extends Feature { val name = "limited-access" }
 
   def of(name: String): Option[Feature] =
     Seq[Feature](
       RejectedGoods,
       InternalUploadDocuments,
-      Securities
+      Securities,
+      LimitedAccess
     ).find(_.name === name)
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -251,6 +251,11 @@ enable-language-switching = false
 
 footerLinkItems = ["cookies", "privacy", "termsConditions", "govukHelp"]
 
+# Base64 encoded list of allowed EORI numbers
+# Example: GB000000000000001,GB000000000000002 encodes as R0IwMDAwMDAwMDAwMDAwMDEsR0IwMDAwMDAwMDAwMDAwMDIK
+limited-access-eori-csv-base64 = ""
+
 features.rejected-goods = on
 features.securities = on
 features.internal-upload-documents = off
+features.limited-access = off

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/AuthSupport.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.TestFeatureSwitchService
 
 trait AuthSupport {
   this: ControllerSpec with SessionSupport =>
@@ -40,7 +41,8 @@ trait AuthSupport {
     mockAuthConnector,
     instanceOf[Configuration],
     instanceOf[ErrorHandler],
-    mockSessionCache
+    mockSessionCache,
+    new TestFeatureSwitchService()
   )(instanceOf[ExecutionContext])
 
   def mockAuth[R](predicate: Predicate, retrieval: Retrieval[R])(

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthActionSpec.scala
@@ -40,6 +40,7 @@ trait AuthActionSpec { this: MockFactory =>
            |bas-gateway.signInUrl = "$signInUrl"
            |gg.origin             = "$origin"
            |self.url              = "$selfBaseUrl"
+           |limited-access-eori-csv-base64 = "R0IwMDAwMDAwMDAwMDAwMDEsR0IwMDAwMDAwMDAwMDAwMDIK"
     """.stripMargin
       )
     )

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthenticatedActionSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthenticatedActionSpec.scala
@@ -18,102 +18,228 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions
 
 import org.scalamock.scalatest.MockFactory
 import play.api.i18n.MessagesApi
-import play.api.mvc.Results.Ok
 import play.api.mvc.MessagesRequest
 import play.api.mvc.Result
+import play.api.mvc.Results.Ok
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.retrieve.EmptyRetrieval
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.TestFeatureSwitchService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class AuthenticatedActionSpec extends ControllerSpec with MockFactory with SessionSupport with AuthActionSpec {
 
-  val authenticatedAction =
-    new AuthenticatedAction(
-      mockAuthConnector,
-      config,
-      instanceOf[ErrorHandler],
-      mockSessionCache
-    )
-
-  def performAction[A](r: FakeRequest[A]): Future[Result] = {
-    @SuppressWarnings(Array("org.wartremover.warts.Any"))
-    val request = new MessagesRequest[A](r, stub[MessagesApi])
-    authenticatedAction.invokeBlock(
-      request,
-      { a: AuthenticatedRequest[A] =>
-        a.request.messagesApi shouldBe request.messagesApi
-        Future.successful(Ok)
-      }
-    )
-  }
-
   "AuthenticatedAction" when {
 
-    "handling a not logged in user" must {
+    "limited access disabled" must {
 
-      "redirect to the login page" in {
-        val requestUri = "/abc"
+      val authenticatedAction =
+        new AuthenticatedAction(
+          mockAuthConnector,
+          config,
+          instanceOf[ErrorHandler],
+          mockSessionCache,
+          new TestFeatureSwitchService()
+        )
 
-        List[NoActiveSession](
-          BearerTokenExpired(),
-          MissingBearerToken(),
-          InvalidBearerToken(),
-          SessionRecordNotFound()
-        ).foreach { e =>
-          withClue(s"For error $e: ") {
-            mockAuth(EmptyPredicate, EmptyRetrieval)(Future.failed(e))
-
-            val result = performAction(FakeRequest("GET", requestUri))
-            status(result) shouldBe SEE_OTHER
-
-            val redirectTo = redirectLocation(result)
-            redirectTo shouldBe Some(
-              s"$signInUrl?continue=${urlEncode(selfBaseUrl + requestUri)}&origin=$origin"
-            )
+      def performAction[A](r: FakeRequest[A]): Future[Result] = {
+        @SuppressWarnings(Array("org.wartremover.warts.Any"))
+        val request = new MessagesRequest[A](r, stub[MessagesApi])
+        authenticatedAction.invokeBlock(
+          request,
+          { a: AuthenticatedRequest[A] =>
+            a.request.messagesApi shouldBe request.messagesApi
+            Future.successful(Ok)
           }
-        }
-      }
-    }
-
-    "handling a logged in user" must {
-
-      "effect the request action" in {
-        mockAuth(EmptyPredicate, EmptyRetrieval)(Future.successful(()))
-
-        val result = performAction(FakeRequest())
-        status(result) shouldBe OK
+        )
       }
 
-    }
+      "handling a not logged in user" must {
 
-    "handling the case when an authorisation exception is thrown" must {
+        "redirect to the login page" in {
+          val requestUri = "/abc"
 
-      "throw an exception" in {
-        List[AuthorisationException](
-          InsufficientEnrolments(),
-          UnsupportedAffinityGroup(),
-          UnsupportedCredentialRole(),
-          UnsupportedAuthProvider(),
-          IncorrectCredentialStrength(),
-          InternalError()
-        ).foreach { e =>
-          withClue(s"For error $e: ") {
-            val exception = intercept[AuthorisationException] {
+          List[NoActiveSession](
+            BearerTokenExpired(),
+            MissingBearerToken(),
+            InvalidBearerToken(),
+            SessionRecordNotFound()
+          ).foreach { e =>
+            withClue(s"For error $e: ") {
               mockAuth(EmptyPredicate, EmptyRetrieval)(Future.failed(e))
-              await(performAction(FakeRequest()))
-            }
 
-            exception shouldBe e
+              val result = performAction(FakeRequest("GET", requestUri))
+              status(result) shouldBe SEE_OTHER
+
+              val redirectTo = redirectLocation(result)
+              redirectTo shouldBe Some(
+                s"$signInUrl?continue=${urlEncode(selfBaseUrl + requestUri)}&origin=$origin"
+              )
+            }
           }
         }
+      }
+
+      "handling a logged in user" must {
+
+        "effect the request action" in {
+          mockAuth(EmptyPredicate, EmptyRetrieval)(Future.successful(()))
+
+          val result = performAction(FakeRequest())
+          status(result) shouldBe OK
+        }
+
+      }
+
+      "handling the case when an authorisation exception is thrown" must {
+
+        "throw an exception" in {
+          List[AuthorisationException](
+            InsufficientEnrolments(),
+            UnsupportedAffinityGroup(),
+            UnsupportedCredentialRole(),
+            UnsupportedAuthProvider(),
+            IncorrectCredentialStrength(),
+            InternalError()
+          ).foreach { e =>
+            withClue(s"For error $e: ") {
+              val exception = intercept[AuthorisationException] {
+                mockAuth(EmptyPredicate, EmptyRetrieval)(Future.failed(e))
+                await(performAction(FakeRequest()))
+              }
+
+              exception shouldBe e
+            }
+          }
+        }
+      }
+    }
+
+    "limited access enabled" must {
+
+      val authenticatedAction =
+        new AuthenticatedAction(
+          mockAuthConnector,
+          config,
+          instanceOf[ErrorHandler],
+          mockSessionCache,
+          new TestFeatureSwitchService(Feature.LimitedAccess)
+        )
+
+      def performAction[A](r: FakeRequest[A]): Future[Result] = {
+        @SuppressWarnings(Array("org.wartremover.warts.Any"))
+        val request = new MessagesRequest[A](r, stub[MessagesApi])
+        authenticatedAction.invokeBlock(
+          request,
+          { a: AuthenticatedRequest[A] =>
+            a.request.messagesApi shouldBe request.messagesApi
+            Future.successful(Ok)
+          }
+        )
+      }
+
+      val retrievals: Retrieval[Enrolments] =
+        Retrievals.allEnrolments
+
+      "handling a not logged in user" must {
+
+        "redirect to the login page" in {
+          val requestUri = "/abc"
+
+          List[NoActiveSession](
+            BearerTokenExpired(),
+            MissingBearerToken(),
+            InvalidBearerToken(),
+            SessionRecordNotFound()
+          ).foreach { e =>
+            withClue(s"For error $e: ") {
+              mockAuth(EmptyPredicate, retrievals)(Future.failed(e))
+
+              val result = performAction(FakeRequest("GET", requestUri))
+              status(result) shouldBe SEE_OTHER
+
+              val redirectTo = redirectLocation(result)
+              redirectTo shouldBe Some(
+                s"$signInUrl?continue=${urlEncode(selfBaseUrl + requestUri)}&origin=$origin"
+              )
+            }
+          }
+        }
+      }
+
+      "handling a logged in user" must {
+
+        def eoriEnrolment(eori: String): Enrolments = Enrolments(
+          Set(
+            Enrolment(
+              "HMRC-CUS-ORG",
+              Seq(
+                EnrolmentIdentifier(
+                  "EORINumber",
+                  eori
+                )
+              ),
+              "Activated",
+              None
+            )
+          )
+        )
+
+        "effect the request action when user is on the allow list #1" in {
+          mockAuth(EmptyPredicate, retrievals)(Future.successful(eoriEnrolment("GB000000000000001")))
+
+          val result = performAction(FakeRequest())
+          status(result) shouldBe OK
+        }
+
+        "effect the request action when user is on the allow list #2" in {
+          mockAuth(EmptyPredicate, retrievals)(Future.successful(eoriEnrolment("GB000000000000002")))
+
+          val result = performAction(FakeRequest())
+          status(result) shouldBe OK
+        }
+
+        "redirect to the start page when user is NOT on the allow list" in {
+          mockAuth(EmptyPredicate, retrievals)(Future.successful(eoriEnrolment("GB000000000000003")))
+
+          val result = performAction(FakeRequest())
+          status(result)           shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some("/claim-back-import-duty-vat/unauthorised")
+        }
+
+        "handling the case when an authorisation exception is thrown" must {
+
+          "throw an exception" in {
+            List[AuthorisationException](
+              InsufficientEnrolments(),
+              UnsupportedAffinityGroup(),
+              UnsupportedCredentialRole(),
+              UnsupportedAuthProvider(),
+              IncorrectCredentialStrength(),
+              InternalError()
+            ).foreach { e =>
+              withClue(s"For error $e: ") {
+                val exception = intercept[AuthorisationException] {
+                  mockAuth(EmptyPredicate, retrievals)(Future.failed(e))
+                  await(performAction(FakeRequest()))
+                }
+
+                exception shouldBe e
+              }
+            }
+          }
+        }
+
       }
     }
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthenticatedActionWithRetrievedDataSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthenticatedActionWithRetrievedDataSpec.scala
@@ -44,9 +44,11 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.contactdetails.Email
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.TestFeatureSwitchService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 
 class AuthenticatedActionWithRetrievedDataSpec
     extends ControllerSpec
@@ -54,27 +56,7 @@ class AuthenticatedActionWithRetrievedDataSpec
     with SessionSupport
     with AuthActionSpec {
 
-  val authenticatedAction =
-    new AuthenticatedActionWithRetrievedData(
-      mockAuthConnector,
-      config,
-      instanceOf[ErrorHandler],
-      mockSessionCache
-    )
-
   implicit val format: OFormat[RetrievedUserType] = derived.oformat[RetrievedUserType]()
-
-  def performAction[A](r: FakeRequest[A]): Future[Result] = {
-    @SuppressWarnings(Array("org.wartremover.warts.Any"))
-    val request = new MessagesRequest[A](r, stub[MessagesApi])
-    authenticatedAction.invokeBlock(
-      request,
-      { a: AuthenticatedRequestWithRetrievedData[A] =>
-        a.request.messagesApi shouldBe request.messagesApi
-        Future.successful(Ok(Json.toJson(a.journeyUserType)))
-      }
-    )
-  }
 
   val retrievals: Retrieval[Option[AffinityGroup] ~ Option[String] ~ Enrolments ~ Option[Credentials] ~ Option[Name]] =
     Retrievals.affinityGroup and
@@ -85,16 +67,14 @@ class AuthenticatedActionWithRetrievedDataSpec
 
   val emptyEnrolments: Enrolments = Enrolments(Set.empty)
 
-  val eori: Eori = sample[Eori]
-
-  val eoriEnrolment: Enrolments = Enrolments(
+  def eoriEnrolment(eori: String): Enrolments = Enrolments(
     Set(
       Enrolment(
         "HMRC-CUS-ORG",
         Seq(
           EnrolmentIdentifier(
             "EORINumber",
-            eori.value
+            eori
           )
         ),
         "Activated",
@@ -125,161 +105,391 @@ class AuthenticatedActionWithRetrievedDataSpec
 
   "Authenticated action with retrieved data" when {
 
-    "handling a user who has logged in with an auth provider which isn't gg" must {
+    "limited access disabled" must {
 
-      "return the auth provider id" in {
-        val providerType     = "other provider"
-        val retrievalsResult =
-          Future successful (new ~(Some(AffinityGroup.Organisation), Some("email")) and emptyEnrolments and Some(
-            Credentials("id", providerType)
-          ) and Some(Name(Some("John Smith"), Some("Smith"))))
+      val authenticatedAction =
+        new AuthenticatedActionWithRetrievedData(
+          mockAuthConnector,
+          config,
+          instanceOf[ErrorHandler],
+          mockSessionCache,
+          new TestFeatureSwitchService()
+        )
 
-        mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
-
-        val result = performAction(FakeRequest())
-
-        status(result)        shouldBe OK
-        contentAsJson(result) shouldBe Json.toJson[RetrievedUserType](
-          RetrievedUserType.NonGovernmentGatewayRetrievedUser(providerType)
+      def performAction[A](r: FakeRequest[A]): Future[Result] = {
+        @SuppressWarnings(Array("org.wartremover.warts.Any"))
+        val request = new MessagesRequest[A](r, stub[MessagesApi])
+        authenticatedAction.invokeBlock(
+          request,
+          { a: AuthenticatedRequestWithRetrievedData[A] =>
+            a.request.messagesApi shouldBe request.messagesApi
+            Future.successful(Ok(Json.toJson(a.journeyUserType)))
+          }
         )
       }
 
-    }
+      "handling a user who has logged in with an auth provider which isn't gg" must {
 
-    "handling a logged in user with an eori enrolment" must {
+        "return the auth provider id" in {
+          val providerType     = "other provider"
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Organisation), Some("email")) and emptyEnrolments and Some(
+              Credentials("id", providerType)
+            ) and Some(Name(Some("John Smith"), Some("Smith"))))
 
-      "return the signed in details for an individual" in {
-        val retrievalsResult =
-          Future successful (new ~(Some(AffinityGroup.Individual), Some("email")) and eoriEnrolment and Some(
-            ggCredentials
-          ) and Some(Name(Some("John Smith"), Some("Smith"))))
-
-        mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
-
-        val result = performAction(FakeRequest())
-
-        status(result)        shouldBe OK
-        contentAsJson(result) shouldBe Json.toJson[RetrievedUserType](
-          RetrievedUserType
-            .Individual(
-              GGCredId("id"),
-              Some(Email("email")),
-              eori,
-              Some(contactdetails.Name(Some("John Smith"), Some("Smith")))
-            )
-        )
-      }
-
-      "return the signed in details for an organisation" in {
-        val retrievalsResult =
-          Future successful (new ~(Some(AffinityGroup.Organisation), Some("email")) and eoriEnrolment and Some(
-            ggCredentials
-          ) and None)
-
-        mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
-
-        val result = performAction(FakeRequest())
-
-        status(result)        shouldBe OK
-        contentAsJson(result) shouldBe Json.toJson[RetrievedUserType](
-          RetrievedUserType
-            .Organisation(
-              GGCredId("id"),
-              Some(Email("email")),
-              eori,
-              None
-            )
-        )
-      }
-    }
-
-    "handling a logged in user with no eori enrolment" must {
-
-      "redirect to unauthorised page" in {
-        val retrievalsResult =
-          Future successful (new ~(Some(AffinityGroup.Individual), Some("email")) and emptyEnrolments and Some(
-            ggCredentials
-          ) and Some(Name(Some("John Smith"), Some("Smith"))))
-
-        inSequence {
           mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+
+          val result = performAction(FakeRequest())
+
+          status(result)        shouldBe OK
+          contentAsJson(result) shouldBe Json.toJson[RetrievedUserType](
+            RetrievedUserType.NonGovernmentGatewayRetrievedUser(providerType)
+          )
         }
 
-        val result = performAction(FakeRequest())
-
-        val redirectTo = redirectLocation(result)
-        redirectTo shouldBe Some(
-          routes.UnauthorisedController.unauthorised().url
-        )
       }
-    }
 
-    "handling cases with incorrect type of credentials" must {
+      "handling a logged in user with an eori enrolment" must {
 
-      "redirect to unauthorised page" in {
-        val retrievalsResult =
-          Future successful (new ~(Some(AffinityGroup.Individual), Some("email")) and someOtherEnrolment and Some(
-            ggCredentials
-          ) and Some(Name(Some("John Smith"), Some("Smith"))))
+        val eori = sample[Eori]
 
-        inSequence {
+        "return the signed in details for an individual" in {
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Individual), Some("email")) and eoriEnrolment(
+              eori.value
+            ) and Some(
+              ggCredentials
+            ) and Some(Name(Some("John Smith"), Some("Smith"))))
+
           mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+
+          val result = performAction(FakeRequest())
+
+          status(result)        shouldBe OK
+          contentAsJson(result) shouldBe Json.toJson[RetrievedUserType](
+            RetrievedUserType
+              .Individual(
+                GGCredId("id"),
+                Some(Email("email")),
+                eori,
+                Some(contactdetails.Name(Some("John Smith"), Some("Smith")))
+              )
+          )
         }
 
-        val result = performAction(FakeRequest())
+        "return the signed in details for an organisation" in {
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Organisation), Some("email")) and eoriEnrolment(
+              eori.value
+            ) and Some(
+              ggCredentials
+            ) and None)
 
-        val redirectTo = redirectLocation(result)
-        redirectTo shouldBe Some(
-          routes.UnauthorisedController.unauthorised().url
-        )
+          mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+
+          val result = performAction(FakeRequest())
+
+          status(result)        shouldBe OK
+          contentAsJson(result) shouldBe Json.toJson[RetrievedUserType](
+            RetrievedUserType
+              .Organisation(
+                GGCredId("id"),
+                Some(Email("email")),
+                eori,
+                None
+              )
+          )
+        }
       }
-    }
 
-    "handling an unauthenticated user" must {
+      "handling a logged in user with no eori enrolment" must {
 
-      "redirect to the login page" in {
-        val requestUri = "/abc"
+        "redirect to unauthorised page" in {
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Individual), Some("email")) and emptyEnrolments and Some(
+              ggCredentials
+            ) and Some(Name(Some("John Smith"), Some("Smith"))))
 
-        List[NoActiveSession](
-          BearerTokenExpired(),
-          MissingBearerToken(),
-          InvalidBearerToken(),
-          SessionRecordNotFound()
-        ).foreach { e =>
-          withClue(s"For error $e: ") {
-            mockAuth(EmptyPredicate, retrievals)(Future.failed(e))
+          inSequence {
+            mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+          }
 
-            val result = performAction(FakeRequest("GET", requestUri))
-            status(result) shouldBe SEE_OTHER
+          val result = performAction(FakeRequest())
 
-            val redirectTo = redirectLocation(result)
-            redirectTo shouldBe Some(
-              s"$signInUrl?continue=${urlEncode(selfBaseUrl + requestUri)}&origin=$origin"
-            )
+          val redirectTo = redirectLocation(result)
+          redirectTo shouldBe Some(
+            routes.UnauthorisedController.unauthorised().url
+          )
+        }
+      }
+
+      "handling cases with incorrect type of credentials" must {
+
+        "redirect to unauthorised page" in {
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Individual), Some("email")) and someOtherEnrolment and Some(
+              ggCredentials
+            ) and Some(Name(Some("John Smith"), Some("Smith"))))
+
+          inSequence {
+            mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+          }
+
+          val result = performAction(FakeRequest())
+
+          val redirectTo = redirectLocation(result)
+          redirectTo shouldBe Some(
+            routes.UnauthorisedController.unauthorised().url
+          )
+        }
+      }
+
+      "handling an unauthenticated user" must {
+
+        "redirect to the login page" in {
+          val requestUri = "/abc"
+
+          List[NoActiveSession](
+            BearerTokenExpired(),
+            MissingBearerToken(),
+            InvalidBearerToken(),
+            SessionRecordNotFound()
+          ).foreach { e =>
+            withClue(s"For error $e: ") {
+              mockAuth(EmptyPredicate, retrievals)(Future.failed(e))
+
+              val result = performAction(FakeRequest("GET", requestUri))
+              status(result) shouldBe SEE_OTHER
+
+              val redirectTo = redirectLocation(result)
+              redirectTo shouldBe Some(
+                s"$signInUrl?continue=${urlEncode(selfBaseUrl + requestUri)}&origin=$origin"
+              )
+            }
+          }
+        }
+      }
+
+      "handling the case when an authorisation exception is thrown" must {
+
+        "throw an exception" in {
+          List[AuthorisationException](
+            InsufficientEnrolments(),
+            UnsupportedAffinityGroup(),
+            UnsupportedAuthProvider(),
+            UnsupportedCredentialRole(),
+            IncorrectCredentialStrength(),
+            InternalError()
+          ).foreach { e =>
+            withClue(s"For error $e: ") {
+              val exception = intercept[AuthorisationException] {
+                mockAuth(EmptyPredicate, retrievals)(Future.failed(e))
+
+                await(performAction(FakeRequest()))
+              }
+
+              exception shouldBe e
+            }
           }
         }
       }
     }
 
-    "handling the case when an authorisation exception is thrown" must {
+    "limited access enabled" must {
 
-      "throw an exception" in {
-        List[AuthorisationException](
-          InsufficientEnrolments(),
-          UnsupportedAffinityGroup(),
-          UnsupportedAuthProvider(),
-          UnsupportedCredentialRole(),
-          IncorrectCredentialStrength(),
-          InternalError()
-        ).foreach { e =>
-          withClue(s"For error $e: ") {
-            val exception = intercept[AuthorisationException] {
+      val authenticatedAction =
+        new AuthenticatedActionWithRetrievedData(
+          mockAuthConnector,
+          config,
+          instanceOf[ErrorHandler],
+          mockSessionCache,
+          new TestFeatureSwitchService(Feature.LimitedAccess)
+        )
+
+      def performAction[A](r: FakeRequest[A]): Future[Result] = {
+        @SuppressWarnings(Array("org.wartremover.warts.Any"))
+        val request = new MessagesRequest[A](r, stub[MessagesApi])
+        authenticatedAction.invokeBlock(
+          request,
+          { a: AuthenticatedRequestWithRetrievedData[A] =>
+            a.request.messagesApi shouldBe request.messagesApi
+            Future.successful(Ok(Json.toJson(a.journeyUserType)))
+          }
+        )
+      }
+
+      "handling a user who has logged in with an auth provider which isn't gg" must {
+
+        "redirect to the start page" in {
+          val providerType     = "other provider"
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Organisation), Some("email")) and emptyEnrolments and Some(
+              Credentials("id", providerType)
+            ) and Some(Name(Some("John Smith"), Some("Smith"))))
+
+          mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+
+          val result = performAction(FakeRequest())
+
+          status(result) shouldBe SEE_OTHER
+        }
+      }
+
+      "handling a logged in user with an eori enrolment" must {
+
+        "return the signed in details for an individual" in {
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Individual), Some("email")) and eoriEnrolment(
+              "GB000000000000001"
+            ) and Some(
+              ggCredentials
+            ) and Some(Name(Some("John Smith"), Some("Smith"))))
+
+          mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+
+          val result = performAction(FakeRequest())
+
+          status(result)        shouldBe OK
+          contentAsJson(result) shouldBe Json.toJson[RetrievedUserType](
+            RetrievedUserType
+              .Individual(
+                GGCredId("id"),
+                Some(Email("email")),
+                Eori("GB000000000000001"),
+                Some(contactdetails.Name(Some("John Smith"), Some("Smith")))
+              )
+          )
+        }
+
+        "return the signed in details for an organisation" in {
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Organisation), Some("email")) and eoriEnrolment(
+              "GB000000000000002"
+            ) and Some(
+              ggCredentials
+            ) and None)
+
+          mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+
+          val result = performAction(FakeRequest())
+
+          status(result)        shouldBe OK
+          contentAsJson(result) shouldBe Json.toJson[RetrievedUserType](
+            RetrievedUserType
+              .Organisation(
+                GGCredId("id"),
+                Some(Email("email")),
+                Eori("GB000000000000002"),
+                None
+              )
+          )
+        }
+
+        "redirect to the start page when user NOT on the allow list" in {
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Organisation), Some("email")) and eoriEnrolment(
+              "GB000000000000003"
+            ) and Some(
+              ggCredentials
+            ) and None)
+
+          mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+
+          val result = performAction(FakeRequest())
+
+          status(result)           shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some("/claim-back-import-duty-vat/unauthorised")
+        }
+      }
+
+      "handling a logged in user with no eori enrolment" must {
+
+        "redirect to unauthorised page" in {
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Individual), Some("email")) and emptyEnrolments and Some(
+              ggCredentials
+            ) and Some(Name(Some("John Smith"), Some("Smith"))))
+
+          inSequence {
+            mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+          }
+
+          val result = performAction(FakeRequest())
+
+          val redirectTo = redirectLocation(result)
+          redirectTo shouldBe Some(
+            routes.UnauthorisedController.unauthorised().url
+          )
+        }
+      }
+
+      "handling cases with incorrect type of credentials" must {
+
+        "redirect to unauthorised page" in {
+          val retrievalsResult =
+            Future successful (new ~(Some(AffinityGroup.Individual), Some("email")) and someOtherEnrolment and Some(
+              ggCredentials
+            ) and Some(Name(Some("John Smith"), Some("Smith"))))
+
+          inSequence {
+            mockAuth(EmptyPredicate, retrievals)(retrievalsResult)
+          }
+
+          val result = performAction(FakeRequest())
+
+          val redirectTo = redirectLocation(result)
+          redirectTo shouldBe Some(
+            routes.UnauthorisedController.unauthorised().url
+          )
+        }
+      }
+
+      "handling an unauthenticated user" must {
+
+        "redirect to the login page" in {
+          val requestUri = "/abc"
+
+          List[NoActiveSession](
+            BearerTokenExpired(),
+            MissingBearerToken(),
+            InvalidBearerToken(),
+            SessionRecordNotFound()
+          ).foreach { e =>
+            withClue(s"For error $e: ") {
               mockAuth(EmptyPredicate, retrievals)(Future.failed(e))
 
-              await(performAction(FakeRequest()))
-            }
+              val result = performAction(FakeRequest("GET", requestUri))
+              status(result) shouldBe SEE_OTHER
 
-            exception shouldBe e
+              val redirectTo = redirectLocation(result)
+              redirectTo shouldBe Some(
+                s"$signInUrl?continue=${urlEncode(selfBaseUrl + requestUri)}&origin=$origin"
+              )
+            }
+          }
+        }
+      }
+
+      "handling the case when an authorisation exception is thrown" must {
+
+        "throw an exception" in {
+          List[AuthorisationException](
+            InsufficientEnrolments(),
+            UnsupportedAffinityGroup(),
+            UnsupportedAuthProvider(),
+            UnsupportedCredentialRole(),
+            IncorrectCredentialStrength(),
+            InternalError()
+          ).foreach { e =>
+            withClue(s"For error $e: ") {
+              val exception = intercept[AuthorisationException] {
+                mockAuth(EmptyPredicate, retrievals)(Future.failed(e))
+
+                await(performAction(FakeRequest()))
+              }
+
+              exception shouldBe e
+            }
           }
         }
       }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/TestFeatureSwitchService.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/TestFeatureSwitchService.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.services
+
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+
+class TestFeatureSwitchService(initialFeatures: Feature*) extends FeatureSwitchService {
+
+  @SuppressWarnings(Array("org.wartremover.warts.MutableDataStructures"))
+  private val features: collection.mutable.Set[Feature] =
+    collection.mutable.Set(initialFeatures: _*)
+
+  def enable(feature: Feature): Boolean =
+    features.add(feature)
+
+  def disable(feature: Feature): Boolean =
+    features.remove(feature)
+
+  def isEnabled(feature: Feature): Boolean =
+    features.contains(feature)
+
+}


### PR DESCRIPTION
This PR adds new feature which can be enabled with adding config property on Github:
 
   features.limited-access: 'true'

When the feature is on then all users are checked against allow list defined as a property:

   limited-access-eori-csv-base64: "XYZ"

where XYZ is a Base64 encoded comma-separated list of the allowed EORI numbers

it can be computed using the following command:

   echo "GB000000000000001,GB000000000000002" | base64