### PR TITLE
[bugfix] after upgrading the bootstrap library ensure callback is processed with the relevant header carrier converter

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyBaseController.scala
@@ -39,6 +39,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.CommonJourneyProperties
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 /** Base journey controller providing common action behaviours:
   *  - feature switch check
@@ -223,6 +224,11 @@ trait JourneyBaseController extends FrontendBaseController with Logging with Seq
     jcc
       .authenticatedActionWithSessionData(requiredFeature, isCallback)
       .async { implicit request =>
+        implicit val hc: HeaderCarrier =
+          if (isCallback)
+            HeaderCarrierConverter.fromRequest(request)
+          else
+            HeaderCarrierConverter.fromRequestAndSession(request, request.session)
         request.sessionData
           .flatMap(sessionData =>
             getJourney(sessionData)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyControllerComponents.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/JourneyControllerComponents.scala
@@ -65,12 +65,12 @@ class JourneyControllerComponents @Inject() (
         actionBuilder
           .andThen(new FeatureSwitchProtectedAction(feature, featureSwitchService, errorHandler))
           .andThen(authenticatedAction.readHeadersFromRequestOnly(isCallback))
-          .andThen(sessionDataAction)
+          .andThen(sessionDataAction.readHeadersFromRequestOnly(isCallback))
 
       case None =>
         actionBuilder
           .andThen(authenticatedAction.readHeadersFromRequestOnly(isCallback))
-          .andThen(sessionDataAction)
+          .andThen(sessionDataAction.readHeadersFromRequestOnly(isCallback))
     }
 
   final def authenticatedActionWithRetrievedDataAndSessionData(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataAction.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataAction.scala
@@ -78,11 +78,21 @@ class SessionDataAction @Inject() (
       RequestWithSessionData
     ] {
 
+  override val headersFromRequestOnly: Boolean = false
+
   def sessionDataAction[A](
     sessionData: Option[SessionData],
     request: AuthenticatedRequest[A]
   ): RequestWithSessionData[A] =
     RequestWithSessionData(sessionData, request)
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  def readHeadersFromRequestOnly(b: Boolean): SessionDataAction =
+    if (b == this.headersFromRequestOnly) this
+    else
+      new SessionDataAction(sessionStore, errorHandler) {
+        override val headersFromRequestOnly: Boolean = b
+      }
 
 }
 

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataActionBase.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataActionBase.scala
@@ -37,6 +37,8 @@ trait SessionDataActionBase[R[_] <: Request[_], P[_] <: Request[_]] extends Acti
 
   val errorHandler: ErrorHandler
 
+  val headersFromRequestOnly: Boolean
+
   implicit val executionContext: ExecutionContext
 
   def sessionDataAction[A](
@@ -47,8 +49,12 @@ trait SessionDataActionBase[R[_] <: Request[_], P[_] <: Request[_]] extends Acti
   override protected def refine[A](request: R[A]): Future[Either[Result, P[A]]] = {
 
     implicit val hc: HeaderCarrier =
-      HeaderCarrierConverter
-        .fromRequestAndSession(request, request.session)
+      if (headersFromRequestOnly)
+        HeaderCarrierConverter
+          .fromRequest(request)
+      else
+        HeaderCarrierConverter
+          .fromRequestAndSession(request, request.session)
 
     sessionStore
       .get()

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataActionWithRetrievedData.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataActionWithRetrievedData.scala
@@ -85,6 +85,8 @@ class SessionDataActionWithRetrievedData @Inject() (
       RequestWithSessionDataAndRetrievedData
     ] {
 
+  override val headersFromRequestOnly: Boolean = false
+
   def sessionDataAction[A](
     sessionData: Option[SessionData],
     request: AuthenticatedRequestWithRetrievedData[A]

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/WithAuthAndSessionDataAction.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/WithAuthAndSessionDataAction.scala
@@ -34,6 +34,6 @@ trait WithAuthAndSessionDataAction { this: FrontendBaseController =>
   val authenticatedCallbackWithSessionData: ActionBuilder[RequestWithSessionData, AnyContent] =
     Action
       .andThen(authenticatedAction.readHeadersFromRequestOnly(true))
-      .andThen(sessionDataAction)
+      .andThen(sessionDataAction.readHeadersFromRequestOnly(true))
 
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple/UploadFilesController.scala
@@ -49,6 +49,8 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 @Singleton
 class UploadFilesController @Inject() (
@@ -127,6 +129,9 @@ class UploadFilesController @Inject() (
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   final val callback: Action[AnyContent] =
     authenticatedCallbackWithSessionData.async { implicit request =>
+      implicit val hc: HeaderCarrier =
+        HeaderCarrierConverter.fromRequest(request)
+
       request.using { case fillingOutClaim: FillingOutClaim =>
         request.body.asJson
           .flatMap(_.asOpt[UploadDocumentsCallback]) match {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadFilesController.scala
@@ -49,6 +49,8 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 @Singleton
 class UploadFilesController @Inject() (
@@ -127,6 +129,9 @@ class UploadFilesController @Inject() (
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   final val callback: Action[AnyContent] =
     authenticatedCallbackWithSessionData.async { implicit request =>
+      implicit val hc: HeaderCarrier =
+        HeaderCarrierConverter.fromRequest(request)
+
       request.using { case fillingOutClaim: FillingOutClaim =>
         request.body.asJson
           .flatMap(_.asOpt[UploadDocumentsCallback]) match {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadMrnListController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadMrnListController.scala
@@ -51,6 +51,8 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 @Singleton
 class UploadMrnListController @Inject() (
@@ -112,6 +114,9 @@ class UploadMrnListController @Inject() (
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   final val callback: Action[AnyContent] =
     authenticatedCallbackWithSessionData.async { implicit request =>
+      implicit val hc: HeaderCarrier =
+        HeaderCarrierConverter.fromRequest(request)
+
       request.using { case fillingOutClaim: FillingOutClaim =>
         request.body.asJson
           .flatMap(_.asOpt[UploadMrnListCallback]) match {

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/UploadFilesController.scala
@@ -49,6 +49,8 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import uk.gov.hmrc.http.HeaderCarrier
 
 @Singleton
 class UploadFilesController @Inject() (
@@ -127,6 +129,9 @@ class UploadFilesController @Inject() (
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   final val callback: Action[AnyContent] =
     authenticatedCallbackWithSessionData.async { implicit request =>
+      implicit val hc: HeaderCarrier =
+        HeaderCarrierConverter.fromRequest(request)
+
       request.using { case fillingOutClaim: FillingOutClaim =>
         request.body.asJson
           .flatMap(_.asOpt[UploadDocumentsCallback]) match {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/ControllerSpec.scala
@@ -418,7 +418,7 @@ trait ControllerSpec
 trait PropertyBasedControllerSpec extends ControllerSpec with ScalaCheckPropertyChecks with ShrinkLowPriority {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    PropertyCheckConfiguration(minSuccessful = 100)
+    PropertyCheckConfiguration(minSuccessful = 20)
 }
 
 @Singleton


### PR DESCRIPTION
This PR fixes regression introduced by the latest libraries upgrade