### PR TITLE
DCWL-4585: updated allowed file extensions

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/UploadFilesMixin.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/mixins/UploadFilesMixin.scala
@@ -182,7 +182,7 @@ trait UploadFilesMixin extends ClaimBaseController {
       maximumFileSizeBytes = fileUploadConfig.readMaxFileSize("supporting-evidence"),
       allowedContentTypes =
         "application/pdf,image/jpeg,image/png,text/csv,text/plain,application/vnd.ms-outlook,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet",
-      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.pst,.ost,.eml,.doc,.docx,.xls,.xlsx,.ods,.odt",
+      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.doc,.docx,.xls,.xlsx,.ods,.odt",
       prePopulateYesOrNoForm = prePopulateYesOrNoForm,
       cargo = Some(documentType),
       newFileDescription = Some(documentTypeDescription(documentType)),

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadMrnListController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentsscheduled/UploadMrnListController.scala
@@ -121,7 +121,7 @@ class UploadMrnListController @Inject() (
       maximumFileSizeBytes = fileUploadConfig.readMaxFileSize("schedule-of-mrn"),
       allowedContentTypes =
         "application/pdf,image/jpeg,image/png,text/csv,text/plain,application/vnd.ms-outlook,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet",
-      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.pst,.ost,.eml,.doc,.docx,.xls,.xlsx,.ods,.odt",
+      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.doc,.docx,.xls,.xlsx,.ods,.odt",
       prePopulateYesOrNoForm = None,
       cargo = Some(UploadDocumentType.ScheduleOfMRNs),
       newFileDescription =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/UploadMrnListController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/rejectedgoodsscheduled/UploadMrnListController.scala
@@ -121,7 +121,7 @@ class UploadMrnListController @Inject() (
       maximumFileSizeBytes = fileUploadConfig.readMaxFileSize("schedule-of-mrn"),
       allowedContentTypes =
         "application/pdf,image/jpeg,image/png,text/csv,text/plain,application/vnd.ms-outlook,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet",
-      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.pst,.ost,.eml,.doc,.docx,.xls,.xlsx,.ods,.odt",
+      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.doc,.docx,.xls,.xlsx,.ods,.odt",
       prePopulateYesOrNoForm = None,
       cargo = Some(UploadDocumentType.ScheduleOfMRNs),
       newFileDescription =

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/UploadBillOfDischarge3Controller.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/UploadBillOfDischarge3Controller.scala
@@ -126,7 +126,7 @@ class UploadBillOfDischarge3Controller @Inject() (
       maximumFileSizeBytes = fileUploadConfig.readMaxFileSize("bill-of-discharge"),
       allowedContentTypes =
         "application/pdf,image/jpeg,image/png,text/csv,text/plain,application/vnd.ms-outlook,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet",
-      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.pst,.ost,.eml,.doc,.docx,.xls,.xlsx,.ods,.odt",
+      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.doc,.docx,.xls,.xlsx,.ods,.odt",
       prePopulateYesOrNoForm = None,
       cargo = Some(UploadDocumentType.BillOfDischarge3),
       newFileDescription = None,

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/UploadBillOfDischarge4Controller.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/UploadBillOfDischarge4Controller.scala
@@ -126,7 +126,7 @@ class UploadBillOfDischarge4Controller @Inject() (
       maximumFileSizeBytes = fileUploadConfig.readMaxFileSize("bill-of-discharge"),
       allowedContentTypes =
         "application/pdf,image/jpeg,image/png,text/csv,text/plain,application/vnd.ms-outlook,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet",
-      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.pst,.ost,.eml,.doc,.docx,.xls,.xlsx,.ods,.odt",
+      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.doc,.docx,.xls,.xlsx,.ods,.odt",
       prePopulateYesOrNoForm = None,
       cargo = Some(UploadDocumentType.BillOfDischarge4),
       newFileDescription = None,

--- a/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/UploadProofOfOriginController.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/securities/UploadProofOfOriginController.scala
@@ -126,7 +126,7 @@ class UploadProofOfOriginController @Inject() (
       maximumFileSizeBytes = fileUploadConfig.readMaxFileSize("proof-of-origin"),
       allowedContentTypes =
         "application/pdf,image/jpeg,image/png,text/csv,text/plain,application/vnd.ms-outlook,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet",
-      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.pst,.ost,.eml,.doc,.docx,.xls,.xlsx,.ods,.odt",
+      allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.doc,.docx,.xls,.xlsx,.ods,.odt",
       prePopulateYesOrNoForm = None,
       cargo = Some(UploadDocumentType.ProofOfOrigin),
       newFileDescription = None,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,13 +4,13 @@ import sbt.*
 object AppDependencies {
 
   val jsoupVersion         = "1.21.2"
-  val hmrcMongoPlayVersion = "2.11.0"
-  val bootstrapVersion     = "10.5.0"
+  val hmrcMongoPlayVersion = "2.12.0"
+  val bootstrapVersion     = "10.7.0"
   val playSuffix           = "-play-30"
 
   val compile = Seq(
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.25.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.32.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % hmrcMongoPlayVersion,
     "org.typelevel"     %% "cats-core"                  % "2.13.0"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" 
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.9")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.10")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-sass-compiler"  % "0.12.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.5")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.3.1")

--- a/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/UploadFilesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimfrontend/controllers/overpaymentssingle/UploadFilesControllerSpec.scala
@@ -235,7 +235,7 @@ class UploadFilesControllerSpec
         maximumFileSizeBytes = 9000000,
         allowedContentTypes =
           "application/pdf,image/jpeg,image/png,text/csv,text/plain,application/vnd.ms-outlook,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet",
-        allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.pst,.ost,.eml,.doc,.docx,.xls,.xlsx,.ods,.odt",
+        allowedFileExtensions = ".pdf,.png,.jpg,.jpeg,.csv,.txt,.msg,.doc,.docx,.xls,.xlsx,.ods,.odt",
         prePopulateYesOrNoForm = Some(false),
         cargo = Some(AirWayBill),
         newFileDescription = Some("Air waybill"),


### PR DESCRIPTION
DCWL-4585: updated allowed file extensions

Following extensions .pst .ost .eml removed from allowed lists