### PR TITLE
[CDSR-2300] modify rejected goods journeys to enable `subsidies only` variant

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpayments/ChooseHowManyMrnsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpayments/ChooseHowManyMrnsController.scala
@@ -77,27 +77,51 @@ class ChooseHowManyMrnsController @Inject() (
 
   private def overpaymentsSingleJourneyFeatures(implicit
     hc: HeaderCarrier
-  ): Option[OverpaymentsSingleJourney.Features] =
-    featureSwitchService.optionally(
-      Feature.BlockSubsidies,
-      OverpaymentsSingleJourney.Features(shouldBlockSubsidies = true)
-    )
+  ): Option[OverpaymentsSingleJourney.Features] = {
+    val blockSubsidies           = featureSwitchService.isEnabled(Feature.BlockSubsidies)
+    val subsidiesForOverpayments = featureSwitchService.isEnabled(Feature.SubsidiesForOverpayments)
+    if (blockSubsidies || subsidiesForOverpayments)
+      Some(
+        OverpaymentsSingleJourney
+          .Features(
+            shouldBlockSubsidies = blockSubsidies,
+            shouldAllowSubsidyOnlyPayments = subsidiesForOverpayments
+          )
+      )
+    else None
+  }
 
   private def overpaymentsMultipleJourneyFeatures(implicit
     hc: HeaderCarrier
-  ): Option[OverpaymentsMultipleJourney.Features] =
-    featureSwitchService.optionally(
-      Feature.BlockSubsidies,
-      OverpaymentsMultipleJourney.Features(shouldBlockSubsidies = true)
-    )
+  ): Option[OverpaymentsMultipleJourney.Features] = {
+    val blockSubsidies           = featureSwitchService.isEnabled(Feature.BlockSubsidies)
+    val subsidiesForOverpayments = featureSwitchService.isEnabled(Feature.SubsidiesForOverpayments)
+    if (blockSubsidies || subsidiesForOverpayments)
+      Some(
+        OverpaymentsMultipleJourney
+          .Features(
+            shouldBlockSubsidies = blockSubsidies,
+            shouldAllowSubsidyOnlyPayments = subsidiesForOverpayments
+          )
+      )
+    else None
+  }
 
   private def overpaymentsScheduledJourneyFeatures(implicit
     hc: HeaderCarrier
-  ): Option[OverpaymentsScheduledJourney.Features] =
-    featureSwitchService.optionally(
-      Feature.BlockSubsidies,
-      OverpaymentsScheduledJourney.Features(shouldBlockSubsidies = true)
-    )
+  ): Option[OverpaymentsScheduledJourney.Features] = {
+    val blockSubsidies           = featureSwitchService.isEnabled(Feature.BlockSubsidies)
+    val subsidiesForOverpayments = featureSwitchService.isEnabled(Feature.SubsidiesForOverpayments)
+    if (blockSubsidies || subsidiesForOverpayments)
+      Some(
+        OverpaymentsScheduledJourney
+          .Features(
+            shouldBlockSubsidies = blockSubsidies,
+            shouldAllowSubsidyOnlyPayments = subsidiesForOverpayments
+          )
+      )
+    else None
+  }
 
   final val start: Action[AnyContent] =
     Action(Redirect(routes.ChooseHowManyMrnsController.show()))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoods/ChooseHowManyMrnsController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoods/ChooseHowManyMrnsController.scala
@@ -78,27 +78,51 @@ class ChooseHowManyMrnsController @Inject() (
 
   private def rejectedGoodsSingleJourneyFeatures(implicit
     hc: HeaderCarrier
-  ): Option[RejectedGoodsSingleJourney.Features] =
-    featureSwitchService.optionally(
-      Feature.BlockSubsidies,
-      RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = true)
-    )
+  ): Option[RejectedGoodsSingleJourney.Features] = {
+    val blockSubsidies            = featureSwitchService.isEnabled(Feature.BlockSubsidies)
+    val subsidiesForRejectedGoods = featureSwitchService.isEnabled(Feature.SubsidiesForRejectedGoods)
+    if (blockSubsidies || subsidiesForRejectedGoods)
+      Some(
+        RejectedGoodsSingleJourney
+          .Features(
+            shouldBlockSubsidies = blockSubsidies,
+            shouldAllowSubsidyOnlyPayments = subsidiesForRejectedGoods
+          )
+      )
+    else None
+  }
 
   private def rejectedGoodsMultipleJourneyFeatures(implicit
     hc: HeaderCarrier
-  ): Option[RejectedGoodsMultipleJourney.Features] =
-    featureSwitchService.optionally(
-      Feature.BlockSubsidies,
-      RejectedGoodsMultipleJourney.Features(shouldBlockSubsidies = true)
-    )
+  ): Option[RejectedGoodsMultipleJourney.Features] = {
+    val blockSubsidies            = featureSwitchService.isEnabled(Feature.BlockSubsidies)
+    val subsidiesForRejectedGoods = featureSwitchService.isEnabled(Feature.SubsidiesForRejectedGoods)
+    if (blockSubsidies || subsidiesForRejectedGoods)
+      Some(
+        RejectedGoodsMultipleJourney
+          .Features(
+            shouldBlockSubsidies = blockSubsidies,
+            shouldAllowSubsidyOnlyPayments = subsidiesForRejectedGoods
+          )
+      )
+    else None
+  }
 
   private def rejectedGoodsScheduledJourneyFeatures(implicit
     hc: HeaderCarrier
-  ): Option[RejectedGoodsScheduledJourney.Features] =
-    featureSwitchService.optionally(
-      Feature.BlockSubsidies,
-      RejectedGoodsScheduledJourney.Features(shouldBlockSubsidies = true)
-    )
+  ): Option[RejectedGoodsScheduledJourney.Features] = {
+    val blockSubsidies            = featureSwitchService.isEnabled(Feature.BlockSubsidies)
+    val subsidiesForRejectedGoods = featureSwitchService.isEnabled(Feature.SubsidiesForRejectedGoods)
+    if (blockSubsidies || subsidiesForRejectedGoods)
+      Some(
+        RejectedGoodsScheduledJourney
+          .Features(
+            shouldBlockSubsidies = blockSubsidies,
+            shouldAllowSubsidyOnlyPayments = subsidiesForRejectedGoods
+          )
+      )
+    else None
+  }
 
   final val start: Action[AnyContent] =
     Action(Redirect(routes.ChooseHowManyMrnsController.show()))

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/CommonJourneyProperties.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/CommonJourneyProperties.scala
@@ -217,4 +217,8 @@ trait CommonJourneyProperties {
     else Some(seq(i + 1))
   }
 
