### PR TITLE
[CDSR-1933] refactor existing mixins for greater clarity and code reuse

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyBaseController.scala
@@ -46,11 +46,9 @@ import scala.concurrent.Future
   *  - sesion data retrieval and journey update
   *  - journey completeness check and redirect to the CYA page
   */
-abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
-  fmt: Format[Journey]
-) extends FrontendBaseController
-    with Logging
-    with SeqUtils {
+trait JourneyBaseController extends FrontendBaseController with Logging with SeqUtils {
+
+  type Journey <: uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.Journey with JourneyBase
 
   implicit def ec: ExecutionContext
   implicit def viewConfig: ViewConfig
@@ -128,7 +126,7 @@ abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
         Future.successful(
           request.sessionData
             .flatMap(getJourney)
-            .map(journey =>
+            .map((journey: Journey) =>
               if (journey.isFinalized) Redirect(claimSubmissionConfirmation)
               else
                 checkIfMaybeActionPreconditionFails(journey) match {
@@ -148,7 +146,7 @@ abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
       .authenticatedActionWithRetrievedDataAndSessionData(requiredFeature)
       .async { implicit request =>
         getJourney(request.sessionData)
-          .map(journey =>
+          .map((journey: Journey) =>
             if (journey.isFinalized) Future.successful(Redirect(claimSubmissionConfirmation))
             else
               checkIfMaybeActionPreconditionFails(journey) match {
@@ -167,7 +165,7 @@ abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
       .authenticatedActionWithRetrievedDataAndSessionData(requiredFeature)
       .apply { implicit request =>
         getJourney(request.sessionData)
-          .map(journey =>
+          .map((journey: Journey) =>
             if (journey.isFinalized) Redirect(claimSubmissionConfirmation)
             else
               checkIfMaybeActionPreconditionFails(journey) match {
@@ -187,7 +185,7 @@ abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
       .async { implicit request =>
         request.sessionData
           .flatMap(getJourney)
-          .map(journey =>
+          .map((journey: Journey) =>
             if (journey.isFinalized) Future.successful(Redirect(claimSubmissionConfirmation))
             else
               checkIfMaybeActionPreconditionFails(journey) match {
@@ -210,7 +208,7 @@ abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
         request.sessionData
           .flatMap(sessionData =>
             getJourney(sessionData)
-              .map(journey =>
+              .map((journey: Journey) =>
                 if (journey.isFinalized) (journey, Redirect(claimSubmissionConfirmation))
                 else
                   checkIfMaybeActionPreconditionFails(journey) match {
@@ -242,7 +240,7 @@ abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
       .authenticatedActionWithRetrievedDataAndSessionData(requiredFeature)
       .async { implicit request =>
         getJourney(request.sessionData)
-          .map(journey =>
+          .map((journey: Journey) =>
             if (journey.isFinalized) (journey, Redirect(claimSubmissionConfirmation))
             else
               checkIfMaybeActionPreconditionFails(journey) match {
@@ -273,7 +271,7 @@ abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
         request.sessionData
           .flatMap(sessionData =>
             getJourney(sessionData)
-              .map(journey =>
+              .map((journey: Journey) =>
                 if (journey.isFinalized) Future.successful((journey, Redirect(claimSubmissionConfirmation)))
                 else
                   checkIfMaybeActionPreconditionFails(journey) match {
@@ -306,7 +304,7 @@ abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
         request.sessionData
           .flatMap(sessionData =>
             getJourney(sessionData)
-              .map(journey =>
+              .map((journey: Journey) =>
                 if (journey.isFinalized) Future.successful(Right((journey, Redirect(claimSubmissionConfirmation))))
                 else
                   checkIfMaybeActionPreconditionFails(journey) match {
@@ -342,7 +340,7 @@ abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
       .authenticatedActionWithRetrievedDataAndSessionData(requiredFeature)
       .async { implicit request =>
         getJourney(request.sessionData)
-          .fold(redirectToTheStartOfTheJourney) { journey =>
+          .fold(redirectToTheStartOfTheJourney) { (journey: Journey) =>
             if (journey.isFinalized) Future.successful(Redirect(claimSubmissionConfirmation))
             else
               (checkIfMaybeActionPreconditionFails(journey) match {
@@ -370,7 +368,7 @@ abstract class JourneyBaseController[Journey <: JourneyBase[Journey]](implicit
     def |>[B](f: A => B): B = f(value)
   }
 
-  final def prettyPrint(journey: Journey): String =
+  final def prettyPrint(journey: Journey)(implicit format: Format[Journey]): String =
     Json.prettyPrint(Json.toJson(journey))
 
   final def logAndDisplayError(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/ContactAddressLookupMixin.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/ContactAddressLookupMixin.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins
+
+import play.api.mvc._
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBaseController
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.CanSubmitContactDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.CommonJourneyProperties
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.JourneyBase
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
+
+trait ContactAddressLookupMixin extends JourneyBaseController with AddressLookupMixin {
+
+  type Journey <: uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.Journey with JourneyBase with CommonJourneyProperties with CanSubmitContactDetails
+
+  val redirectWhenNoAddressDetailsFound: Call
+  val nextPageInTheJourney: Call
+
+  def modifyJourney(journey: Journey, contactDetails: MrnContactDetails): Journey
+
+  def viewTemplate: MrnContactDetails => ContactAddress => Request[_] => HtmlFormat.Appendable
+
+  final val show: Action[AnyContent] = actionReadJourneyAndUser { implicit request => journey => retrievedUserType =>
+    val (maybeContactDetails, maybeAddressDetails) =
+      (journey.computeContactDetails(retrievedUserType), journey.computeAddressDetails)
+    (maybeContactDetails, maybeAddressDetails) match {
+      case (Some(cd), Some(ca)) => Ok(viewTemplate(cd)(ca)(request)).asFuture
+      case _                    =>
+        logger.warn(
+          s"Cannot compute ${maybeContactDetails.map(_ => "").getOrElse("contact details")} ${maybeAddressDetails.map(_ => "").getOrElse("address details")}."
+        )
+        Redirect(redirectWhenNoAddressDetailsFound).asFuture
+    }
+
+  }
+
+  final val submit: Action[AnyContent] = actionReadWriteJourneyAndUser { _ => journey => retrievedUserType =>
+    (journey.computeContactDetails(retrievedUserType), journey.computeAddressDetails) match {
+      case (Some(cd), Some(ca)) =>
+        (
+          modifyJourney(modifyJourney(journey, cd), ca),
+          Redirect(nextPageInTheJourney)
+        ).asFuture
+      case _                    =>
+        (
+          journey,
+          Redirect(redirectWhenNoAddressDetailsFound)
+        ).asFuture
+    }
+
+  }
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/EnterBankAccountDetailsMixin.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/EnterBankAccountDetailsMixin.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.ConnectorError.ServiceUnavailableError
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterBankDetailsForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBaseController
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.JourneyBase
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.CdsError
@@ -41,8 +40,8 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
 
-trait EnterBankAccountDetailsMixin[Journey <: JourneyBase[Journey]] {
-  self: JourneyBaseController[Journey] =>
+trait EnterBankAccountDetailsMixin {
+  self: JourneyBaseController =>
 
   val enterBankAccountDetailsPage: enter_bank_account_details
   val bankAccountReputationService: BankAccountReputationService

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/InspectionAddressLookupMixin.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/InspectionAddressLookupMixin.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins
+
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.inspectionAddressTypeForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBaseController
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.HaveInspectionDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.JourneyBase
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsJourneyProperties
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddress
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddressType.Declarant
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddressType.Importer
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddressType.Other
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{rejectedgoods => pages}
+
+trait InspectionAddressLookupMixin extends JourneyBaseController with AddressLookupMixin {
+
+  type Journey <: journeys.Journey with JourneyBase with RejectedGoodsJourneyProperties with HaveInspectionDetails
+
+  val startAddressLookup: Call
+  val postAction: Call
+
+  val inspectionAddressPage: pages.choose_inspection_address_type
+
+  def modifyJourney(journey: Journey, inspectionAddress: InspectionAddress): Journey
+
+  final val show: Action[AnyContent] = actionReadJourney { implicit request => journey =>
+    journey.getPotentialInspectionAddresses match {
+      case Nil =>
+        Redirect(startAddressLookup).asFuture
+      case xs  =>
+        Ok(
+          inspectionAddressPage(
+            xs,
+            inspectionAddressTypeForm.withDefault(journey.getInspectionAddressType),
+            postAction
+          )
+        ).asFuture
+    }
+  }
+
+  final val submit: Action[AnyContent] = actionReadWriteJourney(
+    { implicit request => journey =>
+      inspectionAddressTypeForm
+        .bindFromRequest()
+        .fold(
+          errors =>
+            (
+              journey,
+              BadRequest(inspectionAddressPage(journey.getPotentialInspectionAddresses, errors, postAction))
+            ).asFuture,
+          {
+            case Other     =>
+              (journey, Redirect(startAddressLookup)).asFuture
+            case Declarant =>
+              journey.getDeclarantContactDetailsFromACC14
+                .map { address =>
+                  redirectToTheNextPage(modifyJourney(journey, InspectionAddress.ofType(Declarant).mapFrom(address)))
+                }
+                .getOrElse((journey, Redirect(baseRoutes.IneligibleController.ineligible())))
+                .asFuture
+            case Importer  =>
+              journey.getConsigneeContactDetailsFromACC14
+                .map { address =>
+                  redirectToTheNextPage(modifyJourney(journey, InspectionAddress.ofType(Importer).mapFrom(address)))
+                }
+                .getOrElse((journey, Redirect(baseRoutes.IneligibleController.ineligible())))
+                .asFuture
+          }
+        )
+    },
+    fastForwardToCYAEnabled = false
+  )
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/UploadFilesMixin.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/UploadFilesMixin.scala
@@ -21,7 +21,6 @@ import play.api.mvc.Call
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.FileUploadConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.UploadDocumentsConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBaseController
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.JourneyBase
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Nonce
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.UploadDocumentsSessionConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.upscan.UploadDocumentType
@@ -29,8 +28,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.rejectedgoods.upload
 
 import java.util.Locale
 
-trait UploadFilesMixin[Journey <: JourneyBase[Journey]] {
-  self: JourneyBaseController[Journey] =>
+trait UploadFilesMixin {
+  self: JourneyBaseController =>
 
   val uploadDocumentsConfig: UploadDocumentsConfig
   val fileUploadConfig: FileUploadConfig

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/WorkInProgressMixin.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/WorkInProgressMixin.scala
@@ -20,16 +20,15 @@ import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.Request
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBaseController
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.JourneyBase
 
 import java.util.UUID
 
-trait WorkInProgressMixin[Journey <: JourneyBase[Journey]] {
-  self: JourneyBaseController[Journey] =>
+trait WorkInProgressMixin {
+  self: JourneyBaseController =>
 
   val show: Action[AnyContent] =
-    simpleActionReadJourney { journey =>
-      Ok(s"Work in progress ...\n\nJourney state:\n\n${prettyPrint(journey)}")
+    simpleActionReadJourney { _ =>
+      Ok(s"Work in progress ...")
     }
 
   def show(a: Any): Action[AnyContent]         = show
@@ -43,7 +42,7 @@ trait WorkInProgressMixin[Journey <: JourneyBase[Journey]] {
       (
         journey,
         Ok(
-          s"Submitted form data:\n\n${request.asInstanceOf[Request[AnyContent]].body.asFormUrlEncoded.map(_.mkString("\n")).getOrElse("<empty>")}\n\nJourney state:\n\n${prettyPrint(journey)}"
+          s"Submitted form data:\n\n${request.asInstanceOf[Request[AnyContent]].body.asFormUrlEncoded.map(_.mkString("\n")).getOrElse("<empty>")}"
         )
       ).asFuture
     }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/RejectedGoodsMultipleJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/RejectedGoodsMultipleJourneyBaseController.scala
@@ -22,10 +22,16 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsMultipleJ
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
+import play.api.libs.json.Format
 
 abstract class RejectedGoodsMultipleJourneyBaseController
-    extends JourneyBaseController[RejectedGoodsMultipleJourney]
+    extends JourneyBaseController
     with RejectedGoodsMultipleJourneyRouter {
+
+  final type Journey = RejectedGoodsMultipleJourney
+
+  final val format: Format[RejectedGoodsMultipleJourney] =
+    RejectedGoodsMultipleJourney.format
 
   final override val requiredFeature: Option[Feature] =
     Some(Feature.RejectedGoods)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/UploadFilesController.scala
@@ -48,7 +48,7 @@ class UploadFilesController @Inject() (
   featureSwitchService: FeatureSwitchService
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
     extends RejectedGoodsMultipleJourneyBaseController
-    with UploadFilesMixin[RejectedGoodsMultipleJourney] {
+    with UploadFilesMixin {
 
   final val selectDocumentTypePageAction: Call = routes.ChooseFileTypeController.show()
   final val callbackAction: Call               = routes.UploadFilesController.submit()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/CheckClaimantDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/CheckClaimantDetailsController.scala
@@ -21,16 +21,18 @@ import play.api.mvc._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.AddressLookupMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.ContactAddressLookupMixin
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduledJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduledJourney.Checks._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.AddressLookupService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.check_claimant_details
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 
 import javax.inject.Inject
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
+import play.twirl.api.HtmlFormat
 
 @Singleton
 class CheckClaimantDetailsController @Inject() (
@@ -39,55 +41,73 @@ class CheckClaimantDetailsController @Inject() (
   claimantDetailsPage: check_claimant_details
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig, val errorHandler: ErrorHandler)
     extends RejectedGoodsScheduledJourneyBaseController
-    with AddressLookupMixin[RejectedGoodsScheduledJourney] {
-
-  val startAddressLookup: Call = routes.CheckClaimantDetailsController.redirectToALF()
-
-  override val problemWithAddressPage: Call = routes.ProblemWithAddressController.show()
-
-  override val retrieveLookupAddress: Call = routes.CheckClaimantDetailsController.retrieveAddressFromALF()
+    with ContactAddressLookupMixin {
 
   // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
   final override val actionPrecondition: Option[Validate[RejectedGoodsScheduledJourney]] =
     Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
 
-  val show: Action[AnyContent] = actionReadJourneyAndUser { implicit request => journey => retrievedUserType =>
-    val changeCd: Call                             = routes.EnterContactDetailsController.show()
-    val postAction: Call                           = routes.CheckClaimantDetailsController.submit()
-    val (maybeContactDetails, maybeAddressDetails) =
-      (journey.computeContactDetails(retrievedUserType), journey.computeAddressDetails)
+  val startAddressLookup: Call = routes.CheckClaimantDetailsController.redirectToALF()
 
-    (maybeContactDetails, maybeAddressDetails) match {
-      case (Some(cd), Some(ca)) =>
-        Ok(claimantDetailsPage(cd, ca, changeCd, startAddressLookup, postAction)).asFuture
-      case _                    =>
-        logger.warn(
-          s"${maybeContactDetails.map(_ => "Contact details is defined").getOrElse("Cannot compute contact details")} " +
-            s"${maybeAddressDetails.map(_ => "Address details is defined").getOrElse("Cannot compute address details")}"
-        )
-        Redirect(routes.EnterMovementReferenceNumberController.show()).asFuture
-    }
+  val changeCd: Call =
+    routes.EnterContactDetailsController.show()
 
-  }
+  val postAction: Call =
+    routes.CheckClaimantDetailsController.submit()
 
-  val submit: Action[AnyContent] = actionReadWriteJourneyAndUser { _ => journey => retrievedUserType =>
-    (journey.computeContactDetails(retrievedUserType), journey.computeAddressDetails) match {
-      case (Some(cd), Some(ca)) =>
-        (
-          journey.submitContactDetails(Some(cd)).submitContactAddress(ca),
-          Redirect(routes.BasisForClaimController.show())
-        ).asFuture
-      case _                    =>
-        (
-          journey,
-          Redirect(routes.EnterMovementReferenceNumberController.show())
-        ).asFuture
-    }
+  override def viewTemplate: MrnContactDetails => ContactAddress => Request[_] => HtmlFormat.Appendable =
+    cd => ca => implicit request => claimantDetailsPage(cd, ca, changeCd, startAddressLookup, postAction)
 
-  }
+  override val redirectWhenNoAddressDetailsFound: Call =
+    routes.EnterMovementReferenceNumberController.show()
 
-  override def update(journey: RejectedGoodsScheduledJourney): ContactAddress => RejectedGoodsScheduledJourney =
-    journey.submitContactAddress
+  override val nextPageInTheJourney: Call =
+    routes.BasisForClaimController.show()
+
+  override val problemWithAddressPage: Call = routes.ProblemWithAddressController.show()
+
+  override val retrieveLookupAddress: Call = routes.CheckClaimantDetailsController.retrieveAddressFromALF()
+
+  // val show: Action[AnyContent] = actionReadJourneyAndUser { implicit request => journey => retrievedUserType =>
+  //   val changeCd: Call                             = routes.EnterContactDetailsController.show()
+  //   val postAction: Call                           = routes.CheckClaimantDetailsController.submit()
+  //   val (maybeContactDetails, maybeAddressDetails) =
+  //     (journey.computeContactDetails(retrievedUserType), journey.computeAddressDetails)
+
+  //   (maybeContactDetails, maybeAddressDetails) match {
+  //     case (Some(cd), Some(ca)) =>
+  //       Ok(claimantDetailsPage(cd, ca, changeCd, startAddressLookup, postAction)).asFuture
+  //     case _                    =>
+  //       logger.warn(
+  //         s"${maybeContactDetails.map(_ => "Contact details is defined").getOrElse("Cannot compute contact details")} " +
+  //           s"${maybeAddressDetails.map(_ => "Address details is defined").getOrElse("Cannot compute address details")}"
+  //       )
+  //       Redirect(routes.EnterMovementReferenceNumberController.show()).asFuture
+  //   }
+
+  // }
+
+  // val submit: Action[AnyContent] = actionReadWriteJourneyAndUser { _ => journey => retrievedUserType =>
+  //   (journey.computeContactDetails(retrievedUserType), journey.computeAddressDetails) match {
+  //     case (Some(cd), Some(ca)) =>
+  //       (
+  //         journey.submitContactDetails(Some(cd)).submitContactAddress(ca),
+  //         Redirect(routes.BasisForClaimController.show())
+  //       ).asFuture
+  //     case _                    =>
+  //       (
+  //         journey,
+  //         Redirect(routes.EnterMovementReferenceNumberController.show())
+  //       ).asFuture
+  //   }
+
+  // }
+
+  override def modifyJourney(journey: Journey, contactDetails: MrnContactDetails): Journey =
+    journey.submitContactDetails(Some(contactDetails))
+
+  override def modifyJourney(journey: Journey, contactAddress: ContactAddress): Journey =
+    journey.submitContactAddress(contactAddress)
 
   override def redirectToTheNextPage(journey: RejectedGoodsScheduledJourney): (RejectedGoodsScheduledJourney, Result) =
     (journey, Redirect(routes.CheckClaimantDetailsController.show()))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/ChooseInspectionAddressTypeController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/ChooseInspectionAddressTypeController.scala
@@ -16,94 +16,53 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.rejectedgoodsscheduled
 
-import javax.inject.Inject
-import javax.inject.Singleton
-import play.api.mvc.Action
-import play.api.mvc.AnyContent
 import play.api.mvc.Call
 import play.api.mvc.Result
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.inspectionAddressTypeForm
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.AddressLookupMixin
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddressType._
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{rejectedgoods => pages}
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.InspectionAddressLookupMixin
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduledJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddress
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddressType.Other
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddressType._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.AddressLookupService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{rejectedgoods => pages}
+
+import javax.inject.Inject
+import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
 
 @Singleton
 class ChooseInspectionAddressTypeController @Inject() (
   val jcc: JourneyControllerComponents,
   val addressLookupService: AddressLookupService,
-  inspectionAddressPage: pages.choose_inspection_address_type
+  val inspectionAddressPage: pages.choose_inspection_address_type
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig, val errorHandler: ErrorHandler)
     extends RejectedGoodsScheduledJourneyBaseController
-    with AddressLookupMixin[RejectedGoodsScheduledJourney] {
+    with InspectionAddressLookupMixin {
 
-  private val postAction: Call              = routes.ChooseInspectionAddressTypeController.submit()
-  private val nextPage: Call                = routes.CheckBankDetailsController.show()
-  override val problemWithAddressPage: Call = routes.ProblemWithAddressController.show()
-  override val retrieveLookupAddress: Call  = routes.ChooseInspectionAddressTypeController.retrieveAddressFromALF()
+  private val nextPage: Call =
+    routes.CheckBankDetailsController.show()
 
-  def show: Action[AnyContent] = actionReadJourney { implicit request => journey =>
-    (journey.getPotentialInspectionAddresses match {
-      case List()    => Redirect(routes.ChooseInspectionAddressTypeController.redirectToALF())
-      case addresses =>
-        Ok(
-          inspectionAddressPage(
-            addresses,
-            inspectionAddressTypeForm.withDefault(journey.getInspectionAddressType),
-            postAction
-          )
-        )
-    }).asFuture
-  }
+  override val postAction: Call =
+    routes.ChooseInspectionAddressTypeController.submit()
 
-  def submit: Action[AnyContent] = actionReadWriteJourney(
-    { implicit request => journey =>
-      inspectionAddressTypeForm
-        .bindFromRequest()
-        .fold(
-          formWithErrors =>
-            (
-              journey,
-              BadRequest(
-                inspectionAddressPage(
-                  journey.getPotentialInspectionAddresses,
-                  formWithErrors,
-                  postAction
-                )
-              )
-            ),
-          {
-            case Other                 =>
-              (
-                journey,
-                Redirect(routes.ChooseInspectionAddressTypeController.redirectToALF())
-              )
-            case inspectionAddressType =>
-              journey
-                .getInspectionAddressForType(inspectionAddressType)
-                .map { address =>
-                  redirectToTheNextPage(journey.submitInspectionAddress(inspectionAddress = address))
-                }
-                .getOrElse(
-                  (
-                    journey,
-                    Redirect(baseRoutes.IneligibleController.ineligible())
-                  )
-                )
-          }
-        )
-        .asFuture
-    },
-    fastForwardToCYAEnabled = false
-  )
+  override val problemWithAddressPage: Call =
+    routes.ProblemWithAddressController.show()
+
+  override val startAddressLookup: Call =
+    routes.ChooseInspectionAddressTypeController.redirectToALF()
+
+  override val retrieveLookupAddress: Call =
+    routes.ChooseInspectionAddressTypeController.retrieveAddressFromALF()
+
+  final override def modifyJourney(journey: Journey, inspectionAddress: InspectionAddress): Journey =
+    journey.submitInspectionAddress(inspectionAddress)
+
+  final override def modifyJourney(journey: Journey, contactAddress: ContactAddress): Journey =
+    journey.submitInspectionAddress(InspectionAddress.ofType(Other).mapFrom(contactAddress))
 
   override def redirectToTheNextPage(journey: RejectedGoodsScheduledJourney): (RejectedGoodsScheduledJourney, Result) =
     (
@@ -113,9 +72,4 @@ class ChooseInspectionAddressTypeController @Inject() (
       else
         Redirect(nextPage)
     )
-
-  override def update(journey: RejectedGoodsScheduledJourney): ContactAddress => RejectedGoodsScheduledJourney = {
-    contactAddress =>
-      journey.submitInspectionAddress(InspectionAddress.ofType(Other).mapFrom(contactAddress))
-  }
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterMovementReferenceNumberController.scala
@@ -32,6 +32,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduled
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.rejectedgoods.enter_movement_reference_number
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 
 import scala.concurrent.ExecutionContext
 
@@ -42,7 +43,7 @@ class EnterMovementReferenceNumberController @Inject() (
   enterMovementReferenceNumberPage: enter_movement_reference_number
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
     extends RejectedGoodsScheduledJourneyBaseController
-    with EnterMovementReferenceNumberMixin[RejectedGoodsScheduledJourney] {
+    with EnterMovementReferenceNumberMixin {
 
   override val form: Form[MRN] = Form(
     mapping(
@@ -65,6 +66,9 @@ class EnterMovementReferenceNumberController @Inject() (
           1,
           routes.EnterMovementReferenceNumberController.submit()
         )
+
+  override def modifyJourney(journey: Journey, mrn: MRN, declaration: DisplayDeclaration): Either[String, Journey] =
+    journey.submitMovementReferenceNumberAndDeclaration(mrn, declaration)
 
   override def afterSuccessfullSubmit(updatedJourney: RejectedGoodsScheduledJourney): Result =
     Redirect(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/RejectedGoodsScheduledJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/RejectedGoodsScheduledJourneyBaseController.scala
@@ -23,12 +23,16 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsScheduled
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
+import play.api.libs.json.Format
 
-import scala.concurrent.ExecutionContext
-
-abstract class RejectedGoodsScheduledJourneyBaseController(implicit ec: ExecutionContext)
-    extends JourneyBaseController[RejectedGoodsScheduledJourney]
+trait RejectedGoodsScheduledJourneyBaseController
+    extends JourneyBaseController
     with RejectedGoodsScheduledJourneyRouter {
+
+  final type Journey = RejectedGoodsScheduledJourney
+
+  final val format: Format[RejectedGoodsScheduledJourney] =
+    RejectedGoodsScheduledJourney.format
 
   final override val requiredFeature: Option[Feature] =
     Some(Feature.RejectedGoods)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/UploadFilesController.scala
@@ -48,7 +48,7 @@ class UploadFilesController @Inject() (
   featureSwitchService: FeatureSwitchService
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
     extends RejectedGoodsScheduledJourneyBaseController
-    with UploadFilesMixin[RejectedGoodsScheduledJourney] {
+    with UploadFilesMixin {
 
   final val selectDocumentTypePageAction: Call = routes.ChooseFileTypeController.show()
   final val callbackAction: Call               = routes.UploadFilesController.submit()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckClaimantDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckClaimantDetailsController.scala
@@ -21,18 +21,19 @@ import play.api.mvc._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.AddressLookupMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.ContactAddressLookupMixin
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney.Checks.declarantOrImporterEoriMatchesUserOrHasBeenVerified
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney.Checks.hasMRNAndDisplayDeclaration
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.AddressLookupService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.check_claimant_details
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 
 import javax.inject.Inject
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
+import play.twirl.api.HtmlFormat
 
 @Singleton
 class CheckClaimantDetailsController @Inject() (
@@ -41,58 +42,71 @@ class CheckClaimantDetailsController @Inject() (
   claimantDetailsPage: check_claimant_details
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig, val errorHandler: ErrorHandler)
     extends RejectedGoodsSingleJourneyBaseController
-    with AddressLookupMixin[RejectedGoodsSingleJourney] {
-
-  override val problemWithAddressPage: Call = routes.ProblemWithAddressController.show()
-
-  val postAction: Call           = routes.CheckClaimantDetailsController.submit()
-  val changeContactDetails: Call = routes.EnterContactDetailsController.show()
-  val startAddressLookup: Call   = routes.CheckClaimantDetailsController.redirectToALF()
-
-  override val retrieveLookupAddress: Call =
-    routes.CheckClaimantDetailsController.retrieveAddressFromALF()
+    with ContactAddressLookupMixin {
 
   // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
   final override val actionPrecondition: Option[Validate[RejectedGoodsSingleJourney]] =
     Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
 
-  val show: Action[AnyContent] = actionReadJourneyAndUser { implicit request => journey => retrievedUserType =>
-    val maybeContactDetails = journey.computeContactDetails(retrievedUserType)
-    val maybeAddressDetails = journey.computeAddressDetails
-    Future.successful(
-      (maybeContactDetails, maybeAddressDetails) match {
-        case (Some(contactDetails), Some(contactAddress)) =>
-          Ok(claimantDetailsPage(contactDetails, contactAddress, changeContactDetails, startAddressLookup, postAction))
-        case _                                            =>
-          logger.warn(
-            s"Cannot compute ${maybeContactDetails.map(_ => "").getOrElse("contact details")} ${maybeAddressDetails.map(_ => "").getOrElse("address details")}."
-          )
-          Redirect(routes.EnterMovementReferenceNumberController.show())
-      }
-    )
-  }
+  val startAddressLookup: Call =
+    routes.CheckClaimantDetailsController.redirectToALF()
 
-  val submit: Action[AnyContent] = actionReadWriteJourneyAndUser { _ => journey => retrievedUserType =>
-    Future.successful(
-      (journey.computeContactDetails(retrievedUserType), journey.computeAddressDetails) match {
-        case (Some(cd), Some(ca)) =>
-          (
-            journey.submitContactDetails(Some(cd)).submitContactAddress(ca),
-            Redirect(routes.BasisForClaimController.show())
-          )
-        case _                    =>
-          (journey, Redirect(routes.EnterMovementReferenceNumberController.show()))
-      }
-    )
-  }
+  val changeCd: Call =
+    routes.EnterContactDetailsController.show()
 
-  override def update(journey: RejectedGoodsSingleJourney): ContactAddress => RejectedGoodsSingleJourney =
-    journey.submitContactAddress
+  val postAction: Call =
+    routes.CheckClaimantDetailsController.submit()
+
+  override def viewTemplate: MrnContactDetails => ContactAddress => Request[_] => HtmlFormat.Appendable =
+    cd => ca => implicit request => claimantDetailsPage(cd, ca, changeCd, startAddressLookup, postAction)
+
+  override val redirectWhenNoAddressDetailsFound: Call =
+    routes.EnterMovementReferenceNumberController.show()
+
+  override val nextPageInTheJourney: Call =
+    routes.BasisForClaimController.show()
+
+  override val problemWithAddressPage: Call = routes.ProblemWithAddressController.show()
+
+  override val retrieveLookupAddress: Call =
+    routes.CheckClaimantDetailsController.retrieveAddressFromALF()
+
+  // val show: Action[AnyContent] = actionReadJourneyAndUser { implicit request => journey => retrievedUserType =>
+  //   val maybeContactDetails = journey.computeContactDetails(retrievedUserType)
+  //   val maybeAddressDetails = journey.computeAddressDetails
+  //   Future.successful(
+  //     (maybeContactDetails, maybeAddressDetails) match {
+  //       case (Some(contactDetails), Some(contactAddress)) =>
+  //         Ok(claimantDetailsPage(contactDetails, contactAddress, changeContactDetails, startAddressLookup, postAction))
+  //       case _                                            =>
+  //         logger.warn(
+  //           s"Cannot compute ${maybeContactDetails.map(_ => "").getOrElse("contact details")} ${maybeAddressDetails.map(_ => "").getOrElse("address details")}."
+  //         )
+  //         Redirect(routes.EnterMovementReferenceNumberController.show())
+  //     }
+  //   )
+  // }
+
+  // val submit: Action[AnyContent] = actionReadWriteJourneyAndUser { _ => journey => retrievedUserType =>
+  //   Future.successful(
+  //     (journey.computeContactDetails(retrievedUserType), journey.computeAddressDetails) match {
+  //       case (Some(cd), Some(ca)) =>
+  //         (
+  //           journey.submitContactDetails(Some(cd)).submitContactAddress(ca),
+  //           Redirect(routes.BasisForClaimController.show())
+  //         )
+  //       case _                    =>
+  //         (journey, Redirect(routes.EnterMovementReferenceNumberController.show()))
+  //     }
+  //   )
+  // }
+
+  override def modifyJourney(journey: Journey, contactDetails: MrnContactDetails): Journey =
+    journey.submitContactDetails(Some(contactDetails))
+
+  override def modifyJourney(journey: Journey, contactAddress: ContactAddress): Journey =
+    journey.submitContactAddress(contactAddress)
 
   override def redirectToTheNextPage(journey: RejectedGoodsSingleJourney): (RejectedGoodsSingleJourney, Result) =
     (journey, Redirect(routes.CheckClaimantDetailsController.show()))
-}
-
-object CheckClaimantDetailsController {
-  val checkContactDetailsKey: String = "check-claimant-details"
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterMovementReferenceNumberController.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerCo
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.EnterMovementReferenceNumberMixin
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.enter_movement_reference_number
 
@@ -40,7 +41,7 @@ class EnterMovementReferenceNumberController @Inject() (
   enterMovementReferenceNumberPage: enter_movement_reference_number
 )(implicit val viewConfig: ViewConfig, val ec: ExecutionContext)
     extends RejectedGoodsSingleJourneyBaseController
-    with EnterMovementReferenceNumberMixin[RejectedGoodsSingleJourney] {
+    with EnterMovementReferenceNumberMixin {
 
   override val form: Form[MRN] = Forms.movementReferenceNumberForm
 
@@ -52,6 +53,9 @@ class EnterMovementReferenceNumberController @Inject() (
           Some("rejected-goods.single"),
           routes.EnterMovementReferenceNumberController.submit()
         )
+
+  override def modifyJourney(journey: Journey, mrn: MRN, declaration: DisplayDeclaration): Either[String, Journey] =
+    journey.submitMovementReferenceNumberAndDeclaration(mrn, declaration)
 
   override def afterSuccessfullSubmit(journey: RejectedGoodsSingleJourney): Result =
     if (journey.needsDeclarantAndConsigneeEoriSubmission) {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/RejectedGoodsSingleJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/RejectedGoodsSingleJourneyBaseController.scala
@@ -22,12 +22,14 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.RejectedGoodsSingleJou
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
+import play.api.libs.json.Format
 
-import scala.concurrent.ExecutionContext
+trait RejectedGoodsSingleJourneyBaseController extends JourneyBaseController with RejectedGoodsSingleJourneyRouter {
 
-abstract class RejectedGoodsSingleJourneyBaseController(implicit ec: ExecutionContext)
-    extends JourneyBaseController[RejectedGoodsSingleJourney]
-    with RejectedGoodsSingleJourneyRouter {
+  final type Journey = RejectedGoodsSingleJourney
+
+  final val format: Format[RejectedGoodsSingleJourney] =
+    RejectedGoodsSingleJourney.format
 
   final override val requiredFeature: Option[Feature] =
     Some(Feature.RejectedGoods)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/UploadFilesController.scala
@@ -48,7 +48,7 @@ class UploadFilesController @Inject() (
   featureSwitchService: FeatureSwitchService
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
     extends RejectedGoodsSingleJourneyBaseController
-    with UploadFilesMixin[RejectedGoodsSingleJourney] {
+    with UploadFilesMixin {
 
   final val selectDocumentTypePageAction: Call = routes.ChooseFileTypeController.show()
   final val callbackAction: Call               = routes.UploadFilesController.submit()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckClaimantDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckClaimantDetailsController.scala
@@ -20,18 +20,19 @@ import play.api.mvc._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.AddressLookupMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.ContactAddressLookupMixin
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.AddressLookupService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.check_claimant_details
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
 
 import javax.inject.Inject
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 import com.github.arturopala.validator.Validator.Validate
 import SecuritiesJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
+import play.twirl.api.HtmlFormat
 
 @Singleton
 class CheckClaimantDetailsController @Inject() (
@@ -40,7 +41,7 @@ class CheckClaimantDetailsController @Inject() (
   claimantDetailsPage: check_claimant_details
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig, val errorHandler: ErrorHandler)
     extends SecuritiesJourneyBaseController
-    with AddressLookupMixin[SecuritiesJourney] {
+    with ContactAddressLookupMixin {
 
   // Allow actions only if the MRN, RfS and ACC14 declaration are in place, and the EORI has been verified.
   override val actionPrecondition: Option[Validate[SecuritiesJourney]] =
@@ -51,45 +52,57 @@ class CheckClaimantDetailsController @Inject() (
 
   override val problemWithAddressPage: Call = routes.ProblemWithAddressController.show()
 
-  val postAction: Call           = routes.CheckClaimantDetailsController.submit()
-  val changeContactDetails: Call = routes.EnterContactDetailsController.show()
-  val startAddressLookup: Call   = routes.CheckClaimantDetailsController.redirectToALF()
+  val postAction: Call         = routes.CheckClaimantDetailsController.submit()
+  val changeCd: Call           = routes.EnterContactDetailsController.show()
+  val startAddressLookup: Call = routes.CheckClaimantDetailsController.redirectToALF()
 
   override val retrieveLookupAddress: Call =
     routes.CheckClaimantDetailsController.retrieveAddressFromALF()
 
-  val show: Action[AnyContent] = actionReadJourneyAndUser { implicit request => journey => retrievedUserType =>
-    val maybeContactDetails = journey.computeContactDetails(retrievedUserType)
-    val maybeAddressDetails = journey.computeAddressDetails
-    Future.successful(
-      (maybeContactDetails, maybeAddressDetails) match {
-        case (Some(contactDetails), Some(contactAddress)) =>
-          Ok(claimantDetailsPage(contactDetails, contactAddress, changeContactDetails, startAddressLookup, postAction))
-        case _                                            =>
-          logger.warn(
-            s"Cannot compute ${maybeContactDetails.map(_ => "").getOrElse("contact details")} ${maybeAddressDetails.map(_ => "").getOrElse("address details")}."
-          )
-          Redirect(routes.EnterMovementReferenceNumberController.show())
-      }
-    )
-  }
+  override def viewTemplate: MrnContactDetails => ContactAddress => Request[_] => HtmlFormat.Appendable =
+    cd => ca => implicit request => claimantDetailsPage(cd, ca, changeCd, startAddressLookup, postAction)
 
-  val submit: Action[AnyContent] = actionReadWriteJourneyAndUser { _ => journey => retrievedUserType =>
-    Future.successful(
-      (journey.computeContactDetails(retrievedUserType), journey.computeAddressDetails) match {
-        case (Some(cd), Some(ca)) =>
-          (
-            journey.submitContactDetails(Some(cd)).submitContactAddress(ca),
-            Redirect(routes.ConfirmFullRepaymentController.showFirst)
-          )
-        case _                    =>
-          (journey, Redirect(routes.EnterMovementReferenceNumberController.show()))
-      }
-    )
-  }
+  override val redirectWhenNoAddressDetailsFound: Call =
+    routes.EnterMovementReferenceNumberController.show()
 
-  override def update(journey: SecuritiesJourney): ContactAddress => SecuritiesJourney =
-    journey.submitContactAddress
+  override val nextPageInTheJourney: Call =
+    routes.ConfirmFullRepaymentController.showFirst
+
+  // val show: Action[AnyContent] = actionReadJourneyAndUser { implicit request => journey => retrievedUserType =>
+  //   val maybeContactDetails = journey.computeContactDetails(retrievedUserType)
+  //   val maybeAddressDetails = journey.computeAddressDetails
+  //   Future.successful(
+  //     (maybeContactDetails, maybeAddressDetails) match {
+  //       case (Some(contactDetails), Some(contactAddress)) =>
+  //         Ok(claimantDetailsPage(contactDetails, contactAddress, changeContactDetails, startAddressLookup, postAction))
+  //       case _                                            =>
+  //         logger.warn(
+  //           s"Cannot compute ${maybeContactDetails.map(_ => "").getOrElse("contact details")} ${maybeAddressDetails.map(_ => "").getOrElse("address details")}."
+  //         )
+  //         Redirect(routes.EnterMovementReferenceNumberController.show())
+  //     }
+  //   )
+  // }
+
+  // val submit: Action[AnyContent] = actionReadWriteJourneyAndUser { _ => journey => retrievedUserType =>
+  //   Future.successful(
+  //     (journey.computeContactDetails(retrievedUserType), journey.computeAddressDetails) match {
+  //       case (Some(cd), Some(ca)) =>
+  //         (
+  //           journey.submitContactDetails(Some(cd)).submitContactAddress(ca),
+  //           Redirect(routes.ConfirmFullRepaymentController.showFirst)
+  //         )
+  //       case _                    =>
+  //         (journey, Redirect(routes.EnterMovementReferenceNumberController.show()))
+  //     }
+  //   )
+  // }
+
+  override def modifyJourney(journey: Journey, contactDetails: MrnContactDetails): Journey =
+    journey.submitContactDetails(Some(contactDetails))
+
+  override def modifyJourney(journey: Journey, contactAddress: ContactAddress): Journey =
+    journey.submitContactAddress(contactAddress)
 
   override def redirectToTheNextPage(journey: SecuritiesJourney): (SecuritiesJourney, Result) =
     if (journey.hasCompleteAnswers) {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckExportDeclarationDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/CheckExportDeclarationDetailsController.scala
@@ -18,16 +18,15 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.securities
 
 import com.google.inject.Inject
 import com.google.inject.Singleton
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.WorkInProgressMixin
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
 
 import scala.concurrent.ExecutionContext
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
 
 @Singleton
 class CheckExportDeclarationDetailsController @Inject() (
   val jcc: JourneyControllerComponents
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
     extends SecuritiesJourneyBaseController
-    with WorkInProgressMixin[SecuritiesJourney]
+    with WorkInProgressMixin

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterBankAccountDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterBankAccountDetailsController.scala
@@ -45,7 +45,7 @@ class EnterBankAccountDetailsController @Inject() (
   val bankAccountReputationService: BankAccountReputationService
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig, errorHandler: ErrorHandler)
     extends SecuritiesJourneyBaseController
-    with EnterBankAccountDetailsMixin[SecuritiesJourney] {
+    with EnterBankAccountDetailsMixin {
 
   final override val actionPrecondition: Option[Validate[SecuritiesJourney]] =
     Some(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SecuritiesJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/SecuritiesJourneyBaseController.scala
@@ -22,12 +22,14 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
+import play.api.libs.json.Format
 
-import scala.concurrent.ExecutionContext
+trait SecuritiesJourneyBaseController extends JourneyBaseController with SecuritiesJourneyRouter {
 
-abstract class SecuritiesJourneyBaseController(implicit ec: ExecutionContext)
-    extends JourneyBaseController[SecuritiesJourney]
-    with SecuritiesJourneyRouter {
+  final type Journey = SecuritiesJourney
+
+  final val format: Format[SecuritiesJourney] =
+    SecuritiesJourney.format
 
   final override val requiredFeature: Option[Feature] =
     Some(Feature.Securities)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/StartController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/StartController.scala
@@ -20,7 +20,6 @@ import com.google.inject.Inject
 import com.google.inject.Singleton
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.WorkInProgressMixin
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
 
 import scala.concurrent.ExecutionContext
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
@@ -30,4 +29,4 @@ class StartController @Inject() (
   val jcc: JourneyControllerComponents
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
     extends SecuritiesJourneyBaseController
-    with WorkInProgressMixin[SecuritiesJourney]
+    with WorkInProgressMixin

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/UploadFilesController.scala
@@ -49,7 +49,7 @@ class UploadFilesController @Inject() (
   featureSwitchService: FeatureSwitchService
 )(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
     extends SecuritiesJourneyBaseController
-    with UploadFilesMixin[SecuritiesJourney] {
+    with UploadFilesMixin {
 
   final val precedingAction: Call              = routes.CheckClaimDetailsController.show()
   final val selectDocumentTypePageAction: Call = routes.ChooseFileTypeController.show()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/CanSubmitContactDetails.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/CanSubmitContactDetails.scala
@@ -16,17 +16,12 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
 
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BasisOfRejectedGoodsClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
 
-/** Common properties of the rejected-goods single, multiple and scheduled journeys. */
-trait RejectedGoodsJourneyProperties extends CommonJourneyProperties {
+trait CanSubmitContactDetails {
+  this: Journey =>
 
-  def answers: RejectedGoodsAnswers
-
-  def hasCompleteReimbursementClaims: Boolean
-  def getTotalReimbursementAmount: BigDecimal
-
-  final def needsSpecialCircumstancesBasisOfClaim: Boolean =
-    answers.basisOfClaim.contains(BasisOfRejectedGoodsClaim.SpecialCircumstances)
-
+  def submitContactDetails(contactDetails: Option[MrnContactDetails]): Journey
+  def submitContactAddress(contactAddress: ContactAddress): Journey
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/CanSubmitMrnAndDeclaration.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/CanSubmitMrnAndDeclaration.scala
@@ -19,13 +19,12 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 
-trait CommonJourneyModifications[Journey] {
+trait CanSubmitMrnAndDeclaration {
+  this: Journey =>
 
-  /** Resets the journey with the new MRN
-    * or keep existing journey if submitted the same MRN and declaration as before.
-    */
   def submitMovementReferenceNumberAndDeclaration(
     mrn: MRN,
     displayDeclaration: DisplayDeclaration
   ): Either[String, Journey]
+
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/HaveInspectionDetails.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/HaveInspectionDetails.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
+
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionDate
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddress
+
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddressType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.InspectionAddressType._
+
+trait HaveInspectionDetails {
+  self: Journey with RejectedGoodsJourneyProperties =>
+
+  def submitInspectionDate(inspectionDate: InspectionDate): Journey
+  def submitInspectionAddress(inspectionAddress: InspectionAddress): Journey
+
+  final def getPotentialInspectionAddresses: Seq[(InspectionAddressType, String)] =
+    Seq(
+      getConsigneeContactDetailsFromACC14.flatMap(_.showAddress).map(Importer  -> _),
+      getDeclarantContactDetailsFromACC14.flatMap(_.showAddress).map(Declarant -> _)
+    ).flatten(Option.option2Iterable)
+
+  final def getInspectionAddressForType(
+    addressType: InspectionAddressType
+  ): Option[InspectionAddress] =
+    addressType match {
+      case Importer  => self.getConsigneeContactDetailsFromACC14.map(InspectionAddress.ofType(addressType).mapFrom(_))
+      case Declarant => self.getDeclarantContactDetailsFromACC14.map(InspectionAddress.ofType(addressType).mapFrom(_))
+      case Other     => None
+    }
+
+  final def getInspectionAddressType: Option[InspectionAddressType] =
+    answers.inspectionAddress.map(_.addressType)
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsSingleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsSingleJourney.scala
@@ -36,6 +36,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.NdrcDetails
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.upscan.UploadDocumentType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.DirectFluentSyntax
+import com.github.arturopala.validator.Validator
 
 /** An encapsulated C&E1179 single MRN journey logic.
   * The constructor of this class MUST stay PRIVATE to protected integrity of the journey.
@@ -48,9 +50,17 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.upscan.UploadDocumentTyp
 final class OverpaymentsSingleJourney private (
   val answers: OverpaymentsSingleJourney.Answers,
   val caseNumber: Option[String] = None
-) extends JourneyBase[OverpaymentsSingleJourney]
+) extends JourneyBase
+    with DirectFluentSyntax[OverpaymentsSingleJourney]
     with OverpaymentsJourneyProperties
-    with CommonJourneyModifications[OverpaymentsSingleJourney] {
+    with CanSubmitMrnAndDeclaration {
+
+  type Type = OverpaymentsSingleJourney
+
+  val self: OverpaymentsSingleJourney = this
+
+  val validate: Validator.Validate[OverpaymentsSingleJourney] =
+    OverpaymentsSingleJourney.validator
 
   /** Check if all the selected duties have reimbursement amount provided. */
   def hasCompleteReimbursementClaims: Boolean =
@@ -118,7 +128,7 @@ final class OverpaymentsSingleJourney private (
   def submitMovementReferenceNumberAndDeclaration(
     mrn: MRN,
     displayDeclaration: DisplayDeclaration
-  ): Either[String, OverpaymentsSingleJourney] =
+  ) =
     whileClaimIsAmendable {
       getLeadMovementReferenceNumber match {
         case Some(existingMrn)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
@@ -41,6 +41,7 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.upscan.UploadDocumentType
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils._
+import com.github.arturopala.validator.Validator
 
 import java.time.LocalDate
 
@@ -55,9 +56,19 @@ import java.time.LocalDate
 final class RejectedGoodsMultipleJourney private (
   val answers: RejectedGoodsMultipleJourney.Answers,
   val caseNumber: Option[String] = None
-) extends JourneyBase[RejectedGoodsMultipleJourney]
+) extends JourneyBase
+    with DirectFluentSyntax[RejectedGoodsMultipleJourney]
     with RejectedGoodsJourneyProperties
-    with CommonJourneyModifications[RejectedGoodsMultipleJourney] {
+    with CanSubmitMrnAndDeclaration
+    with CanSubmitContactDetails
+    with HaveInspectionDetails {
+
+  type Type = RejectedGoodsMultipleJourney
+
+  val self: RejectedGoodsMultipleJourney = this
+
+  val validate: Validator.Validate[RejectedGoodsMultipleJourney] =
+    RejectedGoodsMultipleJourney.validator
 
   /** Check if all the selected duties have reimbursement amount provided. */
   def hasCompleteReimbursementClaims: Boolean =
@@ -194,14 +205,14 @@ final class RejectedGoodsMultipleJourney private (
   def submitMovementReferenceNumberAndDeclaration(
     mrn: MRN,
     displayDeclaration: DisplayDeclaration
-  ): Either[String, RejectedGoodsMultipleJourney] =
+  ) =
     submitMovementReferenceNumberAndDeclaration(0, mrn, displayDeclaration)
 
   def submitMovementReferenceNumberAndDeclaration(
     index: Int,
     mrn: MRN,
     displayDeclaration: DisplayDeclaration
-  ): Either[String, RejectedGoodsMultipleJourney] =
+  ) =
     whileClaimIsAmendable {
       if (index < 0)
         Left("submitMovementReferenceNumber.negativeIndex")
@@ -329,14 +340,14 @@ final class RejectedGoodsMultipleJourney private (
       else Left("submitDeclarantEoriNumber.unexpected")
     }
 
-  def submitContactDetails(contactDetails: Option[MrnContactDetails]): RejectedGoodsMultipleJourney =
+  def submitContactDetails(contactDetails: Option[MrnContactDetails]) =
     whileClaimIsAmendable {
       new RejectedGoodsMultipleJourney(
         answers.copy(contactDetails = contactDetails)
       )
     }
 
-  def submitContactAddress(contactAddress: ContactAddress): RejectedGoodsMultipleJourney =
+  def submitContactAddress(contactAddress: ContactAddress) =
     whileClaimIsAmendable {
       new RejectedGoodsMultipleJourney(
         answers.copy(contactAddress = Some(contactAddress))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
@@ -42,6 +42,8 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.upscan.UploadDocumentType
 
 import java.time.LocalDate
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.DirectFluentSyntax
+import com.github.arturopala.validator.Validator
 
 /** An encapsulated C&E1179 single MRN journey logic.
   * The constructor of this class MUST stay PRIVATE to protected integrity of the journey.
@@ -54,9 +56,19 @@ import java.time.LocalDate
 final class RejectedGoodsSingleJourney private (
   val answers: RejectedGoodsSingleJourney.Answers,
   val caseNumber: Option[String] = None
-) extends JourneyBase[RejectedGoodsSingleJourney]
+) extends JourneyBase
+    with DirectFluentSyntax[RejectedGoodsSingleJourney]
     with RejectedGoodsJourneyProperties
-    with CommonJourneyModifications[RejectedGoodsSingleJourney] {
+    with CanSubmitMrnAndDeclaration
+    with CanSubmitContactDetails
+    with HaveInspectionDetails {
+
+  type Type = RejectedGoodsSingleJourney
+
+  val self: RejectedGoodsSingleJourney = this
+
+  val validate: Validator.Validate[RejectedGoodsSingleJourney] =
+    RejectedGoodsSingleJourney.validator
 
   /** Check if all the selected duties have reimbursement amount provided. */
   def hasCompleteReimbursementClaims: Boolean =
@@ -121,7 +133,7 @@ final class RejectedGoodsSingleJourney private (
   def submitMovementReferenceNumberAndDeclaration(
     mrn: MRN,
     displayDeclaration: DisplayDeclaration
-  ): Either[String, RejectedGoodsSingleJourney] =
+  ) =
     whileClaimIsAmendable {
       getLeadMovementReferenceNumber match {
         case Some(existingMrn)
@@ -172,14 +184,14 @@ final class RejectedGoodsSingleJourney private (
       else Left("submitDeclarantEoriNumber.unexpected")
     }
 
-  def submitContactDetails(contactDetails: Option[MrnContactDetails]): RejectedGoodsSingleJourney =
+  def submitContactDetails(contactDetails: Option[MrnContactDetails]) =
     whileClaimIsAmendable {
       new RejectedGoodsSingleJourney(
         answers.copy(contactDetails = contactDetails)
       )
     }
 
-  def submitContactAddress(contactAddress: ContactAddress): RejectedGoodsSingleJourney =
+  def submitContactAddress(contactAddress: ContactAddress) =
     whileClaimIsAmendable {
       new RejectedGoodsSingleJourney(
         answers.copy(contactAddress = Some(contactAddress))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourney.scala
@@ -42,13 +42,25 @@ import scala.collection.immutable.SortedMap
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TemporaryAdmissionMethodOfDisposal
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DutyAmount
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.DirectFluentSyntax
+
+import com.github.arturopala.validator.Validator
 
 final class SecuritiesJourney private (
   val answers: SecuritiesJourney.Answers,
   val caseNumber: Option[String] = None
-) extends JourneyBase[SecuritiesJourney]
+) extends JourneyBase
     with CommonJourneyProperties
+    with CanSubmitContactDetails
+    with DirectFluentSyntax[SecuritiesJourney]
     with SeqUtils {
+
+  type Type = SecuritiesJourney
+
+  val self: SecuritiesJourney = this
+
+  val validate: Validator.Validate[SecuritiesJourney] =
+    SecuritiesJourney.validator
 
   import SecuritiesJourney.Answers
   import SecuritiesJourney.Checks._
@@ -571,14 +583,14 @@ final class SecuritiesJourney private (
         Left("submitDeclarantEoriNumber.shouldMatchDeclarantEoriFromACC14")
     }
 
-  def submitContactDetails(contactDetails: Option[MrnContactDetails]): SecuritiesJourney =
+  def submitContactDetails(contactDetails: Option[MrnContactDetails]) =
     whileClaimIsAmendable {
       new SecuritiesJourney(
         answers.copy(contactDetails = contactDetails)
       )
     }
 
-  def submitContactAddress(contactAddress: ContactAddress): SecuritiesJourney =
+  def submitContactAddress(contactAddress: ContactAddress) =
     whileClaimIsAmendable {
       new SecuritiesJourney(
         answers.copy(contactAddress = Some(contactAddress))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/sandbox.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/sandbox.scala
@@ -16,17 +16,27 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys
 
-import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BasisOfRejectedGoodsClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
 
-/** Common properties of the rejected-goods single, multiple and scheduled journeys. */
-trait RejectedGoodsJourneyProperties extends CommonJourneyProperties {
+object sandbox {
 
-  def answers: RejectedGoodsAnswers
+  trait Journey {
+    type Type
+  }
 
-  def hasCompleteReimbursementClaims: Boolean
-  def getTotalReimbursementAmount: BigDecimal
+  trait HaveMrn {
+    this: Journey =>
 
-  final def needsSpecialCircumstancesBasisOfClaim: Boolean =
-    answers.basisOfClaim.contains(BasisOfRejectedGoodsClaim.SpecialCircumstances)
+    def submitMrn(mrn: MRN): Either[String, this.Type]
+  }
+
+  final case class X() extends Journey with HaveMrn {
+
+    type Type = X
+
+    override def submitMrn(mrn: MRN): Either[String, X] =
+      Right(new X)
+
+  }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ lazy val wartremoverSettings =
       Wart.ImplicitParameter,
       Wart.Nothing,
       Wart.Overloading,
-      Wart.ToString
+      Wart.ToString,
+      Wart.PublicInference
     ),
     WartRemover.autoImport.wartremoverExcluded += target.value,
     Compile / compile / WartRemover.autoImport.wartremoverExcluded ++=

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/ChooseInspectionAddressTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/ChooseInspectionAddressTypeControllerSpec.scala
@@ -331,7 +331,7 @@ class ChooseInspectionAddressTypeControllerSpec
 
       val expectedJourney = emptyJourney.submitInspectionAddress(inspectionAddress)
 
-      controller.update(emptyJourney)(address) shouldBe expectedJourney
+      controller.modifyJourney(emptyJourney, address) shouldBe expectedJourney
     }
 
     "redirect to the next page" when {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/ChooseInspectionAddressTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/ChooseInspectionAddressTypeControllerSpec.scala
@@ -298,7 +298,7 @@ class ChooseInspectionAddressTypeControllerSpec
 
         val expectedJourney = emptyJourney.submitInspectionAddress(inspectionAddress)
 
-        controller.update(emptyJourney)(address) shouldBe expectedJourney
+        controller.modifyJourney(emptyJourney, address) shouldBe expectedJourney
       }
 
       "redirect to the next page" when {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/ChooseRepaymentMethodControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/ChooseRepaymentMethodControllerSpec.scala
@@ -185,7 +185,7 @@ class ChooseRepaymentMethodControllerSpec
       }
 
       "reject any repayment method and show ineligible page" in {
-        forAll { (ndrcDetails: NdrcDetails, displayDeclaration: DisplayDeclaration) =>
+        forAll { (ndrcDetails: NdrcDetails) =>
           whenever(!ndrcDetails.isCmaEligible) {
 
             inSequence {


### PR DESCRIPTION
This PR is another step in a cleanup, aligning and reuse of common controller code. The scope is a rewrite of Journey parametrisation followed by rewrite of AddressLookupMixin and al.