### PR TITLE
[CDSR-2131] enable overpayments scheduled v2 and add EnterMovementReferenceNumberController

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/OverpaymentsScheduledClaimConnector.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/connectors/OverpaymentsScheduledClaimConnector.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors
+
+import akka.actor.ActorSystem
+import cats.syntax.eq._
+import com.google.inject.Inject
+import play.api.Configuration
+import play.api.libs.json.Format
+import play.api.libs.json.Json
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.utils.HttpResponseOps._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpClient
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+@Singleton
+class OverpaymentsScheduledClaimConnector @Inject() (
+  http: HttpClient,
+  servicesConfig: ServicesConfig,
+  configuration: Configuration,
+  val actorSystem: ActorSystem
+)(implicit
+  ec: ExecutionContext
+) extends Retries {
+
+  import OverpaymentsScheduledClaimConnector._
+
+  lazy val baseUrl: String                     = servicesConfig.baseUrl("cds-reimbursement-claim")
+  lazy val contextPath: String                 =
+    servicesConfig.getConfString("cds-reimbursement-claim.context-path", "cds-reimbursement-claim")
+  lazy val claimUrl: String                    = s"$baseUrl$contextPath/claims/overpayments-scheduled"
+  lazy val retryIntervals: Seq[FiniteDuration] = Retries.getConfIntervals("cds-reimbursement-claim", configuration)
+
+  def submitClaim(claimRequest: Request)(implicit
+    hc: HeaderCarrier
+  ): Future[Response] =
+    retry(retryIntervals: _*)(shouldRetry, retryReason)(
+      http
+        .POST[Request, HttpResponse](
+          claimUrl,
+          claimRequest,
+          Seq("Accept-Language" -> "en")
+        )
+    ).flatMap(response =>
+      if (response.status === 200)
+        response
+          .parseJSON[Response]()
+          .fold(error => Future.failed(Exception(error)), Future.successful)
+      else
+        Future.failed(
+          Exception(s"Request to POST $claimUrl failed because of $response ${response.body}")
+        )
+    )
+}
+
+object OverpaymentsScheduledClaimConnector {
+
+  final case class Request(claim: OverpaymentsScheduledJourney.Output)
+  final case class Response(caseNumber: String)
+  final case class Exception(msg: String) extends scala.RuntimeException(msg)
+
+  implicit val requestFormat: Format[Request]   = Json.format[Request]
+  implicit val responseFormat: Format[Response] = Json.format[Response]
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataActionWithRetrievedData.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/actions/SessionDataActionWithRetrievedData.scala
@@ -43,7 +43,7 @@ final case class RequestWithSessionDataAndRetrievedData[A](
     authenticatedRequest.request.messagesApi
 
   val signedInUserDetails: Option[SignedInUserDetails] = sessionData match {
-    case SessionData(journeyStatus @ Some(_), _, None, None, None, None, None, None) =>
+    case SessionData(journeyStatus @ Some(_), _, None, None, None, None, None, None, None) =>
       journeyStatus.collect {
         case JourneyStatus.FillingOutClaim(_, signedInUserDetails, _)       => signedInUserDetails
         case JourneyStatus.JustSubmittedClaim(_, signedInUserDetails, _, _) => signedInUserDetails

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpayments/ChooseHowManyMrnsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpayments/ChooseHowManyMrnsController.scala
@@ -33,8 +33,10 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.WithAuthRetrievalsAndSessionDataAction
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple_v2.{routes => overpaymentsMultipleRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle_v2.{routes => overpaymentsSingleRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.{routes => overpaymentsScheduledRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsMultipleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsSingleJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.OverpaymentsJourneyType
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.OverpaymentsJourneyType.Individual
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.OverpaymentsJourneyType.Multiple
@@ -105,13 +107,11 @@ class ChooseHowManyMrnsController @Inject() (
                     .map(_ => Redirect(overpaymentsMultipleRoutes.EnterMovementReferenceNumberController.showFirst))
 
                 case Scheduled =>
-                  Future.successful(NotImplemented)
-                //   (if (request.sessionData.overpaymentsScheduledJourney.isEmpty)
-                //      updateSession(sessionStore, request)(_ => SessionData(OverpaymentsScheduledJourney.empty(eori)))
-                //    else
-                //      Future.successful(Right(())))
-                //     .map(_ => Redirect(overpaymentsScheduledRoutes.EnterMovementReferenceNumberController.show()))
-
+                  (if (request.sessionData.overpaymentsScheduledJourney.isEmpty)
+                     updateSession(sessionStore, request)(_ => SessionData(OverpaymentsScheduledJourney.empty(eori)))
+                   else
+                     Future.successful(Right(())))
+                    .map(_ => Redirect(overpaymentsScheduledRoutes.EnterMovementReferenceNumberController.show))
               }
             )
         }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/BasisForClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/BasisForClaimController.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.OverpaymentsBasisForClaimMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks.declarantOrImporterEoriMatchesUserOrHasBeenVerified
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks.hasMRNAndDisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BasisOfOverpaymentClaim
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.components.hints.DropdownHints
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.overpayments.select_basis_for_claim
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class BasisForClaimController @Inject() (
+  val jcc: JourneyControllerComponents,
+  override val basisForClaimPage: select_basis_for_claim
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController
+    with OverpaymentsBasisForClaimMixin {
+
+  override val basisOfClaimsHints: DropdownHints =
+    DropdownHints.range(elementIndex = 1, maxHints = 14)
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  final override val postAction: Call =
+    routes.BasisForClaimController.submit
+
+  final override def continueRoute(basisOfClaim: BasisOfOverpaymentClaim): Call =
+    routes.EnterAdditionalDetailsController.show
+
+  final override def modifyJourney(
+    journey: Journey,
+    basisOfClaim: BasisOfOverpaymentClaim
+  ): Journey =
+    journey.submitBasisOfClaim(basisOfClaim)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckBankDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckBankDetailsController.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.mvc._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.check_bank_account_details
+
+import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.CheckBankDetailsMixin
+
+@Singleton
+class CheckBankDetailsController @Inject() (
+  val jcc: JourneyControllerComponents,
+  val checkBankAccountDetailsPage: check_bank_account_details
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController
+    with CheckBankDetailsMixin {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  final override def continueRoute(journey: Journey): Call =
+    if (journey.userHasSeenCYAPage) checkYourAnswers
+    else routes.ChooseFileTypeController.show
+
+  final override val chooseBankAccountTypeRoute: Call =
+    routes.ChooseBankAccountTypeController.show
+
+  final override val changeBankAccountDetailsRoute: Call =
+    chooseBankAccountTypeRoute
+
+  final override def modifyJourney(journey: Journey, bankAccountDetails: BankAccountDetails): Either[String, Journey] =
+    journey.submitBankAccountDetails(bankAccountDetails)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckClaimDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckClaimDetailsController.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import play.api.data.Form
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.YesOrNoQuestionForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.No
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo.Yes
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.overpayments.check_claim_details_scheduled
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.MRNScheduledRoutes
+
+@Singleton
+class CheckClaimDetailsController @Inject() (
+  val jcc: JourneyControllerComponents,
+  checkClaimDetailsPage: check_claim_details_scheduled
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController {
+
+  val checkClaimDetailsForm: Form[YesNo] = YesOrNoQuestionForm(CheckClaimDetailsController.checkClaimDetailsKey)
+
+  implicit val subKey: Option[String] = MRNScheduledRoutes.subKey
+
+  private val postAction: Call         = routes.CheckClaimDetailsController.submit
+  private val selectDutiesAction: Call = routes.SelectDutyTypesController.show
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  val show: Action[AnyContent] = actionReadJourney { implicit request => journey =>
+    val answers            = journey.getReimbursementClaims
+    val reimbursementTotal = journey.getTotalReimbursementAmount
+
+    if (journey.hasCompleteReimbursementClaims)
+      Ok(checkClaimDetailsPage(answers, reimbursementTotal, checkClaimDetailsForm, postAction)).asFuture
+    else Redirect(selectDutiesAction).asFuture
+  }
+
+  val submit: Action[AnyContent] = actionReadWriteJourney(
+    { implicit request => journey =>
+      val answers            = journey.getReimbursementClaims
+      val reimbursementTotal = journey.getTotalReimbursementAmount
+
+      if (!journey.hasCompleteReimbursementClaims) (journey, Redirect(selectDutiesAction)).asFuture
+      else {
+        checkClaimDetailsForm
+          .bindFromRequest()
+          .fold(
+            formWithErrors =>
+              (
+                journey,
+                BadRequest(
+                  checkClaimDetailsPage(
+                    answers,
+                    reimbursementTotal,
+                    formWithErrors,
+                    postAction
+                  )
+                )
+              ),
+            {
+              case Yes =>
+                (
+                  journey,
+                  Redirect(
+                    if (journey.hasCompleteAnswers)
+                      checkYourAnswers
+                    else
+                      routes.CheckBankDetailsController.show
+                  )
+                )
+              case No  => (journey, Redirect(selectDutiesAction))
+            }
+          )
+          .asFuture
+      }
+    },
+    fastForwardToCYAEnabled = false
+  )
+
+}
+
+object CheckClaimDetailsController {
+  val checkClaimDetailsKey: String = "check-claim-summary"
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckClaimantDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckClaimantDetailsController.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import play.api.mvc._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.ContactAddressLookupMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks.declarantOrImporterEoriMatchesUserOrHasBeenVerified
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks.hasMRNAndDisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.AddressLookupService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.check_claimant_details
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.address.ContactAddress
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
+import play.twirl.api.HtmlFormat
+
+@Singleton
+class CheckClaimantDetailsController @Inject() (
+  val jcc: JourneyControllerComponents,
+  val addressLookupService: AddressLookupService,
+  claimantDetailsPage: check_claimant_details
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig, val errorHandler: ErrorHandler)
+    extends OverpaymentsScheduledJourneyBaseController
+    with ContactAddressLookupMixin {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  val startAddressLookup: Call =
+    routes.CheckClaimantDetailsController.redirectToALF
+
+  val changeCd: Call =
+    routes.EnterContactDetailsController.show
+
+  val postAction: Call =
+    routes.CheckClaimantDetailsController.submit
+
+  override def viewTemplate: MrnContactDetails => ContactAddress => Request[_] => HtmlFormat.Appendable =
+    cd => ca => implicit request => claimantDetailsPage(cd, ca, changeCd, Some(startAddressLookup), postAction)
+
+  override val redirectWhenNoAddressDetailsFound: Call =
+    routes.EnterMovementReferenceNumberController.show
+
+  override val nextPageInTheJourney: Call =
+    routes.NorthernIrelandController.show
+
+  override val problemWithAddressPage: Call = routes.ProblemWithAddressController.show
+
+  override val retrieveLookupAddress: Call =
+    routes.CheckClaimantDetailsController.retrieveAddressFromALF()
+
+  override def modifyJourney(journey: Journey, contactDetails: MrnContactDetails): Journey =
+    journey.submitContactDetails(Some(contactDetails))
+
+  override def modifyJourney(journey: Journey, contactAddress: ContactAddress): Journey =
+    journey.submitContactAddress(contactAddress)
+
+  override def redirectToTheNextPage(journey: OverpaymentsScheduledJourney): (OverpaymentsScheduledJourney, Result) =
+    (journey, Redirect(routes.CheckClaimantDetailsController.show))
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckDeclarationDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckDeclarationDetailsController.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.data.Form
+import play.api.mvc._
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.CheckDeclarationDetailsMixin
+
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.overpayments.check_declaration_details
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class CheckDeclarationDetailsController @Inject() (
+  val jcc: JourneyControllerComponents,
+  checkDeclarationDetailsPage: check_declaration_details
+)(implicit val viewConfig: ViewConfig, val errorHandler: ErrorHandler, val ec: ExecutionContext)
+    extends OverpaymentsScheduledJourneyBaseController
+    with CheckDeclarationDetailsMixin {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  final override def getDisplayDeclaration(journey: Journey): Option[DisplayDeclaration] =
+    journey.getLeadDisplayDeclaration
+
+  final override def continueRoute(journey: Journey): Call =
+    routes.UploadMrnListController.show
+
+  final override val enterMovementReferenceNumberRoute: Call =
+    routes.EnterMovementReferenceNumberController.submit
+
+  private val postAction: Call =
+    routes.CheckDeclarationDetailsController.submit
+
+  override def viewTemplate: (DisplayDeclaration, Form[YesNo]) => Request[_] => HtmlFormat.Appendable = {
+    case (decl, form) =>
+      implicit request =>
+        checkDeclarationDetailsPage(decl, form, false, postAction, None)
+  }
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckYourAnswersController.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.OverpaymentsScheduledClaimConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.UploadDocumentsConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.submit_claim_error
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.confirmation_of_submission
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.overpayments.check_your_answers_scheduled
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class CheckYourAnswersController @Inject() (
+  val jcc: JourneyControllerComponents,
+  overpaymentsScheduledClaimConnector: OverpaymentsScheduledClaimConnector,
+  uploadDocumentsConnector: UploadDocumentsConnector,
+  checkYourAnswersPage: check_your_answers_scheduled,
+  confirmationOfSubmissionPage: confirmation_of_submission,
+  submitClaimFailedPage: submit_claim_error
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController {
+
+  private val postAction: Call             = routes.CheckYourAnswersController.submit
+  private val showConfirmationAction: Call = routes.CheckYourAnswersController.showConfirmation
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  final val show: Action[AnyContent] =
+    actionReadWriteJourney { implicit request => journey =>
+      journey
+        .submitCheckYourAnswersChangeMode(true)
+        .toOutput
+        .fold(
+          errors => {
+            logger.warn(s"Claim not ready to show the CYA page because of ${errors.mkString(",")}")
+            (
+              journey.submitCheckYourAnswersChangeMode(false),
+              Redirect(routeForValidationErrors(errors))
+            )
+          },
+          output =>
+            (
+              journey.submitCheckYourAnswersChangeMode(true),
+              Ok(
+                checkYourAnswersPage(
+                  output,
+                  journey.answers.displayDeclaration,
+                  postAction
+                )
+              )
+            )
+        )
+        .asFuture
+    }
+
+  final val submit: Action[AnyContent] =
+    actionReadWriteJourney { implicit request => journey =>
+      if (journey.isFinalized)
+        (journey, Redirect(showConfirmationAction)).asFuture
+      else
+        journey
+          .submitCheckYourAnswersChangeMode(true)
+          .toOutput
+          .fold(
+            errors => {
+              logger.warn(s"Claim not ready to submit because of ${errors.mkString(",")}")
+              (journey, Redirect(routeForValidationErrors(errors))).asFuture
+            },
+            output =>
+              overpaymentsScheduledClaimConnector
+                .submitClaim(OverpaymentsScheduledClaimConnector.Request(output))
+                .flatMap { response =>
+                  logger.info(
+                    s"Successful submit of claim for ${output.movementReferenceNumber} with case number ${response.caseNumber}."
+                  )
+                  uploadDocumentsConnector.wipeOut
+                    .map(_ =>
+                      (
+                        journey.finalizeJourneyWith(response.caseNumber).getOrElse(journey),
+                        Redirect(showConfirmationAction)
+                      )
+                    )
+                }
+                .recover { case e =>
+                  logger.error(s"Failed to submit claim for ${output.movementReferenceNumber} because of $e.")
+                  (journey, Ok(submitClaimFailedPage()))
+                }
+          )
+    }
+
+  final val showConfirmation: Action[AnyContent] =
+    jcc
+      .authenticatedActionWithSessionData(requiredFeature)
+      .async { implicit request =>
+        request.sessionData
+          .flatMap(getJourney)
+          .map(journey =>
+            (journey.caseNumber match {
+              case Some(caseNumber) => Ok(confirmationOfSubmissionPage(journey.getTotalReimbursementAmount, caseNumber))
+              case None             => Redirect(checkYourAnswers)
+            }).asFuture
+          )
+          .getOrElse(redirectToTheStartOfTheJourney)
+      }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/ChooseBankAccountTypeController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/ChooseBankAccountTypeController.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import com.google.inject.Inject
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.ChooseBankAccountTypeMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.choose_bank_account_type_page
+
+import scala.concurrent.ExecutionContext
+
+class ChooseBankAccountTypeController @Inject() (
+  val jcc: JourneyControllerComponents,
+  val chooseBankAccountTypePage: choose_bank_account_type_page
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController
+    with ChooseBankAccountTypeMixin {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  final override val postAction: Call =
+    routes.ChooseBankAccountTypeController.submit
+
+  final override val enterBankAccountDetailsRoute: Call =
+    routes.EnterBankAccountDetailsController.show
+
+  final override def modifyJourney(
+    journey: Journey,
+    bankAccountType: BankAccountType
+  ): Either[String, Journey] =
+    journey.submitBankAccountType(bankAccountType)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/ChooseFileTypeController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/ChooseFileTypeController.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import play.api.data.Form
+import play.api.mvc.Call
+import play.api.mvc.Request
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.ChooseFileTypeMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.upscan.UploadDocumentType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.choose_file_type
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class ChooseFileTypeController @Inject() (
+  val jcc: JourneyControllerComponents,
+  chooseFileTypePage: choose_file_type
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig, val errorHandler: ErrorHandler)
+    extends OverpaymentsScheduledJourneyBaseController
+    with ChooseFileTypeMixin {
+
+  final override val uploadFilesRoute: Call =
+    routes.UploadFilesController.show
+
+  final override def viewTemplate
+    : (Form[Option[UploadDocumentType]], Seq[UploadDocumentType], Boolean) => Request[_] => HtmlFormat.Appendable =
+    (form, documentTypes, hasExistingUploads) =>
+      implicit request =>
+        chooseFileTypePage(form, documentTypes, hasExistingUploads, routes.ChooseFileTypeController.submit)
+
+  final override def modifyJourney(journey: Journey, documentType: UploadDocumentType): Either[String, Journey] =
+    Right(
+      journey
+        .submitDocumentTypeSelection(documentType)
+    )
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterAdditionalDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterAdditionalDetailsController.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.OverpaymentsEnterAdditionalDetailsMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks.declarantOrImporterEoriMatchesUserOrHasBeenVerified
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks.hasMRNAndDisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.overpayments.enter_additional_details
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class EnterAdditionalDetailsController @Inject() (
+  val jcc: JourneyControllerComponents,
+  override val enterAdditionalDetailsPage: enter_additional_details
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController
+    with OverpaymentsEnterAdditionalDetailsMixin {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  final val postAction: Call    = routes.EnterAdditionalDetailsController.submit
+  final val continueRoute: Call = routes.SelectDutyTypesController.show
+
+  final override def modifyJourney(journey: Journey, additionalDetails: String): Journey =
+    journey.submitAdditionalDetails(additionalDetails)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterBankAccountDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterBankAccountDetailsController.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ErrorHandler
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.common.{routes => commonRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.EnterBankAccountDetailsMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.BankAccountDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.BankAccountReputationService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_bank_account_details
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class EnterBankAccountDetailsController @Inject() (
+  val jcc: JourneyControllerComponents,
+  val bankAccountReputationService: BankAccountReputationService,
+  val enterBankAccountDetailsPage: enter_bank_account_details
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig, val errorHandler: ErrorHandler)
+    extends OverpaymentsScheduledJourneyBaseController
+    with EnterBankAccountDetailsMixin {
+
+  final override def modifyJourney(
+    journey: Journey,
+    bankAccountDetails: BankAccountDetails
+  ): Either[String, Journey] =
+    journey.submitBankAccountDetails(bankAccountDetails)
+
+  override val routesPack: RoutesPack = RoutesPack(
+    errorPath = commonRoutes.BankAccountVerificationUnavailable.show(),
+    retryPath = routes.EnterBankAccountDetailsController.show,
+    successPath = routes.CheckBankDetailsController.show,
+    submitPath = routes.EnterBankAccountDetailsController.submit,
+    getBankAccountTypePath = routes.ChooseBankAccountTypeController.show
+  )
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterClaimController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterClaimController.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import play.api.data.Form
+import play.api.data.FormError
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.enterScheduledClaimForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DutyType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.overpayments.enter_scheduled_claim
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.AmountPaidWithCorrect
+
+@Singleton
+class EnterClaimController @Inject() (
+  val jcc: JourneyControllerComponents,
+  enterClaimPage: enter_scheduled_claim
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  final def showFirst(): Action[AnyContent] = actionReadJourney { _ => journey =>
+    journey.findNextDutyToSelectDuties match {
+      case None =>
+        (journey.getSelectedDuties.headOption
+          .flatMap { case (dt, tcs) => tcs.headOption.map(tc => (dt, tc)) } match {
+          case Some((dutyType, taxCode)) =>
+            Redirect(routes.EnterClaimController.show(dutyType, taxCode))
+
+          case None =>
+            Redirect(routes.SelectDutyTypesController.show)
+        }).asFuture
+
+      case Some(emptyDuty) =>
+        Redirect(routes.SelectDutiesController.show(emptyDuty)).asFuture
+    }
+  }
+
+  final def show(dutyType: DutyType, taxCode: TaxCode): Action[AnyContent] = actionReadJourney {
+    implicit request => journey =>
+      journey.findNextDutyToSelectDuties match {
+        case None =>
+          val postAction: Call                                  = routes.EnterClaimController.submit(dutyType, taxCode)
+          val maybeReimbursement: Option[AmountPaidWithCorrect] = journey.getReimbursementFor(dutyType, taxCode)
+          val form                                              = enterScheduledClaimForm.withDefault(maybeReimbursement)
+
+          Ok(enterClaimPage(dutyType, taxCode, form, postAction)).asFuture
+
+        case Some(emptyDuty) =>
+          Redirect(routes.SelectDutiesController.show(emptyDuty)).asFuture
+      }
+
+  }
+
+  final def submit(currentDuty: DutyType, currentTaxCode: TaxCode): Action[AnyContent] = actionReadWriteJourney(
+    { implicit request => journey =>
+      journey.findNextDutyToSelectDuties match {
+        case None =>
+          val postAction: Call = routes.EnterClaimController.submit(currentDuty, currentTaxCode)
+
+          Future.successful(
+            enterScheduledClaimForm
+              .bindFromRequest()
+              .fold(
+                formWithErrors =>
+                  (
+                    journey,
+                    BadRequest(
+                      enterClaimPage(
+                        currentDuty,
+                        currentTaxCode,
+                        redirectVerificationMessage(formWithErrors),
+                        postAction
+                      )
+                    )
+                  ),
+                reimbursement =>
+                  journey
+                    .submitAmountForReimbursement(
+                      currentDuty,
+                      currentTaxCode,
+                      reimbursement.refundAmount,
+                      reimbursement.paidAmount
+                    )
+                    .fold(
+                      errors => {
+                        logger.error(s"Error updating reimbursement selection - $errors")
+                        (
+                          journey,
+                          BadRequest(
+                            enterClaimPage(
+                              currentDuty,
+                              currentTaxCode,
+                              enterScheduledClaimForm,
+                              postAction
+                            )
+                          )
+                        )
+                      },
+                      updatedJourney =>
+                        (
+                          updatedJourney,
+                          updatedJourney.findNextSelectedTaxCodeAfter(currentDuty, currentTaxCode) match {
+                            case Some((nextDutyType, nextTaxCode)) =>
+                              if (journey.hasCompleteReimbursementClaims)
+                                Redirect(routes.CheckClaimDetailsController.show)
+                              else Redirect(routes.EnterClaimController.show(nextDutyType, nextTaxCode))
+                            case None                              =>
+                              Redirect(routes.CheckClaimDetailsController.show)
+                          }
+                        )
+                    )
+              )
+          )
+
+        case Some(emptyDuty) =>
+          (journey, Redirect(routes.SelectDutiesController.show(emptyDuty))).asFuture
+      }
+    },
+    fastForwardToCYAEnabled = false
+  )
+
+  def redirectVerificationMessage(
+    formWithErrors: Form[AmountPaidWithCorrect]
+  ): Form[AmountPaidWithCorrect] = {
+    val errors: Seq[FormError] = formWithErrors.errors.map {
+      case formError if formError.messages.contains("invalid.claim") =>
+        formError.copy(key = s"${formError.key}.claim-amount")
+      case formError                                                 => formError
+    }
+    formWithErrors.copy(errors = errors)
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterContactDetailsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterContactDetailsController.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.EnterContactDetailsMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.MrnContactDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_or_change_contact_details
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class EnterContactDetailsController @Inject() (
+  val jcc: JourneyControllerComponents,
+  val enterOrChangeContactDetailsPage: enter_or_change_contact_details
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController
+    with EnterContactDetailsMixin {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  final override val postAction: Call =
+    routes.EnterContactDetailsController.submit
+
+  final override val continueRoute: Call =
+    routes.CheckClaimantDetailsController.show
+
+  final override def modifyJourney(journey: Journey, contactDetails: Option[MrnContactDetails]): Journey =
+    journey.submitContactDetails(contactDetails)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterDeclarantEoriNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterDeclarantEoriNumberController.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.EnterDeclarantEoriNumberMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_declarant_eori_number
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class EnterDeclarantEoriNumberController @Inject() (
+  val jcc: JourneyControllerComponents,
+  val enterDeclarantEoriNumber: enter_declarant_eori_number
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController
+    with EnterDeclarantEoriNumberMixin {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration)
+
+  final override val postAction: Call =
+    routes.EnterDeclarantEoriNumberController.submit
+
+  final override val continueAction: Call =
+    routes.CheckDeclarationDetailsController.show
+
+  final override val whenEoriInputNotRequiredAction: Call =
+    routes.BasisForClaimController.show
+
+  final override def modifyJourney(journey: Journey, eori: Eori): Either[String, Journey] =
+    journey.submitDeclarantEoriNumber(eori)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterImporterEoriNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterImporterEoriNumberController.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.EnterImporterEoriNumberMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.enter_importer_eori_number
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class EnterImporterEoriNumberController @Inject() (
+  val jcc: JourneyControllerComponents,
+  val enterImporterEoriNumber: enter_importer_eori_number
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController
+    with EnterImporterEoriNumberMixin {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration)
+
+  final override val postAction: Call =
+    routes.EnterImporterEoriNumberController.submit
+
+  final override val continueAction: Call =
+    routes.EnterDeclarantEoriNumberController.show
+
+  final override val whenEoriInputNotRequiredAction: Call =
+    routes.BasisForClaimController.show
+
+  final override def modifyJourney(journey: Journey, eori: Eori): Either[String, Journey] =
+    journey.submitConsigneeEoriNumber(eori)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterMovementReferenceNumberController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterMovementReferenceNumberController.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.data.Form
+import play.api.mvc.Request
+import play.api.mvc.Result
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.EnterMovementReferenceNumberMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.claims.enter_movement_reference_number
+
+import scala.concurrent.ExecutionContext
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+
+@Singleton
+class EnterMovementReferenceNumberController @Inject() (
+  val jcc: JourneyControllerComponents,
+  val claimService: ClaimService,
+  enterMovementReferenceNumberPage: enter_movement_reference_number
+)(implicit val viewConfig: ViewConfig, val ec: ExecutionContext)
+    extends OverpaymentsScheduledJourneyBaseController
+    with EnterMovementReferenceNumberMixin {
+
+  override def form(journey: Journey): Form[MRN] =
+    Forms.movementReferenceNumberForm
+
+  override def getMovementReferenceNumber(journey: Journey): Option[MRN] =
+    journey.getLeadMovementReferenceNumber
+
+  override def viewTemplate: Form[MRN] => Request[_] => HtmlFormat.Appendable =
+    form =>
+      implicit request =>
+        enterMovementReferenceNumberPage(
+          form,
+          Some("overpayments.scheduled"),
+          routes.EnterMovementReferenceNumberController.submit
+        )
+
+  override def modifyJourney(journey: Journey, mrn: MRN, declaration: DisplayDeclaration): Either[String, Journey] =
+    journey.submitMovementReferenceNumberAndDeclaration(mrn, declaration)
+
+  override def afterSuccessfullSubmit(journey: OverpaymentsScheduledJourney): Result =
+    if (journey.needsDeclarantAndConsigneeEoriSubmission) {
+      Redirect(routes.EnterImporterEoriNumberController.show)
+    } else {
+      Redirect(routes.CheckDeclarationDetailsController.show)
+    }
+
+  final val start: Action[AnyContent] =
+    Action(Redirect(routes.EnterMovementReferenceNumberController.show))
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/NorthernIrelandController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/NorthernIrelandController.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.OverpaymentsNorthernIrelandMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.overpayments.claim_northern_ireland
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class NorthernIrelandController @Inject() (
+  val jcc: JourneyControllerComponents,
+  val northernIrelandAnswerPage: claim_northern_ireland
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController
+    with OverpaymentsNorthernIrelandMixin {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  final override def modifyJourney(journey: Journey, whetherNorthernIreland: Boolean): Journey =
+    journey.submitWhetherNorthernIreland(whetherNorthernIreland)
+
+  final val postAction: Call       = routes.NorthernIrelandController.submit
+  final val continueRoute: Call    = routes.BasisForClaimController.show
+  final val subkey: Option[String] = None
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/OverpaymentsScheduledJourneyBaseController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/OverpaymentsScheduledJourneyBaseController.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyBaseController
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{upscan => _}
+import play.api.libs.json.Format
+
+trait OverpaymentsScheduledJourneyBaseController extends JourneyBaseController with OverpaymentsScheduledJourneyRouter {
+
+  final type Journey = OverpaymentsScheduledJourney
+
+  final val format: Format[OverpaymentsScheduledJourney] =
+    OverpaymentsScheduledJourney.format
+
+  final override val requiredFeature: Option[Feature] =
+    Some(Feature.Overpayments_v2)
+
+  final override val startOfTheJourney: Call =
+    uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.routes.StartController.start()
+
+  final override val checkYourAnswers: Call            = routes.CheckYourAnswersController.show
+  final override val claimSubmissionConfirmation: Call = routes.CheckYourAnswersController.showConfirmation
+
+  final override def getJourney(sessionData: SessionData): Option[OverpaymentsScheduledJourney] =
+    sessionData.overpaymentsScheduledJourney
+
+  final override def updateJourney(sessionData: SessionData, journey: OverpaymentsScheduledJourney): SessionData =
+    sessionData.copy(overpaymentsScheduledJourney = Some(journey))
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/OverpaymentsScheduledJourneyRouter.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/OverpaymentsScheduledJourneyRouter.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.JourneyValidationErrors._
+
+trait OverpaymentsScheduledJourneyRouter {
+
+  private val undefined: Call = routes.EnterMovementReferenceNumberController.show
+
+  def routeForValidationError(error: String): Call =
+    error match {
+      case JOURNEY_ALREADY_FINALIZED                                => routes.CheckYourAnswersController.showConfirmation
+      case MISSING_FIRST_MOVEMENT_REFERENCE_NUMBER                  => routes.EnterMovementReferenceNumberController.show
+      case MISSING_DISPLAY_DECLARATION                              => routes.EnterMovementReferenceNumberController.show
+      case MISSING_SCHEDULED_DOCUMENT                               => routes.UploadMrnListController.show
+      case MISSING_BASIS_OF_CLAIM                                   => routes.BasisForClaimController.show
+      case INCOMPLETE_REIMBURSEMENT_CLAIMS                          => routes.CheckClaimDetailsController.show
+      case INCOMPLETE_SUPPORTING_EVIDENCES                          => routes.ChooseFileTypeController.show
+      case MISSING_CONTACT_DETAILS                                  => routes.EnterContactDetailsController.show
+      case MISSING_CONTACT_ADDRESS                                  => routes.CheckClaimantDetailsController.redirectToALF
+      case TOTAL_REIMBURSEMENT_AMOUNT_MUST_BE_GREATER_THAN_ZERO     => routes.CheckClaimDetailsController.show
+      case DECLARANT_EORI_NUMBER_MUST_BE_PROVIDED                   => routes.EnterDeclarantEoriNumberController.show
+      case DECLARANT_EORI_NUMBER_MUST_BE_EQUAL_TO_THAT_OF_ACC14     => routes.EnterDeclarantEoriNumberController.show
+      case CONSIGNEE_EORI_NUMBER_MUST_BE_PROVIDED                   => routes.EnterImporterEoriNumberController.show
+      case CONSIGNEE_EORI_NUMBER_MUST_BE_EQUAL_TO_THAT_OF_ACC14     => routes.EnterImporterEoriNumberController.show
+      case DECLARANT_EORI_NUMBER_DOES_NOT_HAVE_TO_BE_PROVIDED       => undefined
+      case CONSIGNEE_EORI_NUMBER_DOES_NOT_HAVE_TO_BE_PROVIDED       => undefined
+      case BANK_ACCOUNT_DETAILS_MUST_BE_DEFINED                     => routes.CheckBankDetailsController.show
+      case BANK_ACCOUNT_DETAILS_MUST_NOT_BE_DEFINED                 => undefined
+      case BASIS_OF_CLAIM_SPECIAL_CIRCUMSTANCES_MUST_NOT_BE_DEFINED => undefined
+      case DUTIES_CHANGE_MODE_ENABLED                               => routes.CheckClaimDetailsController.show
+      case _                                                        => undefined
+    }
+
+  def routeForValidationErrors(errors: Seq[String]): Call =
+    errors.headOption.map(routeForValidationError).getOrElse(undefined)
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/ProblemWithAddressController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/ProblemWithAddressController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.common.problem_with_address
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class ProblemWithAddressController @Inject() (
+  val jcc: JourneyControllerComponents,
+  problemWithAddressPage: problem_with_address
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController {
+
+  val startAddressLookup: Call = routes.CheckClaimantDetailsController.redirectToALF
+
+  def show(): Action[AnyContent] = actionReadJourney { implicit request => _ =>
+    Ok(problemWithAddressPage(startAddressLookup)).asFuture
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/SelectDutiesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/SelectDutiesController.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import play.api.data.Form
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.selectDutyCodesForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DutyType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+@Singleton
+class SelectDutiesController @Inject() (
+  val jcc: JourneyControllerComponents,
+  selectDutyCodesPage: pages.select_duty_codes
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController {
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  def show(dutyType: DutyType): Action[AnyContent] = actionReadJourney { implicit request => journey =>
+    if (journey.isDutyTypeSelected) {
+      val postAction: Call                     = routes.SelectDutiesController.submit(dutyType)
+      val maybeTaxCodes: Option[List[TaxCode]] = Option(journey.getSelectedDuties(dutyType).toList)
+      val form: Form[List[TaxCode]]            = selectDutyCodesForm.withDefault(maybeTaxCodes)
+
+      Ok(selectDutyCodesPage(dutyType, form, postAction)).asFuture
+    } else {
+      Redirect(routes.SelectDutyTypesController.show).asFuture
+    }
+
+  }
+
+  def submit(currentDuty: DutyType): Action[AnyContent] = actionReadWriteJourney { implicit request => journey =>
+    val postAction: Call = routes.SelectDutiesController.submit(currentDuty)
+    if (journey.isDutyTypeSelected) {
+      Future.successful(
+        selectDutyCodesForm
+          .bindFromRequest()
+          .fold(
+            formWithErrors => (journey, BadRequest(selectDutyCodesPage(currentDuty, formWithErrors, postAction))),
+            selectedTaxCodes =>
+              journey
+                .selectAndReplaceTaxCodeSetForReimbursement(currentDuty, selectedTaxCodes)
+                .fold(
+                  errors => {
+                    logger.error(s"Error updating tax codes selection - $errors")
+                    (journey, BadRequest(selectDutyCodesPage(currentDuty, selectDutyCodesForm, postAction)))
+                  },
+                  updatedJourney =>
+                    (
+                      updatedJourney,
+                      updatedJourney.findNextSelectedDutyAfter(currentDuty) match {
+                        case Some(nextDuty) => Redirect(routes.SelectDutiesController.show(nextDuty))
+                        case None           => Redirect(routes.EnterClaimController.showFirst)
+                      }
+                    )
+                )
+          )
+      )
+    } else {
+      (journey, Redirect(routes.SelectDutyTypesController.show)).asFuture
+    }
+
+  }
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/SelectDutyTypesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/SelectDutyTypesController.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.Forms.selectDutyTypesForm
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.{claims => pages}
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class SelectDutyTypesController @Inject() (
+  val jcc: JourneyControllerComponents,
+  selectDutyTypesPage: pages.select_duty_types
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController {
+
+  val postAction: Call = routes.SelectDutyTypesController.submit
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  val show: Action[AnyContent] = actionReadJourney { implicit request => _ =>
+    val form = selectDutyTypesForm
+
+    Ok(selectDutyTypesPage(form, postAction)).asFuture
+
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  val submit: Action[AnyContent] = actionReadWriteJourney { implicit request => journey =>
+    selectDutyTypesForm
+      .bindFromRequest()
+      .fold(
+        formWithErrors =>
+          (
+            journey,
+            BadRequest(
+              selectDutyTypesPage(
+                formWithErrors,
+                postAction
+              )
+            )
+          ),
+        dutyTypes =>
+          journey
+            .selectAndReplaceDutyTypeSetForReimbursement(dutyTypes)
+            .fold(
+              errors => {
+                logger.error(s"Error updating duty types selection - $errors")
+                (journey, BadRequest(selectDutyTypesPage(selectDutyTypesForm, postAction)))
+              },
+              updatedJourney =>
+                (
+                  updatedJourney,
+                  Redirect(
+                    routes.SelectDutiesController
+                      .show(dutyTypes.headOption.getOrElse(throw new Exception("Unexpected empty duty types")))
+                  )
+                )
+            )
+      )
+      .asFuture
+  }
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/UploadFilesController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/UploadFilesController.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import com.github.arturopala.validator.Validator.Validate
+import play.api.mvc.Call
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.FileUploadConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.UploadDocumentsConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.UploadDocumentsConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.mixins.UploadFilesMixin
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney.Checks._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Nonce
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.UploadedFile
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.upscan.UploadDocumentType
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.overpayments.upload_files_description
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+
+@Singleton
+class UploadFilesController @Inject() (
+  val jcc: JourneyControllerComponents,
+  val uploadDocumentsConnector: UploadDocumentsConnector,
+  val uploadDocumentsConfig: UploadDocumentsConfig,
+  val fileUploadConfig: FileUploadConfig,
+  upload_files_description: upload_files_description,
+  val featureSwitchService: FeatureSwitchService
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController
+    with UploadFilesMixin {
+
+  final val selectDocumentTypePageAction: Call = routes.ChooseFileTypeController.show
+  final val callbackAction: Call               = routes.UploadFilesController.submit
+
+  final override def chooseFilesPageDescriptionTemplate: String => Messages => HtmlFormat.Appendable =
+    documentType => messages => upload_files_description("choose-files.overpayments", documentType)(messages)
+
+  // Allow actions only if the MRN and ACC14 declaration are in place, and the EORI has been verified.
+  final override val actionPrecondition: Option[Validate[OverpaymentsScheduledJourney]] =
+    Some(hasMRNAndDisplayDeclaration & declarantOrImporterEoriMatchesUserOrHasBeenVerified)
+
+  final override def modifyJourney(
+    journey: Journey,
+    documentType: UploadDocumentType,
+    requestNonce: Nonce,
+    uploadedFiles: Seq[UploadedFile]
+  ): Either[String, Journey] =
+    journey
+      .receiveUploadedFiles(
+        documentType,
+        requestNonce,
+        uploadedFiles
+      )
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/UploadMrnListController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/UploadMrnListController.scala
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import play.api.i18n.Messages
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.Call
+import play.api.mvc.Request
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.FileUploadConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.UploadDocumentsConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.connectors.UploadDocumentsConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.JourneyControllerComponents
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Nonce
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.UploadMrnListCallback
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.UploadDocumentsSessionConfig
+// FIXME
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.rejectedgoods.upload_mrn_list_description
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.upscan.UploadDocumentType
+
+@Singleton
+class UploadMrnListController @Inject() (
+  val jcc: JourneyControllerComponents,
+  uploadDocumentsConnector: UploadDocumentsConnector,
+  val uploadDocumentsConfig: UploadDocumentsConfig,
+  val fileUploadConfig: FileUploadConfig,
+  val upload_mrn_list_description: upload_mrn_list_description,
+  featureSwitchService: FeatureSwitchService
+)(implicit val ec: ExecutionContext, val viewConfig: ViewConfig)
+    extends OverpaymentsScheduledJourneyBaseController {
+
+  final val backlinkUrl: Call    = routes.CheckDeclarationDetailsController.show
+  final val callbackAction: Call = routes.UploadMrnListController.submit
+  final val selfUrl: String      = jcc.servicesConfig.getString("self.url")
+
+  final val show: Action[AnyContent] = actionReadJourney { implicit request => journey =>
+    val continueUrl: Call =
+      if (journey.hasCompleteAnswers) checkYourAnswers
+      else routes.CheckClaimantDetailsController.show
+
+    uploadDocumentsConnector
+      .initialize(
+        UploadDocumentsConnector
+          .Request(
+            uploadDocumentsSessionConfig(
+              journey.answers.nonce,
+              continueUrl
+            ),
+            journey.answers.scheduledDocument.map(file => Seq(file)).getOrElse(Seq.empty),
+            featureSwitchService
+              .optionally(Feature.InternalUploadDocuments, "schedule-document")
+          )
+      )
+      .map {
+        case Some(url) =>
+          Redirect(url)
+        case None      =>
+          Redirect(
+            s"${uploadDocumentsConfig.publicUrl}${uploadDocumentsConfig.contextPath}"
+          )
+      }
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  final val submit: Action[AnyContent] = simpleActionReadWriteJourney(
+    { implicit request => journey =>
+      request
+        .asInstanceOf[Request[AnyContent]]
+        .body
+        .asJson
+        .flatMap(_.asOpt[UploadMrnListCallback]) match {
+        case None =>
+          logger.warn("missing or invalid callback payload")
+          (journey, BadRequest("missing or invalid callback payload"))
+
+        case Some(callback) =>
+          callback.uploadedFiles.headOption match {
+            case Some(uploadedFile) =>
+              journey
+                .receiveScheduledDocument(
+                  callback.nonce,
+                  uploadedFile
+                )
+                .fold(
+                  error => (journey, BadRequest(error)),
+                  modifiedJourney => (modifiedJourney, NoContent)
+                )
+            case None               =>
+              (journey.removeScheduledDocument, NoContent)
+          }
+
+      }
+    },
+    isCallback = true
+  )
+
+  def uploadDocumentsSessionConfig(
+    nonce: Nonce,
+    continueUrl: Call
+  )(implicit messages: Messages): UploadDocumentsSessionConfig =
+    UploadDocumentsSessionConfig(
+      nonce = nonce,
+      continueUrl = selfUrl + continueUrl.url,
+      continueWhenFullUrl = selfUrl + continueUrl.url,
+      callbackUrl = uploadDocumentsConfig.callbackUrlPrefix + callbackAction.url,
+      minimumNumberOfFiles = 1,
+      maximumNumberOfFiles = 1,
+      initialNumberOfEmptyRows = 1,
+      maximumFileSizeBytes = fileUploadConfig.readMaxFileSize("schedule-of-mrn"),
+      allowedContentTypes = "application/pdf,image/jpeg,image/png",
+      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg",
+      cargo = Some(UploadDocumentType.ScheduleOfMRNs),
+      newFileDescription =
+        Some(messages(s"schedule-document.file-type.${UploadDocumentType.keyOf(UploadDocumentType.ScheduleOfMRNs)}")),
+      content = uploadDocumentsContent,
+      features = UploadDocumentsSessionConfig.Features(
+        showUploadMultiple = true,
+        showLanguageSelection = viewConfig.enableLanguageSwitching,
+        showAddAnotherDocumentButton = false,
+        showYesNoQuestionBeforeContinue = false
+      )
+    )
+
+  def uploadDocumentsContent(implicit messages: Messages): UploadDocumentsSessionConfig.Content = {
+    val descriptionHtml = upload_mrn_list_description(
+      "schedule-document.upload"
+    )(messages).body
+
+    UploadDocumentsSessionConfig.Content(
+      serviceName = messages("service.title"),
+      title = messages("schedule-document.upload.title"),
+      descriptionHtml = descriptionHtml,
+      serviceUrl = viewConfig.homePageUrl,
+      accessibilityStatementUrl = viewConfig.accessibilityStatementUrl,
+      phaseBanner = "beta",
+      phaseBannerUrl = viewConfig.serviceFeedBackUrl,
+      signOutUrl = viewConfig.signOutUrl,
+      timedOutUrl = viewConfig.ggTimedOutUrl,
+      keepAliveUrl = viewConfig.ggKeepAliveUrl,
+      timeoutSeconds = viewConfig.ggTimeoutSeconds.toInt,
+      countdownSeconds = viewConfig.ggCountdownSeconds.toInt,
+      pageTitleClasses = "govuk-heading-xl",
+      allowedFilesTypesHint = messages("schedule-document.upload.allowed-file-types"),
+      fileUploadedProgressBarLabel = messages("choose-files.uploaded.label"),
+      chooseFirstFileLabel = messages("schedule-document.upload.choose.description")
+    )
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsScheduledJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsScheduledJourney.scala
@@ -161,7 +161,8 @@ final class OverpaymentsScheduledJourney private (
     Some(UploadDocumentType.overpaymentsScheduledDocumentTypes)
 
   override def getAvailableClaimTypes: BasisOfOverpaymentClaimsList =
-    BasisOfOverpaymentClaimsList()
+    BasisOfOverpaymentClaimsList
+      .withoutDuplicateEntry()
       .excludeNorthernIrelandClaims(answers.whetherNorthernIreland.getOrElse(false), answers.displayDeclaration)
 
   /** Resets the journey with the new MRN

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/SessionData.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/SessionData.scala
@@ -27,11 +27,13 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.SecuritiesJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsSingleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsMultipleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
 
 final case class SessionData(
   journeyStatus: Option[JourneyStatus] = None,
   overpaymentsSingleJourney: Option[OverpaymentsSingleJourney] = None,
   overpaymentsMultipleJourney: Option[OverpaymentsMultipleJourney] = None,
+  overpaymentsScheduledJourney: Option[OverpaymentsScheduledJourney] = None,
   rejectedGoodsSingleJourney: Option[RejectedGoodsSingleJourney] = None,
   rejectedGoodsMultipleJourney: Option[RejectedGoodsMultipleJourney] = None,
   rejectedGoodsScheduledJourney: Option[RejectedGoodsScheduledJourney] = None,
@@ -60,6 +62,9 @@ object SessionData {
   def apply(overpaymentsMultipleJourney: OverpaymentsMultipleJourney): SessionData =
     SessionData(overpaymentsMultipleJourney = Some(overpaymentsMultipleJourney))
 
+  def apply(overpaymentsScheduledJourney: OverpaymentsScheduledJourney): SessionData =
+    SessionData(overpaymentsScheduledJourney = Some(overpaymentsScheduledJourney))
+
   def apply(rejectedGoodsSingleJourney: RejectedGoodsSingleJourney): SessionData =
     SessionData(rejectedGoodsSingleJourney = Some(rejectedGoodsSingleJourney))
 
@@ -86,6 +91,7 @@ object SessionData {
       session.overpaymentsSingleJourney
         .map(_.getClaimantEori)
         .orElse(session.overpaymentsMultipleJourney.map(_.getClaimantEori))
+        .orElse(session.overpaymentsScheduledJourney.map(_.getClaimantEori))
         .orElse(session.rejectedGoodsSingleJourney.map(_.getClaimantEori))
         .orElse(session.rejectedGoodsScheduledJourney.map(_.getClaimantEori))
         .orElse(session.rejectedGoodsMultipleJourney.map(_.getClaimantEori))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/overpayments/check_claim_details_scheduled.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/overpayments/check_claim_details_scheduled.scala.html
@@ -1,0 +1,90 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.data.Form
+@import play.api.i18n.Messages
+@import play.api.mvc.{Call, Request}
+@import play.twirl.api.Html
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.{AmountPaidWithCorrect, DutyType, TaxCode}
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.helpers.{DutyAndTaxCodeReimbursementRejectedGoodsSummary, TaxCodeReimbursementRejectedGoodsSummary}
+@import uk.gov.hmrc.govukfrontend.views.Aliases.RadioItem
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+
+@import scala.collection.SortedMap
+
+@this(
+        layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
+        submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
+        heading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.heading,
+        subHeading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.sub_heading,
+        formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF,
+        errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary,
+        paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph,
+        radios: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.input_radio,
+        summary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.summary
+)
+
+@(answer: SortedMap[DutyType, SortedMap[TaxCode, AmountPaidWithCorrect]], reimbursementTotal: BigDecimal, form: Form[YesNo], postAction: Call)(implicit request: Request[_], messages: Messages, viewConfig: ViewConfig, subKey: Option[String])
+
+@key = @{"check-claim-summary"}
+@title = @{messages(s"$key.scheduled.title")}
+
+@hasErrors = @{form.hasErrors || form.hasGlobalErrors}
+
+@layout(pageTitle = Some(s"$title"), suppressBackLink = false, hasErrors = hasErrors) {
+
+    @errorSummary(form.errors)
+
+    @heading(Html(title))
+
+    @paragraph(Html(messages(s"$key.scheduled.help-text")), Some("govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-3"))
+    // FIXME
+    @answer.map { claims =>
+        @subHeading(Html(messages(s"duty-type.${claims._1.repr}")), classes = "govuk-heading-m")
+        // FIXME
+        <br/>
+    }
+
+    @subHeading(Html(messages(s"$key.total.header")), classes = "govuk-heading-m")
+   
+    <br/>
+
+    @formWithCSRF(postAction, 'novalidate -> "novalidate") {
+
+        @radios(
+            form = form,
+            name = key,
+            legend = messages(s"$key.are-duties-correct"),
+            inline = true,
+            items = Seq(
+                RadioItem(
+                    value = Some("true"),
+                    content = Text(messages(s"$key.yes")),
+                    checked = false
+                ),
+                RadioItem(
+                    value = Some("false"),
+                    content = Text(messages(s"$key.no")),
+                    checked = false
+                )
+            )
+        )
+
+        @submitButton("button.continue")
+    }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/overpayments/check_your_answers_scheduled.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/overpayments/check_your_answers_scheduled.scala.html
@@ -1,0 +1,87 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.twirl.api.Html
+@import play.api.i18n.Messages
+@import play.api.mvc.Call
+@import play.api.mvc.Request
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.routes
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.helpers._
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.helpers.MessagesHelper._
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.helpers._
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.answers.YesNo
+
+@this(
+    layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
+    heading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.heading,
+    subHeading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.sub_heading,
+    summary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.summary,
+    submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
+    paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph,
+    formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+)
+
+@(claim: OverpaymentsScheduledJourney.Output, displayDeclarationOpt: Option[DisplayDeclaration], postAction: Call, subKey: Option[String] = None)(implicit request: Request[_], messages: Messages,viewConfig: ViewConfig)
+
+@key = @{"check-your-answers"}
+@title = @{messages(s"$key.title")}
+
+@layout(pageTitle = Some(s"$title")) {
+
+    @heading(Html(title))
+
+    @subHeading(Html(messages(combine(s"$key.reference-number", subKey, "h2"))), classes = "govuk-heading-m govuk-!-margin-top-7")
+    @summary(MovementReferenceNumberSummary.single(claim.movementReferenceNumber, s"$key.reference-number", subKey, Some(routes.EnterMovementReferenceNumberController.show)))
+
+    @displayDeclarationOpt.map { displayDeclaration =>
+        @subHeading(Html(messages(s"$key.declaration-details.h2")))
+        @summary(SummaryList(CdsDisplayDeclarationSummary(displayDeclaration,s"$key.declaration-details", subKey).rows.drop(2)))
+    } 
+
+    @subHeading(Html(messages(s"$key.contact-information.h2")))
+    @summary(ClaimantInformationSummary(claim.claimantInformation, s"$key.contact-information", routes.CheckClaimantDetailsController.show, Some(routes.CheckClaimantDetailsController.show)))
+    
+    @subHeading(Html(messages(s"$key.northern-ireland-claim.h2")))
+    @summary(NorthernIrelandAnswerSummary(YesNo.of(claim.whetherNorthernIreland), s"$key.northern-ireland-claim", Some(routes.NorthernIrelandController.show)))
+    
+    @subHeading(Html(messages(s"$key.basis.h2")))
+    @summary(BasisOfClaimSummary(claim.basisOfClaim,s"$key.basis", Some(routes.BasisForClaimController.show)))
+    
+    @subHeading(Html(messages(s"$key.additional-details.h2")))
+    @summary(AdditionalDetailsSummary(claim.additionalDetails, s"$key.additional-details", Some(routes.EnterAdditionalDetailsController.show)))
+    
+    // FIXME
+
+    @claim.bankAccountDetails.map { bankAccountDetails =>
+        @subHeading(Html(messages(s"$key.bank-details.h2")))
+        @summary(BankAccountDetailsSummary(bankAccountDetails, s"$key.bank-details", Some(routes.CheckBankDetailsController.show)))
+    }
+
+    @subHeading(Html(messages(s"$key.attached-documents.h2")))
+    @summary(EvidenceDocumentsSummary(claim.supportingEvidences,s"$key.attached-documents", Some(routes.UploadFilesController.summary)))
+    
+    @subHeading(Html(messages(s"$key.confirmation-statement.h2")))
+    @paragraph(Html(messages(s"$key.confirmation-statement")))
+
+    @formWithCSRF(postAction, 'novalidate -> "novalidate") {
+        @submitButton("button.accept-and-send")
+    }
+}
+

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/overpayments/enter_scheduled_claim.scala.html
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/views/overpayments/enter_scheduled_claim.scala.html
@@ -1,0 +1,87 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.data.Form
+@import play.api.i18n.Messages
+@import play.twirl.api.Html
+@import play.api.mvc.Request
+@import play.api.mvc.Call
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.config.ViewConfig
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.TaxCode
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.input.PrefixOrSuffix
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.DutyType
+@import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.AmountPaidWithCorrect
+
+@this(
+        submitButton: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.button,
+        heading: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.heading,
+        layout: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.Layout,
+        errorSummary: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.error_summary,
+        inputText: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.input_text,
+        formWithCSRF: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF,
+        paragraph: uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.components.paragraph
+)
+
+@(dutyType: DutyType, dutyCode: TaxCode, form : Form[AmountPaidWithCorrect], postAction: Call)(implicit request: Request[_], messages: Messages, viewConfig: ViewConfig)
+
+@key = @{"enter-claim-scheduled"}
+@title = @{messages(s"$key.title", messages(s"duty-type.${dutyType.repr}"), dutyCode.value)}
+@hintText = @{Html(messages(s"$key.claim-amount.hint"))}
+@hasErrors = @{form.hasErrors || form.hasGlobalErrors}
+
+@layout(pageTitle = Some(s"$title"), hasErrors = hasErrors) {
+
+    @errorSummary(form.errors)
+
+    @heading(Html(title))
+
+    @paragraph(Html(messages(s"$key.help-text", messages(s"tax-code.${dutyCode.value}"))))
+
+    @paragraph(Html(messages(s"$key.inset-text")), Some("govuk-inset-text govuk-!-margin-bottom-8"))
+
+    @formWithCSRF(postAction, 'novalidate -> "novalidate") {
+
+        @inputText(
+            form = form,
+            id = s"$key.paid-amount",
+            name = s"$key.paid-amount",
+            label = s"$key.paid-amount",
+            labelClasses = Some("govuk-label govuk-label--m"),
+            inputMode = Some("numeric"),
+            isPageHeading = false,
+            classes = Some("govuk-input govuk-!-width-one-quarter"),
+            prefix = Some(PrefixOrSuffix(content = Text(messages(s"currency"))))
+        )
+
+
+        @inputText(
+            form = form,
+            id = s"$key.claim-amount",
+            name = s"$key.claim-amount",
+            label = s"$key.claim-amount",
+            labelClasses = Some("govuk-label govuk-label--m"),
+            inputMode = Some("numeric"),
+            isPageHeading = false,
+            classes = Some("govuk-input govuk-!-width-one-quarter"),
+            hintHtml = Some(hintText),
+            prefix = Some(PrefixOrSuffix(content = Text(messages(s"currency"))))
+        )
+
+        @submitButton("button.continue")
+    }
+}
+

--- a/conf/overpayments_scheduled_v2.routes
+++ b/conf/overpayments_scheduled_v2.routes
@@ -1,68 +1,68 @@
-#GET         /overpayments/v2/scheduled/enter-movement-reference-number                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterMovementReferenceNumberController.show
-#POST        /overpayments/v2/scheduled/enter-movement-reference-number                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterMovementReferenceNumberController.submit
+GET         /overpayments/v2/scheduled/enter-movement-reference-number                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterMovementReferenceNumberController.show
+POST        /overpayments/v2/scheduled/enter-movement-reference-number                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterMovementReferenceNumberController.submit
 
-#GET         /overpayments/v2/scheduled/enter-importer-eori                                      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterImporterEoriNumberController.show
-#POST        /overpayments/v2/scheduled/enter-importer-eori                                      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterImporterEoriNumberController.submit
+GET         /overpayments/v2/scheduled/enter-importer-eori                                      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterImporterEoriNumberController.show
+POST        /overpayments/v2/scheduled/enter-importer-eori                                      @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterImporterEoriNumberController.submit
 
-#GET         /overpayments/v2/scheduled/enter-declarant-eori                                     @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterDeclarantEoriNumberController.show
-#POST        /overpayments/v2/scheduled/enter-declarant-eori                                     @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterDeclarantEoriNumberController.submit
+GET         /overpayments/v2/scheduled/enter-declarant-eori                                     @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterDeclarantEoriNumberController.show
+POST        /overpayments/v2/scheduled/enter-declarant-eori                                     @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterDeclarantEoriNumberController.submit
 
-#GET         /overpayments/v2/scheduled/check-declaration-details                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckDeclarationDetailsController.show
-#POST        /overpayments/v2/scheduled/check-declaration-details                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckDeclarationDetailsController.submit
+GET         /overpayments/v2/scheduled/check-declaration-details                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckDeclarationDetailsController.show
+POST        /overpayments/v2/scheduled/check-declaration-details                                @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckDeclarationDetailsController.submit
 
-#GET         /overpayments/v2/scheduled/upload-mrn-list                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.UploadMrnListController.show
-#+nocsrf
-#POST        /overpayments/v2/scheduled/upload-mrn-list                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.UploadMrnListController.submit
+GET         /overpayments/v2/scheduled/upload-mrn-list                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.UploadMrnListController.show
++nocsrf
+POST        /overpayments/v2/scheduled/upload-mrn-list                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.UploadMrnListController.submit
 
-#GET         /overpayments/v2/scheduled/claimant-details                                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimantDetailsController.show
-#POST        /overpayments/v2/scheduled/claimant-details                                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimantDetailsController.submit
+GET         /overpayments/v2/scheduled/claimant-details                                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimantDetailsController.show
+POST        /overpayments/v2/scheduled/claimant-details                                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimantDetailsController.submit
 
-#GET         /overpayments/v2/scheduled/claimant-details/lookup-address                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimantDetailsController.redirectToALF
-#GET         /overpayments/v2/scheduled/claimant-details/update-address                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimantDetailsController.retrieveAddressFromALF(id: Option[UUID] ?= None)
+GET         /overpayments/v2/scheduled/claimant-details/lookup-address                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimantDetailsController.redirectToALF
+GET         /overpayments/v2/scheduled/claimant-details/update-address                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimantDetailsController.retrieveAddressFromALF(id: Option[UUID] ?= None)
 
-#GET         /overpayments/v2/scheduled/claimant-details/problem-with-address                    @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.ProblemWithAddressController.show
+GET         /overpayments/v2/scheduled/claimant-details/problem-with-address                    @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.ProblemWithAddressController.show
 
-#GET         /overpayments/v2/scheduled/claimant-details/change-contact-details                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterContactDetailsController.show
-#POST        /overpayments/v2/scheduled/claimant-details/change-contact-details                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterContactDetailsController.submit
+GET         /overpayments/v2/scheduled/claimant-details/change-contact-details                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterContactDetailsController.show
+POST        /overpayments/v2/scheduled/claimant-details/change-contact-details                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterContactDetailsController.submit
 
-#GET         /overpayments/v2/scheduled/claim-northern-ireland                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.NorthernIrelandController.show
-#POST        /overpayments/v2/scheduled/claim-northern-ireland                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.NorthernIrelandController.submit
+GET         /overpayments/v2/scheduled/claim-northern-ireland                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.NorthernIrelandController.show
+POST        /overpayments/v2/scheduled/claim-northern-ireland                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.NorthernIrelandController.submit
 
-#GET         /overpayments/v2/scheduled/choose-basis-for-claim                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.BasisForClaimController.show
-#POST        /overpayments/v2/scheduled/choose-basis-for-claim                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.BasisForClaimController.submit
+GET         /overpayments/v2/scheduled/choose-basis-for-claim                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.BasisForClaimController.show
+POST        /overpayments/v2/scheduled/choose-basis-for-claim                                   @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.BasisForClaimController.submit
 
-#GET         /overpayments/v2/scheduled/bank-account-type                                        @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.ChooseBankAccountTypeController.show
-#POST        /overpayments/v2/scheduled/bank-account-type                                        @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.ChooseBankAccountTypeController.submit
+GET         /overpayments/v2/scheduled/bank-account-type                                        @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.ChooseBankAccountTypeController.show
+POST        /overpayments/v2/scheduled/bank-account-type                                        @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.ChooseBankAccountTypeController.submit
 
-#GET         /overpayments/v2/scheduled/check-bank-details                                       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckBankDetailsController.show
+GET         /overpayments/v2/scheduled/check-bank-details                                       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckBankDetailsController.show
 
-#GET         /overpayments/v2/scheduled/enter-bank-account-details                               @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterBankAccountDetailsController.show
-#POST        /overpayments/v2/scheduled/enter-bank-account-details                               @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterBankAccountDetailsController.submit
+GET         /overpayments/v2/scheduled/enter-bank-account-details                               @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterBankAccountDetailsController.show
+POST        /overpayments/v2/scheduled/enter-bank-account-details                               @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterBankAccountDetailsController.submit
 
-#GET         /overpayments/v2/scheduled/enter-additional-details                                 @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterAdditionalDetailsController.show
-#POST        /overpayments/v2/scheduled/enter-additional-details                                 @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterAdditionalDetailsController.submit
+GET         /overpayments/v2/scheduled/enter-additional-details                                 @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterAdditionalDetailsController.show
+POST        /overpayments/v2/scheduled/enter-additional-details                                 @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterAdditionalDetailsController.submit
 
-#GET         /overpayments/v2/scheduled/select-duties/select-duty-types                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.SelectDutyTypesController.show
-#POST        /overpayments/v2/scheduled/select-duties/select-duty-types                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.SelectDutyTypesController.submit
+GET         /overpayments/v2/scheduled/select-duties/select-duty-types                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.SelectDutyTypesController.show
+POST        /overpayments/v2/scheduled/select-duties/select-duty-types                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.SelectDutyTypesController.submit
 
-#GET         /overpayments/v2/scheduled/select-duties/:dutyType                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.SelectDutiesController.show(dutyType: DutyType)
-#POST        /overpayments/v2/scheduled/select-duties/:dutyType                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.SelectDutiesController.submit(dutyType: DutyType)
+GET         /overpayments/v2/scheduled/select-duties/:dutyType                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.SelectDutiesController.show(dutyType: DutyType)
+POST        /overpayments/v2/scheduled/select-duties/:dutyType                                  @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.SelectDutiesController.submit(dutyType: DutyType)
 
-#GET         /overpayments/v2/scheduled/enter-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterClaimController.showFirst
-#GET         /overpayments/v2/scheduled/enter-claim/:dutyType/:taxCode                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterClaimController.show(dutyType: DutyType, taxCode: TaxCode)
-#POST        /overpayments/v2/scheduled/enter-claim/:dutyType/:taxCode                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterClaimController.submit(dutyType: DutyType, taxCode: TaxCode)
+GET         /overpayments/v2/scheduled/enter-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterClaimController.showFirst
+GET         /overpayments/v2/scheduled/enter-claim/:dutyType/:taxCode                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterClaimController.show(dutyType: DutyType, taxCode: TaxCode)
+POST        /overpayments/v2/scheduled/enter-claim/:dutyType/:taxCode                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.EnterClaimController.submit(dutyType: DutyType, taxCode: TaxCode)
 
-#GET         /overpayments/v2/scheduled/check-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimDetailsController.show
-#POST        /overpayments/v2/scheduled/check-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimDetailsController.submit
+GET         /overpayments/v2/scheduled/check-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimDetailsController.show
+POST        /overpayments/v2/scheduled/check-claim                                              @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckClaimDetailsController.submit
 
-#GET         /overpayments/v2/scheduled/choose-file-type                                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.ChooseFileTypeController.show
-#POST        /overpayments/v2/scheduled/choose-file-type                                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.ChooseFileTypeController.submit
+GET         /overpayments/v2/scheduled/choose-file-type                                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.ChooseFileTypeController.show
+POST        /overpayments/v2/scheduled/choose-file-type                                         @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.ChooseFileTypeController.submit
 
-#GET         /overpayments/v2/scheduled/choose-files                                             @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.UploadFilesController.show
-#+nocsrf
-#POST        /overpayments/v2/scheduled/choose-files                                             @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.UploadFilesController.submit
-#GET         /overpayments/v2/scheduled/upload-summary                                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.UploadFilesController.summary
+GET         /overpayments/v2/scheduled/choose-files                                             @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.UploadFilesController.show
++nocsrf
+POST        /overpayments/v2/scheduled/choose-files                                             @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.UploadFilesController.submit
+GET         /overpayments/v2/scheduled/upload-summary                                           @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.UploadFilesController.summary
 
-#POST        /overpayments/v2/scheduled/submit-claim                                             @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckYourAnswersController.submit
-#GET         /overpayments/v2/scheduled/claim-submitted                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckYourAnswersController.showConfirmation
-#GET         /overpayments/v2/scheduled/check-your-answers                                       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckYourAnswersController.show
+POST        /overpayments/v2/scheduled/submit-claim                                             @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckYourAnswersController.submit
+GET         /overpayments/v2/scheduled/claim-submitted                                          @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckYourAnswersController.showConfirmation
+GET         /overpayments/v2/scheduled/check-your-answers                                       @uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.CheckYourAnswersController.show

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -8,6 +8,7 @@
 ->          /claim-back-import-duty-vat                   overpayments_multiple.Routes
 ->          /claim-back-import-duty-vat                   overpayments_multiple_v2.Routes
 ->          /claim-back-import-duty-vat                   overpayments_scheduled.Routes
+->          /claim-back-import-duty-vat                   overpayments_scheduled_v2.Routes
 ->          /claim-back-import-duty-vat                   rejected_goods.Routes
 ->          /claim-back-import-duty-vat                   rejected_goods_single.Routes
 ->          /claim-back-import-duty-vat                   rejected_goods_multiple.Routes

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpayments/ChooseHowManyMrnsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpayments/ChooseHowManyMrnsControllerSpec.scala
@@ -41,14 +41,16 @@ import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.Authenticat
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.actions.SessionDataActionWithRetrievedData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsmultiple_v2.{routes => overpaymentsMultipleRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentssingle_v2.{routes => overpaymentsSingleRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2.{routes => overpaymentsScheduledRoutes}
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsMultipleJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsSingleJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsSingleJourneyGenerators.exampleEori
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Nonce
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.OverpaymentsJourneyType.Individual
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.OverpaymentsJourneyType.Multiple
-//import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.OverpaymentsJourneyType.Scheduled
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.OverpaymentsJourneyType.Scheduled
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.views.html.overpayments.choose_how_many_mrns
@@ -159,19 +161,19 @@ class ChooseHowManyMrnsControllerSpec
         checkIsRedirect(result, overpaymentsMultipleRoutes.EnterMovementReferenceNumberController.showFirst)
       }
 
-      // "Redirect to (scheduled route) EnterMovementReferenceNumber page when user chooses Scheduled" in {
-      //   val updatedSession = SessionData(OverpaymentsScheduledJourney.empty(eoriExample, Nonce.Any))
+      "Redirect to (scheduled route) EnterMovementReferenceNumber page when user chooses Scheduled" in {
+        val updatedSession = SessionData(OverpaymentsScheduledJourney.empty(eoriExample, Nonce.Any))
 
-      //   inSequence {
-      //     mockAuthWithEoriEnrolmentRetrievals(exampleEori)
-      //     mockGetSession(SessionData.empty)
-      //     mockStoreSession(updatedSession)(Right(()))
-      //   }
+        inSequence {
+          mockAuthWithEoriEnrolmentRetrievals(exampleEori)
+          mockGetSession(SessionData.empty)
+          mockStoreSession(updatedSession)(Right(()))
+        }
 
-      //   val result = performAction(Seq("overpayments.choose-how-many-mrns" -> Scheduled.toString))
+        val result = performAction(Seq("overpayments.choose-how-many-mrns" -> Scheduled.toString))
 
-      //   checkIsRedirect(result, overpaymentsScheduledRoutes.EnterMovementReferenceNumberController.show)
-      // }
+        checkIsRedirect(result, overpaymentsScheduledRoutes.EnterMovementReferenceNumberController.show)
+      }
 
       "Show error message when no data selected" in {
         inSequence {

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterMovementReferenceNumberControllerSpec.scala
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.overpaymentsscheduled_v2
+
+import cats.data.EitherT
+import cats.implicits._
+import org.scalatest.BeforeAndAfterEach
+import play.api.http.Status.BAD_REQUEST
+import play.api.http.Status.NOT_FOUND
+import play.api.i18n.Lang
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
+import play.api.inject.bind
+import play.api.inject.guice.GuiceableModule
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.cache.SessionCache
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.AuthSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.PropertyBasedControllerSpec
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.SessionSupport
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.controllers.{routes => baseRoutes}
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourney
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.journeys.OverpaymentsScheduledJourneyGenerators._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Error
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.Feature
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.SessionData
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.ConsigneeDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DeclarantDetails
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DisplayDeclarationGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.DisplayResponseDetailGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.Generators.sample
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators.IdGen._
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.Eori
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ids.MRN
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.ClaimService
+import uk.gov.hmrc.cdsreimbursementclaimfrontend.services.FeatureSwitchService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class EnterMovementReferenceNumberControllerSpec
+    extends PropertyBasedControllerSpec
+    with AuthSupport
+    with SessionSupport
+    with BeforeAndAfterEach {
+
+  val mockClaimService: ClaimService = mock[ClaimService]
+
+  val enterMovementReferenceNumberKey: String = "enter-movement-reference-number"
+
+  override val overrideBindings: List[GuiceableModule] =
+    List[GuiceableModule](
+      bind[AuthConnector].toInstance(mockAuthConnector),
+      bind[SessionCache].toInstance(mockSessionCache),
+      bind[ClaimService].toInstance(mockClaimService)
+    )
+
+  val controller: EnterMovementReferenceNumberController = instanceOf[EnterMovementReferenceNumberController]
+
+  implicit val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messages: Messages       = MessagesImpl(Lang("en"), messagesApi)
+
+  private lazy val featureSwitch = instanceOf[FeatureSwitchService]
+
+  override def beforeEach(): Unit =
+    featureSwitch.enable(Feature.Overpayments_v2)
+
+  val session = SessionData.empty.copy(
+    overpaymentsScheduledJourney = Some(OverpaymentsScheduledJourney.empty(exampleEori))
+  )
+
+  private def mockGetDisplayDeclaration(expectedMrn: MRN, response: Either[Error, Option[DisplayDeclaration]]) =
+    (mockClaimService
+      .getDisplayDeclaration(_: MRN)(_: HeaderCarrier))
+      .expects(expectedMrn, *)
+      .returning(EitherT.fromEither[Future](response))
+
+  "Movement Reference Number Controller" when {
+    "Enter MRN page" must {
+
+      def performAction(): Future[Result] =
+        controller.show()(FakeRequest())
+
+      "do not find the page if overpayments feature is disabled" in {
+        featureSwitch.disable(Feature.Overpayments_v2)
+
+        status(performAction()) shouldBe NOT_FOUND
+      }
+
+      "display the page on a new journey" in {
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+        }
+
+        checkPageIsDisplayed(
+          performAction(),
+          messageFromMessageKey("enter-movement-reference-number.title"),
+          doc => {
+            doc.select("#enter-movement-reference-number").`val`() shouldBe ""
+            doc.select("form").attr("action")                      shouldBe routes.EnterMovementReferenceNumberController.submit.url
+          }
+        )
+      }
+
+      "display the page on a pre-existing journey" in {
+        val journey        = completeJourneyWithMatchingUserEoriGen.sample.getOrElse(
+          fail("Unable to generate complete journey")
+        )
+        val mrn            = journey.answers.movementReferenceNumber.getOrElse(fail("No mrn found in journey"))
+        val sessionToAmend = session.copy(overpaymentsScheduledJourney = Some(journey))
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(sessionToAmend)
+        }
+
+        checkPageIsDisplayed(
+          performAction(),
+          messageFromMessageKey("enter-movement-reference-number.title"),
+          doc => doc.select("#enter-movement-reference-number").`val`() shouldBe mrn.value
+        )
+      }
+    }
+
+    "Submit MRN page" must {
+
+      def performAction(data: (String, String)*): Future[Result] =
+        controller.submit()(FakeRequest().withFormUrlEncodedBody(data: _*))
+
+      "do not find the page if overpayments feature is disabled" in {
+        featureSwitch.disable(Feature.Overpayments_v2)
+
+        status(performAction()) shouldBe NOT_FOUND
+      }
+
+      "reject an invalid MRN" in {
+        val invalidMRN = MRN("INVALID_MOVEMENT_REFERENCE_NUMBER")
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+        }
+
+        checkPageIsDisplayed(
+          performAction(enterMovementReferenceNumberKey -> invalidMRN.value),
+          messageFromMessageKey("enter-movement-reference-number.title"),
+          doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-movement-reference-number.invalid.number"),
+          expectedStatus = BAD_REQUEST
+        )
+      }
+
+      "reject an empty MRN" in {
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+        }
+
+        checkPageIsDisplayed(
+          performAction(enterMovementReferenceNumberKey -> ""),
+          messageFromMessageKey("enter-movement-reference-number.title"),
+          doc => getErrorSummary(doc) shouldBe messageFromMessageKey("enter-movement-reference-number.error.required"),
+          expectedStatus = BAD_REQUEST
+        )
+      }
+
+      "submit an unknown MRN" in forAll { (mrn: MRN) =>
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+          mockGetDisplayDeclaration(mrn, Right(None))
+        }
+
+        checkIsRedirect(
+          performAction(enterMovementReferenceNumberKey -> mrn.value),
+          baseRoutes.IneligibleController.ineligible()
+        )
+      }
+
+      "submit a valid MRN and user is declarant" in forAll { (mrn: MRN) =>
+        val journey                       = session.overpaymentsScheduledJourney.getOrElse(fail("No overpayments journey"))
+        val displayDeclaration            = sample[DisplayDeclaration].withDeclarationId(mrn.value)
+        val updatedDeclarantDetails       = displayDeclaration.displayResponseDetail.declarantDetails.copy(
+          declarantEORI = journey.answers.userEoriNumber.value
+        )
+        val updatedDisplayResponseDetails =
+          displayDeclaration.displayResponseDetail.copy(declarantDetails = updatedDeclarantDetails)
+        val updatedDisplayDeclaration     = displayDeclaration.copy(displayResponseDetail = updatedDisplayResponseDetails)
+        val updatedJourney                =
+          journey
+            .submitMovementReferenceNumberAndDeclaration(mrn, updatedDisplayDeclaration)
+            .getOrFail
+        val updatedSession                = session.copy(overpaymentsScheduledJourney = Some(updatedJourney))
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+          mockGetDisplayDeclaration(mrn, Right(Some(updatedDisplayDeclaration)))
+          mockStoreSession(updatedSession)(Right(()))
+        }
+
+        checkIsRedirect(
+          performAction(enterMovementReferenceNumberKey -> mrn.value),
+          routes.CheckDeclarationDetailsController.show
+        )
+      }
+
+      "submit a valid MRN and user is not the declarant or consignee" in forAll {
+        (mrn: MRN, declarant: Eori, consignee: Eori) =>
+          whenever(declarant =!= exampleEori && consignee =!= exampleEori) {
+            val journey            = session.overpaymentsScheduledJourney.getOrElse(fail("No overpayments journey"))
+            val displayDeclaration = sample[DisplayDeclaration].withDeclarationId(mrn.value)
+            val declarantDetails   = sample[DeclarantDetails].copy(declarantEORI = declarant.value)
+            val consigneeDetails   = sample[ConsigneeDetails].copy(consigneeEORI = consignee.value)
+
+            val updatedDisplayResponseDetails = displayDeclaration.displayResponseDetail.copy(
+              declarantDetails = declarantDetails,
+              consigneeDetails = Some(consigneeDetails)
+            )
+            val updatedDisplayDeclaration     =
+              displayDeclaration.copy(displayResponseDetail = updatedDisplayResponseDetails)
+            val updatedJourney                =
+              journey
+                .submitMovementReferenceNumberAndDeclaration(mrn, updatedDisplayDeclaration)
+                .getOrFail
+            val updatedSession                = session.copy(overpaymentsScheduledJourney = Some(updatedJourney))
+
+            inSequence {
+              mockAuthWithNoRetrievals()
+              mockGetSession(session)
+              mockGetDisplayDeclaration(mrn, Right(Some(updatedDisplayDeclaration)))
+              mockStoreSession(updatedSession)(Right(()))
+            }
+
+            checkIsRedirect(
+              performAction(enterMovementReferenceNumberKey -> mrn.value),
+              routes.EnterImporterEoriNumberController.show
+            )
+          }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsScheduledJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsScheduledJourneySpec.scala
@@ -884,9 +884,11 @@ class OverpaymentsScheduledJourneySpec
       val availableDocumentTypes = UploadDocumentType.overpaymentsScheduledDocumentTypes
 
       val availableClaimTypesNotNi      =
-        BasisOfOverpaymentClaimsList().excludeNorthernIrelandClaims(false, Some(displayDeclaration))
+        BasisOfOverpaymentClaimsList.withoutDuplicateEntry
+          .excludeNorthernIrelandClaims(false, Some(displayDeclaration))
       val availableClaimTypesIncludesNi =
-        BasisOfOverpaymentClaimsList().excludeNorthernIrelandClaims(true, Some(displayDeclaration))
+        BasisOfOverpaymentClaimsList.withoutDuplicateEntry
+          .excludeNorthernIrelandClaims(true, Some(displayDeclaration))
 
       val journey = OverpaymentsScheduledJourney
         .empty(exampleEori)


### PR DESCRIPTION
This PR creates a rough stitch of "overpayments scheduled V2" controllers with no tests. Only the tests for EnterMovementReferenceNumberController and ChooseHowManyMrnsController are included. The remaining tests have to be provided as part of respective tickets.