+  final def declarationsHasOnlySubsidyPayments: Boolean =
+    getDisplayDeclarations.nonEmpty &&
+      getDisplayDeclarations.forall(_.hasOnlySubsidyPayments)
+
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsJourneyProperties.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsJourneyProperties.scala
@@ -29,4 +29,8 @@ trait OverpaymentsJourneyProperties extends CommonJourneyProperties {
   def getTotalReimbursementAmount: BigDecimal
 
   def getAvailableClaimTypes: Set[BasisOfOverpaymentClaim]
+
+  final def isSubsidyOnlyJourney: Boolean =
+    features.exists(_.shouldAllowSubsidyOnlyPayments) &&
+      declarationsHasOnlySubsidyPayments
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsMultipleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsMultipleJourney.scala
@@ -679,7 +679,8 @@ object OverpaymentsMultipleJourney extends JourneyCompanion[OverpaymentsMultiple
   type CorrectedAmounts = OrderedMap[TaxCode, Option[BigDecimal]]
 
   final case class Features(
-    shouldBlockSubsidies: Boolean
+    shouldBlockSubsidies: Boolean,
+    shouldAllowSubsidyOnlyPayments: Boolean
   ) extends SubsidiesFeatures
 
   // All user answers captured during C&E1179 single MRN journey

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsScheduledJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsScheduledJourney.scala
@@ -533,7 +533,8 @@ object OverpaymentsScheduledJourney extends JourneyCompanion[OverpaymentsSchedul
   type CorrectedAmounts = SortedMap[DutyType, SortedMap[TaxCode, Option[AmountPaidWithCorrect]]]
 
   final case class Features(
-    shouldBlockSubsidies: Boolean
+    shouldBlockSubsidies: Boolean,
+    shouldAllowSubsidyOnlyPayments: Boolean
   ) extends SubsidiesFeatures
 
   final case class Answers(

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsSingleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsSingleJourney.scala
@@ -698,7 +698,8 @@ object OverpaymentsSingleJourney extends JourneyCompanion[OverpaymentsSingleJour
   type CorrectedAmounts = Map[TaxCode, Option[BigDecimal]]
 
   final case class Features(
-    shouldBlockSubsidies: Boolean
+    shouldBlockSubsidies: Boolean,
+    shouldAllowSubsidyOnlyPayments: Boolean
   ) extends SubsidiesFeatures
 
   // All user answers captured during C&E1179 single MRN journey

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsJourneyChecks.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsJourneyChecks.scala
@@ -64,5 +64,4 @@ trait RejectedGoodsJourneyChecks[J <: RejectedGoodsJourneyProperties]
 
   final def shouldBlockSubsidiesAndDeclarationHasNoSubsidyPayments: Validate[J] =
     whenTrue(_.features.exists(_.shouldBlockSubsidies), declarationsHasNoSubsidyPayments)
-
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsJourneyProperties.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsJourneyProperties.scala
@@ -31,4 +31,8 @@ trait RejectedGoodsJourneyProperties extends CommonJourneyProperties {
   final def needsSpecialCircumstancesBasisOfClaim: Boolean =
     answers.basisOfClaim.contains(BasisOfRejectedGoodsClaim.SpecialCircumstances)
 
+  final def isSubsidyOnlyJourney: Boolean =
+    features.exists(_.shouldAllowSubsidyOnlyPayments) &&
+      declarationsHasOnlySubsidyPayments
+
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourney.scala
@@ -123,7 +123,7 @@ final class RejectedGoodsMultipleJourney private (
       .getOrElse(OrderedMap.empty)
 
   def needsBanksAccountDetailsSubmission: Boolean =
-    true
+    !this.isSubsidyOnlyJourney
 
   def needsDeclarantAndConsigneeEoriMultipleSubmission(pageIndex: Int): Boolean =
     if (pageIndex === 1) needsDeclarantAndConsigneeEoriSubmission else false
@@ -637,8 +637,12 @@ final class RejectedGoodsMultipleJourney private (
           reimbursementClaims = getReimbursementClaims,
           supportingEvidences = supportingEvidences.map(EvidenceDocument.from),
           basisOfClaimSpecialCircumstances = answers.basisOfClaimSpecialCircumstances,
-          reimbursementMethod = ReimbursementMethod.BankAccountTransfer,
-          bankAccountDetails = answers.bankAccountDetails
+          reimbursementMethod =
+            if (isSubsidyOnlyJourney) ReimbursementMethod.Subsidy
+            else ReimbursementMethod.BankAccountTransfer,
+          bankAccountDetails =
+            if (isSubsidyOnlyJourney) None
+            else answers.bankAccountDetails
         )).toRight(
           List("Unfortunately could not produce the output, please check if all answers are complete.")
         )
@@ -659,7 +663,8 @@ object RejectedGoodsMultipleJourney extends JourneyCompanion[RejectedGoodsMultip
   type ReimbursementClaims = OrderedMap[TaxCode, Option[BigDecimal]]
 
   final case class Features(
-    shouldBlockSubsidies: Boolean
+    shouldBlockSubsidies: Boolean,
+    shouldAllowSubsidyOnlyPayments: Boolean
   ) extends SubsidiesFeatures
 
   // All user answers captured during C&E1179 multiple MRNs journey

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsScheduledJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsScheduledJourney.scala
@@ -86,7 +86,8 @@ final class RejectedGoodsScheduledJourney private (
   def getLeadDisplayDeclaration: Option[DisplayDeclaration] =
     answers.displayDeclaration
 
-  def needsBanksAccountDetailsSubmission: Boolean = true
+  def needsBanksAccountDetailsSubmission: Boolean =
+    !this.isSubsidyOnlyJourney
 
   def getSelectedDutyTypes: Option[Seq[DutyType]] =
     answers.reimbursementClaims.map(_.keys.toSeq)
@@ -525,8 +526,12 @@ final class RejectedGoodsScheduledJourney private (
           scheduledDocument = EvidenceDocument.from(scheduledDocument),
           supportingEvidences = answers.supportingEvidences.map(EvidenceDocument.from),
           basisOfClaimSpecialCircumstances = answers.basisOfClaimSpecialCircumstances,
-          reimbursementMethod = ReimbursementMethod.BankAccountTransfer,
-          bankAccountDetails = answers.bankAccountDetails
+          reimbursementMethod =
+            if (isSubsidyOnlyJourney) ReimbursementMethod.Subsidy
+            else ReimbursementMethod.BankAccountTransfer,
+          bankAccountDetails =
+            if (isSubsidyOnlyJourney) None
+            else answers.bankAccountDetails
         )).toRight(
           List("Unfortunately could not produce the output, please check if all answers are complete.")
         )
@@ -547,7 +552,8 @@ object RejectedGoodsScheduledJourney extends JourneyCompanion[RejectedGoodsSched
   type ReimbursementClaims = SortedMap[DutyType, SortedMap[TaxCode, Option[AmountPaidWithRefund]]]
 
   final case class Features(
-    shouldBlockSubsidies: Boolean
+    shouldBlockSubsidies: Boolean,
+    shouldAllowSubsidyOnlyPayments: Boolean
   ) extends SubsidiesFeatures
 
   // All user answers captured during C&E1179 scheduled MRN journey

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourney.scala
@@ -75,7 +75,8 @@ final class RejectedGoodsSingleJourney private (
     answers.displayDeclaration
 
   def needsBanksAccountDetailsSubmission: Boolean =
-    answers.reimbursementMethod.isEmpty ||
+    !isSubsidyOnlyJourney &&
+      answers.reimbursementMethod.isEmpty ||
       answers.reimbursementMethod.contains(ReimbursementMethod.BankAccountTransfer)
 
   def getNdrcDetails: Option[List[NdrcDetails]] =
@@ -506,8 +507,12 @@ final class RejectedGoodsSingleJourney private (
           reimbursementClaims = getReimbursementClaims,
           supportingEvidences = supportingEvidences.map(EvidenceDocument.from),
           basisOfClaimSpecialCircumstances = answers.basisOfClaimSpecialCircumstances,
-          reimbursementMethod = answers.reimbursementMethod.getOrElse(ReimbursementMethod.BankAccountTransfer),
-          bankAccountDetails = answers.bankAccountDetails
+          reimbursementMethod =
+            if (isSubsidyOnlyJourney) ReimbursementMethod.Subsidy
+            else answers.reimbursementMethod.getOrElse(ReimbursementMethod.BankAccountTransfer),
+          bankAccountDetails =
+            if (isSubsidyOnlyJourney) None
+            else answers.bankAccountDetails
         )).toRight(
           List("Unfortunately could not produce the output, please check if all answers are complete.")
         )
@@ -528,7 +533,8 @@ object RejectedGoodsSingleJourney extends JourneyCompanion[RejectedGoodsSingleJo
   type ReimbursementClaims = Map[TaxCode, Option[BigDecimal]]
 
   final case class Features(
-    shouldBlockSubsidies: Boolean
+    shouldBlockSubsidies: Boolean,
+    shouldAllowSubsidyOnlyPayments: Boolean
   ) extends SubsidiesFeatures
 
   // All user answers captured during C&E1179 single MRN journey
@@ -593,9 +599,15 @@ object RejectedGoodsSingleJourney extends JourneyCompanion[RejectedGoodsSingleJo
             _.answers.reimbursementMethod,
             REIMBURSEMENT_METHOD_ANSWER_MUST_NOT_BE_DEFINED
           )
+        ),
+        whenTrue(
+          _.isSubsidyOnlyJourney,
+          checkIsEmpty(
+            _.answers.reimbursementMethod,
+            REIMBURSEMENT_METHOD_ANSWER_MUST_NOT_BE_DEFINED
+          )
         )
       )
-
   }
 
   import Checks._

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/Feature.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/Feature.scala
@@ -35,6 +35,8 @@ object Feature extends EnumerationFormat[Feature] {
   case object Overpayments_v2 extends Feature { val name = "overpayments_v2" }
   case object XiEori extends Feature { val name = "xi-eori" }
   case object BlockSubsidies extends Feature { val name = "block-subsidies" }
+  case object SubsidiesForRejectedGoods extends Feature { val name = "subsidies-for-rejected-goods" }
+  case object SubsidiesForOverpayments extends Feature { val name = "subsidies-for-overpayments" }
 
   def of(name: String): Option[Feature] =
     values.find(_.name === name)

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/ReimbursementMethod.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/ReimbursementMethod.scala
@@ -24,7 +24,11 @@ object ReimbursementMethod extends EnumerationFormat[ReimbursementMethod] {
 
   case object CurrentMonthAdjustment extends ReimbursementMethod
   case object BankAccountTransfer extends ReimbursementMethod
+  case object Subsidy extends ReimbursementMethod
 
   override val values: Set[ReimbursementMethod] =
+    Set(CurrentMonthAdjustment, BankAccountTransfer, Subsidy)
+
+  val nonSubsidyValues: Set[ReimbursementMethod] =
     Set(CurrentMonthAdjustment, BankAccountTransfer)
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/SubsidiesFeatures.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/SubsidiesFeatures.scala
@@ -18,4 +18,5 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.models
 
 trait SubsidiesFeatures {
   def shouldBlockSubsidies: Boolean
+  def shouldAllowSubsidyOnlyPayments: Boolean
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -265,3 +265,5 @@ features.view-upload = on
 features.overpayments_v2 = off
 features.xi-eori = on
 features.block-subsidies = off
+features.subsidies-for-rejected-goods = on
+features.subsidies-for-overpayments = off

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple_v2/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple_v2/CheckYourAnswersControllerSpec.scala
@@ -207,7 +207,9 @@ class CheckYourAnswersControllerSpec
         val journey =
           buildCompleteJourneyGen(
             generateSubsidyPayments = GenerateSubsidyPayments.Some,
-            features = Some(OverpaymentsMultipleJourney.Features(shouldBlockSubsidies = true))
+            features = Some(
+              OverpaymentsMultipleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+            )
           ).sample.getOrElse(fail())
 
         val errors: Seq[String] = journey.toOutput.left.getOrElse(Seq.empty)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple_v2/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsmultiple_v2/EnterMovementReferenceNumberControllerSpec.scala
@@ -397,7 +397,7 @@ class EnterMovementReferenceNumberControllerSpec
             .withDeclarationId(mrn.value)
             .withDeclarantEori(declarant)
             .withConsigneeEori(consignee)
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         inSequence {
           mockAuthWithNoRetrievals()
@@ -427,7 +427,7 @@ class EnterMovementReferenceNumberControllerSpec
             .withDeclarationId(mrn.value)
             .withDeclarantEori(journey.getDeclarantEoriFromACC14.value)
             .withConsigneeEori(journey.getConsigneeEoriFromACC14.value)
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         inSequence {
           mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/CheckYourAnswersControllerSpec.scala
@@ -203,7 +203,9 @@ class CheckYourAnswersControllerSpec
         val journey =
           buildCompleteJourneyGen(
             generateSubsidyPayments = GenerateSubsidyPayments.Some,
-            features = Some(OverpaymentsScheduledJourney.Features(shouldBlockSubsidies = true))
+            features = Some(
+              OverpaymentsScheduledJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+            )
           ).sample.getOrElse(fail())
 
         val errors: Seq[String] = journey.toOutput.left.getOrElse(Seq.empty)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled_v2/EnterMovementReferenceNumberControllerSpec.scala
@@ -278,7 +278,7 @@ class EnterMovementReferenceNumberControllerSpec
             .withDeclarationId(mrn.value)
             .withDeclarantEori(declarant)
             .withConsigneeEori(consignee)
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         inSequence {
           mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle_v2/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle_v2/CheckYourAnswersControllerSpec.scala
@@ -206,7 +206,9 @@ class CheckYourAnswersControllerSpec
         val journey =
           buildCompleteJourneyGen(
             generateSubsidyPayments = GenerateSubsidyPayments.Some,
-            features = Some(OverpaymentsSingleJourney.Features(shouldBlockSubsidies = true))
+            features = Some(
+              OverpaymentsSingleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+            )
           ).sample.getOrElse(fail())
 
         val errors: Seq[String] = journey.toOutput.left.getOrElse(Seq.empty)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle_v2/EnterDuplicateMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle_v2/EnterDuplicateMovementReferenceNumberControllerSpec.scala
@@ -301,7 +301,7 @@ class EnterDuplicateMovementReferenceNumberControllerSpec
         val displayDeclaration =
           buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false), (TaxCode.A70, 100, false)))
             .withDeclarationId(mrn.value)
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         inSequence {
           mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle_v2/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle_v2/EnterMovementReferenceNumberControllerSpec.scala
@@ -217,7 +217,7 @@ class EnterMovementReferenceNumberControllerSpec
             .withDeclarationId(mrn.value)
             .withDeclarantEori(declarant)
             .withConsigneeEori(consignee)
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         inSequence {
           mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/CheckYourAnswersControllerSpec.scala
@@ -211,7 +211,9 @@ class CheckYourAnswersControllerSpec
         val journey =
           buildCompleteJourneyGen(
             generateSubsidyPayments = GenerateSubsidyPayments.Some,
-            features = Some(RejectedGoodsMultipleJourney.Features(shouldBlockSubsidies = true))
+            features = Some(
+              RejectedGoodsMultipleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+            )
           ).sample.getOrElse(fail())
 
         val errors: Seq[String] = journey.toOutput.left.getOrElse(Seq.empty)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsmultiple/EnterMovementReferenceNumberControllerSpec.scala
@@ -398,7 +398,7 @@ class EnterMovementReferenceNumberControllerSpec
             .withDeclarationId(mrn.value)
             .withDeclarantEori(declarant)
             .withConsigneeEori(consignee)
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         inSequence {
           mockAuthWithNoRetrievals()
@@ -428,7 +428,7 @@ class EnterMovementReferenceNumberControllerSpec
             .withDeclarationId(mrn.value)
             .withDeclarantEori(journey.getDeclarantEoriFromACC14.value)
             .withConsigneeEori(journey.getConsigneeEoriFromACC14.value)
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         inSequence {
           mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/CheckYourAnswersControllerSpec.scala
@@ -218,7 +218,12 @@ class CheckYourAnswersControllerSpec
         val journey =
           buildCompleteJourneyGen(
             generateSubsidyPayments = GenerateSubsidyPayments.Some,
-            features = Some(RejectedGoodsScheduledJourney.Features(shouldBlockSubsidies = true))
+            features = Some(
+              RejectedGoodsScheduledJourney.Features(
+                shouldBlockSubsidies = true,
+                shouldAllowSubsidyOnlyPayments = false
+              )
+            )
           ).sample.getOrElse(fail())
 
         val errors: Seq[String] = journey.toOutput.left.getOrElse(Seq.empty)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/EnterMovementReferenceNumberControllerSpec.scala
@@ -379,7 +379,7 @@ class EnterMovementReferenceNumberControllerSpec
             .withDeclarationId(mrn.value)
             .withDeclarantEori(declarant)
             .withConsigneeEori(consignee)
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         inSequence {
           mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/CheckYourAnswersControllerSpec.scala
@@ -220,7 +220,9 @@ class CheckYourAnswersControllerSpec
         val journey =
           buildCompleteJourneyGen(
             generateSubsidyPayments = GenerateSubsidyPayments.Some,
-            features = Some(RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = true))
+            features = Some(
+              RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+            )
           ).sample.getOrElse(fail())
 
         val errors: Seq[String] = journey.toOutput.left.getOrElse(Seq.empty)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterMovementReferenceNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/EnterMovementReferenceNumberControllerSpec.scala
@@ -367,7 +367,7 @@ class EnterMovementReferenceNumberControllerSpec
             .withDeclarationId(mrn.value)
             .withDeclarantEori(declarant)
             .withConsigneeEori(consignee)
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         inSequence {
           mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/SelectDutiesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodssingle/SelectDutiesControllerSpec.scala
@@ -122,10 +122,10 @@ class SelectDutiesControllerSpec
 
       "display the page for subsidies MRNs" in {
         val journey = RejectedGoodsSingleJourney
-          .empty(exampleDisplayDeclaration.withSubsidiesPaymentMethod().getDeclarantEori)
+          .empty(exampleDisplayDeclaration.withAllSubsidiesPaymentMethod().getDeclarantEori)
           .submitMovementReferenceNumberAndDeclaration(
             exampleMrn,
-            exampleDisplayDeclaration.withSubsidiesPaymentMethod()
+            exampleDisplayDeclaration.withAllSubsidiesPaymentMethod()
           )
           .getOrFail
 

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsMultipleJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsMultipleJourneySpec.scala
@@ -935,7 +935,7 @@ class OverpaymentsMultipleJourneySpec
       "feature not enabled" in new DeclarationSupport {
         val declaration =
           buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false)))
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         val journey = RejectedGoodsMultipleJourney
           .empty(exampleEori)
@@ -952,14 +952,21 @@ class OverpaymentsMultipleJourneySpec
       "feature enabled" in new DeclarationSupport {
         val declaration =
           buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false)))
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         val journey = RejectedGoodsMultipleJourney
-          .empty(exampleEori, features = Some(RejectedGoodsMultipleJourney.Features(shouldBlockSubsidies = true)))
+          .empty(
+            exampleEori,
+            features = Some(
+              RejectedGoodsMultipleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+            )
+          )
           .submitMovementReferenceNumberAndDeclaration(exampleMrn, declaration)
           .getOrFail
 
-        journey.features shouldBe Some(RejectedGoodsMultipleJourney.Features(shouldBlockSubsidies = true))
+        journey.features shouldBe Some(
+          RejectedGoodsMultipleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+        )
 
         RejectedGoodsMultipleJourney.Checks.shouldBlockSubsidiesAndDeclarationHasNoSubsidyPayments.apply(
           journey

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsScheduledJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsScheduledJourneySpec.scala
@@ -1397,7 +1397,7 @@ class OverpaymentsScheduledJourneySpec
       "feature not enabled" in new DeclarationSupport {
         val declaration =
           buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false)))
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         val journey = OverpaymentsScheduledJourney
           .empty(exampleEori)
@@ -1414,14 +1414,21 @@ class OverpaymentsScheduledJourneySpec
       "feature enabled" in new DeclarationSupport {
         val declaration =
           buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false)))
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         val journey = OverpaymentsScheduledJourney
-          .empty(exampleEori, features = Some(OverpaymentsScheduledJourney.Features(shouldBlockSubsidies = true)))
+          .empty(
+            exampleEori,
+            features = Some(
+              OverpaymentsScheduledJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+            )
+          )
           .submitMovementReferenceNumberAndDeclaration(exampleMrn, declaration)
           .getOrFail
 
-        journey.features shouldBe Some(OverpaymentsScheduledJourney.Features(shouldBlockSubsidies = true))
+        journey.features shouldBe Some(
+          OverpaymentsScheduledJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+        )
 
         OverpaymentsScheduledJourney.Checks.shouldBlockSubsidiesAndDeclarationHasNoSubsidyPayments.apply(
           journey

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsSingleJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsSingleJourneyGenerators.scala
@@ -243,7 +243,8 @@ object OverpaymentsSingleJourneyGenerators extends JourneyGenerators with Journe
       duplicateMrn                <- if (basisOfClaim == BasisOfOverpaymentClaim.DuplicateEntry) IdGen.genMRN.map(Option.apply)
                                      else Gen.const(None)
       whetherNorthernIreland      <- Gen.oneOf(true, false)
-      reimbursementMethod         <- reimbursementMethod.map(Gen.const).getOrElse(Gen.oneOf(ReimbursementMethod.values))
+      reimbursementMethod         <-
+        reimbursementMethod.map(Gen.const).getOrElse(Gen.oneOf(ReimbursementMethod.nonSubsidyValues))
       numberOfSelectedTaxCodes    <- Gen.choose(1, numberOfTaxCodes)
       numberOfSupportingEvidences <- Gen.choose(0, 3)
       numberOfDocumentTypes       <- Gen.choose(1, 2)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsSingleJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/OverpaymentsSingleJourneySpec.scala
@@ -1193,7 +1193,7 @@ class OverpaymentsSingleJourneySpec
       "feature not enabled" in new DeclarationSupport {
         val declaration =
           buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false)))
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         val journey = OverpaymentsSingleJourney
           .empty(exampleEori)
@@ -1210,14 +1210,21 @@ class OverpaymentsSingleJourneySpec
       "feature enabled" in new DeclarationSupport {
         val declaration =
           buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false)))
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         val journey = OverpaymentsSingleJourney
-          .empty(exampleEori, features = Some(OverpaymentsSingleJourney.Features(shouldBlockSubsidies = true)))
+          .empty(
+            exampleEori,
+            features = Some(
+              OverpaymentsSingleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+            )
+          )
           .submitMovementReferenceNumberAndDeclaration(exampleMrn, declaration)
           .getOrFail
 
-        journey.features shouldBe Some(OverpaymentsSingleJourney.Features(shouldBlockSubsidies = true))
+        journey.features shouldBe Some(
+          OverpaymentsSingleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+        )
 
         OverpaymentsSingleJourney.Checks.shouldBlockSubsidiesAndDeclarationHasNoSubsidyPayments.apply(
           journey

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsMultipleJourneyGenerators.scala
@@ -173,6 +173,26 @@ object RejectedGoodsMultipleJourneyGenerators extends JourneyGenerators with Jou
       completeJourneyNotCMAEligibleGen
     )
 
+  val completeJourneyWithOnlySubsidiesGen: Gen[RejectedGoodsMultipleJourney] =
+    buildCompleteJourneyGen(
+      generateSubsidyPayments = GenerateSubsidyPayments.All,
+      acc14ConsigneeMatchesUserEori = true,
+      acc14DeclarantMatchesUserEori = false,
+      submitBankAccountDetails = false,
+      submitBankAccountType = false,
+      features = Some(RejectedGoodsMultipleJourney.Features(false, true))
+    )
+
+  val completeJourneyWithSomeSubsidiesGen: Gen[RejectedGoodsMultipleJourney] =
+    buildCompleteJourneyGen(
+      generateSubsidyPayments = GenerateSubsidyPayments.Some,
+      acc14ConsigneeMatchesUserEori = true,
+      acc14DeclarantMatchesUserEori = false,
+      submitBankAccountDetails = false,
+      submitBankAccountType = false,
+      features = Some(RejectedGoodsMultipleJourney.Features(false, true))
+    )
+
   val completeJourneyGenWithoutSpecialCircumstances: Gen[RejectedGoodsMultipleJourney] = for {
     journey      <- completeJourneyGen
     basisOfClaim <- Gen.oneOf(BasisOfRejectedGoodsClaim.values - BasisOfRejectedGoodsClaim.SpecialCircumstances)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsScheduledJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsScheduledJourneyGenerators.scala
@@ -127,6 +127,26 @@ object RejectedGoodsScheduledJourneyGenerators extends JourneyGenerators with Jo
       completeJourneyWithNonNatchingUserEoriGen
     )
 
+  val completeJourneyWithOnlySubsidiesGen: Gen[RejectedGoodsScheduledJourney] =
+    buildCompleteJourneyGen(
+      generateSubsidyPayments = GenerateSubsidyPayments.All,
+      acc14ConsigneeMatchesUserEori = true,
+      acc14DeclarantMatchesUserEori = false,
+      submitBankAccountDetails = false,
+      submitBankAccountType = false,
+      features = Some(RejectedGoodsScheduledJourney.Features(false, true))
+    )
+
+  val completeJourneyWithSomeSubsidiesGen: Gen[RejectedGoodsScheduledJourney] =
+    buildCompleteJourneyGen(
+      generateSubsidyPayments = GenerateSubsidyPayments.Some,
+      acc14ConsigneeMatchesUserEori = true,
+      acc14DeclarantMatchesUserEori = false,
+      submitBankAccountDetails = false,
+      submitBankAccountType = false,
+      features = Some(RejectedGoodsScheduledJourney.Features(false, true))
+    )
+
   val completeJourneyGenWithoutSpecialCircumstances: Gen[RejectedGoodsScheduledJourney] = for {
     journey      <- completeJourneyGen
     basisOfClaim <- Gen.oneOf(BasisOfRejectedGoodsClaim.values - BasisOfRejectedGoodsClaim.SpecialCircumstances)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneyGenerators.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneyGenerators.scala
@@ -113,6 +113,28 @@ object RejectedGoodsSingleJourneyGenerators extends JourneyGenerators with Journ
       completeJourneyNotCMAEligibleGen
     )
 
+  val completeJourneyWithOnlySubsidiesGen: Gen[RejectedGoodsSingleJourney] =
+    buildCompleteJourneyGen(
+      allDutiesCmaEligible = false,
+      generateSubsidyPayments = GenerateSubsidyPayments.All,
+      acc14ConsigneeMatchesUserEori = true,
+      acc14DeclarantMatchesUserEori = false,
+      submitBankAccountDetails = false,
+      submitBankAccountType = false,
+      features = Some(RejectedGoodsSingleJourney.Features(false, true))
+    )
+
+  val completeJourneyWithSomeSubsidiesGen: Gen[RejectedGoodsSingleJourney] =
+    buildCompleteJourneyGen(
+      allDutiesCmaEligible = false,
+      generateSubsidyPayments = GenerateSubsidyPayments.Some,
+      acc14ConsigneeMatchesUserEori = true,
+      acc14DeclarantMatchesUserEori = false,
+      submitBankAccountDetails = false,
+      submitBankAccountType = false,
+      features = Some(RejectedGoodsSingleJourney.Features(false, true))
+    )
+
   val completeJourneyGenWithoutSpecialCircumstances: Gen[RejectedGoodsSingleJourney] = for {
     journey      <- completeJourneyGen
     basisOfClaim <- Gen.oneOf(BasisOfRejectedGoodsClaim.values - BasisOfRejectedGoodsClaim.SpecialCircumstances)
@@ -193,7 +215,8 @@ object RejectedGoodsSingleJourneyGenerators extends JourneyGenerators with Journ
         )
       basisOfClaim                <- Gen.oneOf(BasisOfRejectedGoodsClaim.values)
       methodOfDisposal            <- Gen.oneOf(MethodOfDisposal.values)
-      reimbursementMethod         <- reimbursementMethod.map(Gen.const).getOrElse(Gen.oneOf(ReimbursementMethod.values))
+      reimbursementMethod         <-
+        reimbursementMethod.map(Gen.const).getOrElse(Gen.oneOf(ReimbursementMethod.nonSubsidyValues))
       numberOfSelectedTaxCodes    <- Gen.choose(1, numberOfTaxCodes)
       numberOfSupportingEvidences <- Gen.choose(0, 3)
       numberOfDocumentTypes       <- Gen.choose(1, 2)

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneySpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/journeys/RejectedGoodsSingleJourneySpec.scala
@@ -81,6 +81,7 @@ class RejectedGoodsSingleJourneySpec
         journey.hasCompleteSupportingEvidences              shouldBe true
         journey.hasCompleteAnswers                          shouldBe true
         journey.isFinalized                                 shouldBe false
+        journey.isSubsidyOnlyJourney                        shouldBe false
 
         val output = journey.toOutput.getOrElse(fail("Journey output not defined."))
 
@@ -96,6 +97,33 @@ class RejectedGoodsSingleJourneySpec
         output.reimbursementClaims      shouldBe journey.getReimbursementClaims
         output.supportingEvidences      shouldBe journey.answers.supportingEvidences.map(EvidenceDocument.from)
         output.bankAccountDetails       shouldBe journey.answers.bankAccountDetails
+        output.claimantInformation.eori shouldBe journey.answers.userEoriNumber
+      }
+    }
+
+    "check completeness and produce the correct output when only subsidies" in {
+      forAll(completeJourneyWithOnlySubsidiesGen) { journey =>
+        RejectedGoodsSingleJourney.validator.apply(journey) shouldBe Right(())
+        journey.answers.checkYourAnswersChangeMode          shouldBe true
+        journey.hasCompleteReimbursementClaims              shouldBe true
+        journey.hasCompleteSupportingEvidences              shouldBe true
+        journey.hasCompleteAnswers                          shouldBe true
+        journey.isFinalized                                 shouldBe false
+        journey.isSubsidyOnlyJourney                        shouldBe true
+
+        val output = journey.toOutput.getOrElse(fail("Journey output not defined."))
+
+        output.movementReferenceNumber  shouldBe journey.answers.movementReferenceNumber.get
+        output.claimantType             shouldBe journey.getClaimantType
+        output.basisOfClaim             shouldBe journey.answers.basisOfClaim.get
+        output.methodOfDisposal         shouldBe journey.answers.methodOfDisposal.get
+        output.detailsOfRejectedGoods   shouldBe journey.answers.detailsOfRejectedGoods.get
+        output.inspectionDate           shouldBe journey.answers.inspectionDate.get
+        output.inspectionAddress        shouldBe journey.answers.inspectionAddress.get
+        output.reimbursementMethod      shouldBe ReimbursementMethod.Subsidy
+        output.reimbursementClaims      shouldBe journey.getReimbursementClaims
+        output.supportingEvidences      shouldBe journey.answers.supportingEvidences.map(EvidenceDocument.from)
+        output.bankAccountDetails       shouldBe None
         output.claimantInformation.eori shouldBe journey.answers.userEoriNumber
       }
     }
@@ -1135,14 +1163,14 @@ class RejectedGoodsSingleJourneySpec
       }
     }
 
-    "validate subsidy payment methods in declaration" when {
+    "validate if any subsidy payment method is in the declaration" when {
 
       import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration.DeclarationSupport
 
-      "feature not enabled" in new DeclarationSupport {
+      "BlockSubsidies feature not enabled" in new DeclarationSupport {
         val declaration =
           buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false)))
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         val journey = RejectedGoodsSingleJourney
           .empty(exampleEori)
@@ -1156,17 +1184,72 @@ class RejectedGoodsSingleJourneySpec
         ) shouldBe Validator.Valid
       }
 
