### PR TITLE
[TechDebt] Improve manual feature switches behaviour and scope

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/cache/FeaturesCache.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/cache/FeaturesCache.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.cache
+
+import cats.syntax.eq._
+import com.google.inject.ImplementedBy
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.Configuration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.FeatureSet
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.TimestampSupport
+import uk.gov.hmrc.mongo.cache.MongoCacheRepository
+import uk.gov.hmrc.mongo.cache.DataKey
+
+@ImplementedBy(classOf[DefaultFeaturesCache])
+trait FeaturesCache {
+
+  def get()(implicit
+    hc: HeaderCarrier
+  ): Future[Either[Error, FeatureSet]]
+
+  def store(featureSet: FeatureSet)(implicit
+    hc: HeaderCarrier
+  ): Future[Either[Error, Unit]]
+
+  final def update(modify: FeatureSet => FeatureSet)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): Future[Either[Error, Unit]] =
+    try get().flatMap {
+      case Right(value) =>
+        val newFeatureSet = modify(value)
+        if (newFeatureSet =!= value)
+          store(newFeatureSet)
+        else
+          Future.successful(Right(()))
+
+      case Left(error) =>
+        Future.successful(Left(error))
+    } catch {
+      case e: Exception => Future.successful(Left(Error(e)))
+    }
+
+}
+
+@Singleton
+class DefaultFeaturesCache @Inject() (
+  mongoComponent: MongoComponent,
+  timestampSupport: TimestampSupport,
+  configuration: Configuration
+)(implicit
+  ec: ExecutionContext
+) extends MongoCacheRepository[HeaderCarrier](
+      mongoComponent = mongoComponent,
+      collectionName = "features",
+      ttl = configuration.get[FiniteDuration]("features-store.expiry-time"),
+      timestampSupport = timestampSupport,
+      cacheIdType = HeaderCarrierCacheId
+    )
+    with FeaturesCache {
+
+  val featureSetKey: DataKey[FeatureSet] =
+    DataKey[FeatureSet]("cdsrc-features")
+
+  def get()(implicit
+    hc: HeaderCarrier
+  ): Future[Either[Error, FeatureSet]] =
+    try super
+      .get[FeatureSet](hc)(featureSetKey)
+      .map(opt => Right(opt.getOrElse(FeatureSet.empty)))
+      .recover { case e ⇒ Left(Error(e)) } catch {
+      case HeaderCarrierCacheId.NoSessionException => Future.successful(Right(FeatureSet.empty))
+      case e: Exception                            => Future.successful(Left(Error(e)))
+    }
+
+  def store(
+    featureSet: FeatureSet
+  )(implicit hc: HeaderCarrier): Future[Either[Error, Unit]] =
+    try super
+      .put(hc)(featureSetKey, featureSet)
+      .map(_ => Right(()))
+      .recover { case e ⇒ Left(Error(e)) } catch {
+      case HeaderCarrierCacheId.NoSessionException => Future.successful(Right(()))
+      case e: Exception                            => Future.successful(Left(Error(e)))
+    }
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/UploadDocumentsConnector.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/UploadDocumentsConnector.scala
@@ -85,7 +85,7 @@ class UploadDocumentsConnectorProvider @Inject() (
 ) extends Provider[UploadDocumentsConnector] {
 
   override def get(): UploadDocumentsConnector =
-    if (features.isEnabled(Feature.InternalUploadDocuments))
+    if (features.isEnabledForApplication(Feature.InternalUploadDocuments))
       internal
     else
       external

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthenticatedActionWithRetrievedData.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/AuthenticatedActionWithRetrievedData.scala
@@ -123,7 +123,7 @@ class AuthenticatedActionWithRetrievedData @Inject() (
     ggCredId: GGCredId,
     name: Option[Name],
     request: MessagesRequest[A]
-  ): Future[Either[Result, AuthenticatedRequestWithRetrievedData[A]]] =
+  )(implicit hc: HeaderCarrier): Future[Either[Result, AuthenticatedRequestWithRetrievedData[A]]] =
     hasEoriEnrolment(enrolments, request) map {
       case Left(_)           => Left(Redirect(routes.UnauthorisedController.unauthorised()))
       case Right(Some(eori)) =>
@@ -205,7 +205,7 @@ class AuthenticatedActionWithRetrievedData @Inject() (
     f: GGCredId => Future[
       Either[Result, AuthenticatedRequestWithRetrievedData[A]]
     ]
-  ): Future[Either[Result, AuthenticatedRequestWithRetrievedData[A]]] =
+  )(implicit hc: HeaderCarrier): Future[Either[Result, AuthenticatedRequestWithRetrievedData[A]]] =
     credentials match {
       case None =>
         logger.warn("No credentials were retrieved")

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/FeatureSwitchProtectedAction.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/FeatureSwitchProtectedAction.scala
@@ -24,16 +24,21 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 class FeatureSwitchProtectedAction(feature: Feature, featureSwitch: FeatureSwitchService, errorHandler: ErrorHandler)(
   implicit val executionContext: ExecutionContext
 ) extends ActionRefiner[MessagesRequest, MessagesRequest]
     with Logging { self =>
 
-  override protected def refine[A](request: MessagesRequest[A]): Future[Either[Result, MessagesRequest[A]]] =
+  override protected def refine[A](request: MessagesRequest[A]): Future[Either[Result, MessagesRequest[A]]] = {
+    implicit val hc: HeaderCarrier =
+      HeaderCarrierConverter.fromRequestAndSession(request, request.session)
     Future.successful(
       if (featureSwitch.isEnabled(feature)) Right(request)
       else Left(Results.NotFound(errorHandler.notFoundTemplate(request)))
     )
+  }
 
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/testonly/controllers/FeatureSwitchController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/testonly/controllers/FeatureSwitchController.scala
@@ -29,17 +29,17 @@ class FeatureSwitchController @Inject() (
   val controllerComponents: MessagesControllerComponents
 ) extends FrontendBaseController {
 
-  def enable(featureName: String): Action[AnyContent] = Action {
+  def enable(featureName: String): Action[AnyContent] = Action { implicit request =>
     Feature
       .of(featureName)
-      .map(featureSwitch.enable(_))
+      .map(featureSwitch.enableForSession(_))
       .fold(NotFound(s"No $featureName feature exists"))(_ => Ok(s"Enabled feature $featureName"))
   }
 
-  def disable(featureName: String): Action[AnyContent] = Action {
+  def disable(featureName: String): Action[AnyContent] = Action { implicit request =>
     Feature
       .of(featureName)
-      .map(featureSwitch.disable(_))
+      .map(featureSwitch.disableForSession(_))
       .fold(NotFound(s"No $featureName feature exists"))(_ => Ok(s"Disabled feature $featureName"))
   }
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/common/choose_claim_type.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/common/choose_claim_type.scala.html
@@ -25,6 +25,7 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 @import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+@import uk.gov.hmrc.http.HeaderCarrier
 
 @this(
         layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
@@ -35,7 +36,7 @@
         featureSwitchService: FeatureSwitchService
 )
 
-@(form: Form[ClaimForm])(implicit request: Request[_], messages: Messages, viewConfig: ViewConfig)
+@(form: Form[ClaimForm])(implicit request: Request[_], hc: HeaderCarrier, messages: Messages, viewConfig: ViewConfig)
 
 @key = @{"choose-claim-type"}
 @title = @{messages(s"$key.title")}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -262,4 +262,4 @@ features.securities = on
 features.internal-upload-documents = off
 features.limited-access = off
 features.view-upload = on
-features.overpayments_v2 = on
+features.overpayments_v2 = off

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -247,6 +247,7 @@ play.i18n.langs = ["en", "cy"]
 
 mongodb.uri = "mongodb://localhost:27017/cds-reimbursement-claim-frontend"
 session-store.expiry-time = 7 days
+features-store.expiry-time = 7 days
 
 enable-language-switching = false
 
@@ -261,4 +262,4 @@ features.securities = on
 features.internal-upload-documents = off
 features.limited-access = off
 features.view-upload = on
-features.overpayments_v2 = off
+features.overpayments_v2 = on

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/FeatureSwitchServiceSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/FeatureSwitchServiceSpec.scala
@@ -29,30 +29,79 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.ControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.TestFeaturesCache
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.FeaturesCache
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import uk.gov.hmrc.http.SessionId
+import java.util.UUID
 
 class FeatureSwitchServiceSpec extends ControllerSpec with TableDrivenPropertyChecks with OptionValues {
 
   "FeatureSwitchService" should {
-    val configuration                       =
+    val configuration =
       Configuration.from(Map("feature.bulk-claim" -> "abc"))
 
-    val featureSwitch: FeatureSwitchService =
-      new ConfiguredFeatureSwitchService(configuration)
-
-    val featureList =
+    val featureList   =
       Table[Feature](
         "Features",
-        Feature.RejectedGoods
+        Feature.RejectedGoods,
+        Feature.LimitedAccess,
+        Feature.Overpayments_v2,
+        Feature.ViewUpload
       )
 
-    "enable and disable All features" in forAll(featureList) { feature =>
+    val featuresCache: FeaturesCache = new TestFeaturesCache
+
+    implicit val hc: HeaderCarrier = new HeaderCarrier(sessionId = Some(SessionId(UUID.randomUUID().toString)))
+
+    "enable and disable all features for test" in forAll(featureList) { feature =>
+      val featureSwitch: FeatureSwitchService =
+        new ConfiguredFeatureSwitchService(configuration, featuresCache)
+
       featureSwitch.enable(feature)
       featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe true
+      featureSwitch.disable(feature)
+      featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe false
+      featureSwitch.enable(feature)
+      featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe true
+      featureSwitch.disable(feature)
+      featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe false
+    }
+
+    "enable and disable all features for session" in forAll(featureList) { feature =>
+      val featureSwitch: FeatureSwitchService =
+        new ConfiguredFeatureSwitchService(configuration, featuresCache)
+
+      featureSwitch.enableForSession(feature)
+      featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe true
+      featureSwitch.disableForSession(feature)
+      featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe false
+      featureSwitch.enableForSession(feature)
+      featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe true
+      featureSwitch.disableForSession(feature)
+      featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe false
+    }
+
+    "enable and disable all features for test and session" in forAll(featureList) { feature =>
+      val featureSwitch: FeatureSwitchService =
+        new ConfiguredFeatureSwitchService(configuration, featuresCache)
+
+      featureSwitch.enable(feature)
+      featureSwitch.disableForSession(feature)
+      featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe true
+      featureSwitch.disable(feature)
+      featureSwitch.enableForSession(feature)
+      featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe false
+      featureSwitch.disableForSession(feature)
+      featureSwitch.enable(feature)
+      featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe true
+      featureSwitch.enableForSession(feature)
       featureSwitch.disable(feature)
       featureSwitch.isEnabled(Feature.of(feature.name).value) shouldBe false
     }
@@ -87,6 +136,7 @@ class FeatureSwitchServiceSpec extends ControllerSpec with TableDrivenPropertyCh
       new ActionBuilder[Request, AnyContent] with ActionFilter[Request] {
 
         def filter[A](input: Request[A]): Future[Option[Result]] = Future.successful {
+          implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(input, input.session)
           if (fs.isEnabled(feature)) None
           else Some(NotFound(errorHandler.notFoundTemplate(input)))
         }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/TestFeatureSwitchService.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/services/TestFeatureSwitchService.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.services
 
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+import uk.gov.hmrc.http.HeaderCarrier
 
 class TestFeatureSwitchService(initialFeatures: Feature*) extends FeatureSwitchService {
 
@@ -24,13 +25,22 @@ class TestFeatureSwitchService(initialFeatures: Feature*) extends FeatureSwitchS
   private val features: collection.mutable.Set[Feature] =
     collection.mutable.Set(initialFeatures: _*)
 
-  def enable(feature: Feature): Boolean =
+  override def enable(feature: Feature): Unit =
     features.add(feature)
 
-  def disable(feature: Feature): Boolean =
+  override def disable(feature: Feature): Unit =
     features.remove(feature)
 
-  def isEnabled(feature: Feature): Boolean =
+  override def isEnabled(feature: Feature)(implicit hc: HeaderCarrier): Boolean =
     features.contains(feature)
+
+  override def enableForSession(feature: Feature)(implicit hc: HeaderCarrier): Unit =
+    enable(feature)
+
+  override def disableForSession(feature: Feature)(implicit hc: HeaderCarrier): Unit =
+    disable(feature)
+
+  override def isEnabledForApplication(feature: Feature): Boolean =
+    isEnabled(feature)(HeaderCarrier())
 
 }


### PR DESCRIPTION
!Attention! This PR is changing how manual feature switching works. 

Before, manually switched feature was observable globally inside the single instance of a service (JVM), making it hard both for acceptance testing and testing manually on multi-instance environments (Dev, QA, Staging). 

After this PR, manually switched feature will be observable inside the current user's session across all service instances.

How to switch feature manually? 

E.g. 
- call /claim-back-import-duty-vat/test-only/feature/overpayments_v2/enable 
- call /claim-back-import-duty-vat/test-only/feature/overpayments_v2/disable