### PR TITLE
[CDSR-2041] reject provided export MRN if same as current import MRN

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/SecuritiesJourney.scala
@@ -352,13 +352,16 @@ final class SecuritiesJourney private (
   ): Either[String, SecuritiesJourney] =
     whileClaimIsAmendableAnd(hasMRNAndDisplayDeclarationAndRfS & thereIsNoSimilarClaimInCDFPay) {
       if (needsExportMRNSubmission)
-        Right(
-          new SecuritiesJourney(
-            answers.copy(
-              exportMovementReferenceNumber = Some(exportMrn)
+        if (answers.movementReferenceNumber.contains(exportMrn))
+          Left("submitExportMovementReferenceNumber.duplicated")
+        else
+          Right(
+            new SecuritiesJourney(
+              answers.copy(
+                exportMovementReferenceNumber = Some(exportMrn)
+              )
             )
           )
-        )
       else
         Left("submitExportMovementReferenceNumber.unexpected")
     }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterExportMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/EnterExportMovementReferenceNumberControllerSpec.scala
@@ -230,6 +230,60 @@ class EnterExportMovementReferenceNumberControllerSpec
         )
       }
 
+      "reject an export MRN if duplicate of import MRN (single shipment)" in forAllWith(
+        JourneyGenerator(
+          mrnWithRfsTempAdmissionWithDisplayDeclarationWithSingleShipmentMfdGen,
+          buildSecuritiesJourneyWithSomeSecuritiesSelectedWithMehodOfDisposal
+        )
+      ) { case (journey, _) =>
+        val session = SessionData(journey)
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+          mockGetDisplayDeclaration(Left(Error("")))
+        }
+
+        checkPageIsDisplayed(
+          performAction(
+            enterExportMovementReferenceNumberSingleKey -> journey.answers.movementReferenceNumber.get.value
+          ),
+          messageFromMessageKey(s"$enterExportMovementReferenceNumberSingleKeyAndSubKey.title"),
+          doc =>
+            getErrorSummary(doc) shouldBe messageFromMessageKey(
+              s"$enterExportMovementReferenceNumberSingleKey.securities.error.import"
+            ),
+          expectedStatus = BAD_REQUEST
+        )
+      }
+
+      "reject an export MRN if duplicate of import MRN (multiple shipment)" in forAllWith(
+        JourneyGenerator(
+          mrnWithRfsTempAdmissionWithDisplayDeclarationWithMultipleShipmentMfdGen,
+          buildSecuritiesJourneyWithSomeSecuritiesSelectedWithMehodOfDisposal
+        )
+      ) { case (journey, _) =>
+        val session = SessionData(journey)
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+          mockGetDisplayDeclaration(Left(Error("")))
+        }
+
+        checkPageIsDisplayed(
+          performAction(
+            enterExportMovementReferenceNumberMultipleKey -> journey.answers.movementReferenceNumber.get.value
+          ),
+          messageFromMessageKey(s"$enterExportMovementReferenceNumberMultipleKeyAndSubKey.title"),
+          doc =>
+            getErrorSummary(doc) shouldBe messageFromMessageKey(
+              s"$enterExportMovementReferenceNumberMultipleKey.securities.error.import"
+            ),
+          expectedStatus = BAD_REQUEST
+        )
+      }
+
       "display error if acc14 returns a successful response (single shipment)" in forAllWith(
         JourneyGenerator(
           mrnWithRfsTempAdmissionWithDisplayDeclarationWithSingleShipmentMfdGen,


### PR DESCRIPTION
This PR fixes a single issue: entering export MRN being the same as current import MRN. There is also a difffent issue: the check for existing import MRN fails for MRNs linked to the Securities, but it works for MRNs linked to NDRC Adjustments. Fixing this problem would require different handling of ACC14 errors in our backend.