-      "feature enabled" in new DeclarationSupport {
+      "BlockSubsidies feature enabled and SubsidyOnlyPayments not" in new DeclarationSupport {
         val declaration =
           buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false)))
-            .withSubsidiesPaymentMethod()
+            .withAllSubsidiesPaymentMethod()
 
         val journey = RejectedGoodsSingleJourney
-          .empty(exampleEori, features = Some(RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = true)))
+          .empty(
+            exampleEori,
+            features = Some(
+              RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+            )
+          )
           .submitMovementReferenceNumberAndDeclaration(exampleMrn, declaration)
           .getOrFail
 
-        journey.features shouldBe Some(RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = true))
+        journey.features shouldBe Some(
+          RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = false)
+        )
+
+        RejectedGoodsSingleJourney.Checks.shouldBlockSubsidiesAndDeclarationHasNoSubsidyPayments.apply(
+          journey
+        ) shouldBe Validator.Invalid(DISPLAY_DECLARATION_HAS_SUBSIDY_PAYMENT)
+      }
+
+      "BlockSubsidies feature disabled and SubsidyOnlyPayments enabled" in new DeclarationSupport {
+        val declaration =
+          buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false)))
+            .withAllSubsidiesPaymentMethod()
+
+        val journey = RejectedGoodsSingleJourney
+          .empty(
+            exampleEori,
+            features = Some(
+              RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = false, shouldAllowSubsidyOnlyPayments = true)
+            )
+          )
+          .submitMovementReferenceNumberAndDeclaration(exampleMrn, declaration)
+          .getOrFail
+
+        journey.features shouldBe Some(
+          RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = false, shouldAllowSubsidyOnlyPayments = true)
+        )
+
+        RejectedGoodsSingleJourney.Checks.shouldBlockSubsidiesAndDeclarationHasNoSubsidyPayments.apply(
+          journey
+        ) shouldBe Validator.Valid
+      }
+
+      "both BlockSubsidies and SubsidyOnlyPayments features enabled" in new DeclarationSupport {
+        val declaration =
+          buildDisplayDeclaration(dutyDetails = Seq((TaxCode.A50, 100, false)))
+            .withAllSubsidiesPaymentMethod()
+
+        val journey = RejectedGoodsSingleJourney
+          .empty(
+            exampleEori,
+            features = Some(
+              RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = true)
+            )
+          )
+          .submitMovementReferenceNumberAndDeclaration(exampleMrn, declaration)
+          .getOrFail
+
+        journey.features shouldBe Some(
+          RejectedGoodsSingleJourney.Features(shouldBlockSubsidies = true, shouldAllowSubsidyOnlyPayments = true)
+        )
 
         RejectedGoodsSingleJourney.Checks.shouldBlockSubsidiesAndDeclarationHasNoSubsidyPayments.apply(
           journey

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/DeclarationSupport.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/declaration/DeclarationSupport.scala
@@ -18,10 +18,22 @@ package uk.gov.hmrc.cdsreimbursementclaimfrontend.models.declaration
 
 trait DeclarationSupport {
   implicit class TestDisplayDeclaration(val declaration: DisplayDeclaration) {
-    def withSubsidiesPaymentMethod(): DisplayDeclaration =
+    def withAllSubsidiesPaymentMethod(): DisplayDeclaration =
       declaration.copy(displayResponseDetail =
         declaration.displayResponseDetail.copy(ndrcDetails =
           declaration.displayResponseDetail.ndrcDetails.map(_.map(_.copy(paymentMethod = "006")))
+        )
+      )
+
+    def withSomeSubsidiesPaymentMethod(): DisplayDeclaration =
+      declaration.copy(displayResponseDetail =
+        declaration.displayResponseDetail.copy(ndrcDetails =
+          declaration.displayResponseDetail.ndrcDetails.map(_.zipWithIndex.map { case (ndrcDetails, index) =>
+            if (index % 2 == 0)
+              ndrcDetails.copy(paymentMethod = "006")
+            else
+              ndrcDetails
+          })
         )
       )
   }

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/ReimbursementMethodAnswerGen.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/models/generators/ReimbursementMethodAnswerGen.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc.cdsreimbursementclaimfrontend.models.generators
 
-import org.scalacheck.magnolia.Typeclass
-import org.scalacheck.magnolia.gen
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 import uk.gov.hmrc.cdsreimbursementclaimfrontend.models.ReimbursementMethod
 
 object ReimbursementMethodGen {
 
-  implicit lazy val arbitraryReimbursementMethod: Typeclass[Option[ReimbursementMethod]] =
-    gen[Option[ReimbursementMethod]]
+  implicit lazy val arbitraryReimbursementMethod: Arbitrary[Option[ReimbursementMethod]] =
+    Arbitrary(Gen.option(Gen.oneOf(ReimbursementMethod.nonSubsidyValues)))
 
 }


### PR DESCRIPTION
This PR adds two new feature flags: 
- subsidies-for-rejected-goods
- subsidies-for-overpayments